### PR TITLE
Skip null EDIFCellInst pointer

### DIFF
--- a/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -910,6 +910,7 @@ public class EDIFNetlist extends EDIFName {
 				if(portInst.isTopLevelPort()){
 					// Going up in hierarchy
 					EDIFCellInst cellInst = getCellInstFromHierName(curr.getHierarchicalInstName());
+					if(cellInst == null) continue;
 					EDIFPortInst epr = cellInst.getPortInst(portInst.getPortInstNameFromPort());
 					if(epr == null || epr.getNet() == null) continue;
 					String hierName = EDIFTools.getHierarchicalRootFromPinName(curr.getHierarchicalInstName());


### PR DESCRIPTION
Check and skip null pointer of an EDIFCellInst returned from a getCellInstFromHierName(...) call.
This was encountered while parsing an EDF exported by Vivado from a DCP.