### PR TITLE
Update PerformanceExplorer.java

### DIFF
--- a/src/com/xilinx/rapidwright/util/PerformanceExplorer.java
+++ b/src/com/xilinx/rapidwright/util/PerformanceExplorer.java
@@ -282,6 +282,9 @@ public class PerformanceExplorer {
 			lines.add("source " + FileTools.getRapidWrightPath() + File.separator + "tcl" + File.separator + "rapidwright.tcl");
 			lines.add("generate_metadata "+ instDirectory + File.separator + "routed.dcp false 0");
 		}
+		for (int i = 0 ; i < lines.size(); i++){
+			lines.set(i, lines.get(i).replace('\\', '/'));
+		}
 		return lines;
 	}
 	


### PR DESCRIPTION
In Windows OS, running PerformanceExplorer would encounter a problem; for file separator in Windows is "\" while in Vivado Tcl is “/”. Therefore, the Tcl script created by PerformanceExplorer in Windows OS would fail in Vivado. 
I suppose the simplest way to solve this problem would be making a replacement of all "\" in the Tcl script to "/".