### PR TITLE
Update EDIFNetlist.java: migrateCellAndSubCells()

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -283,10 +283,38 @@ public class EDIFNetlist extends EDIFName {
 		}
 	}
 
-	
 	public void migrateCellAndSubCells(EDIFCell cell){
-		Queue<EDIFCell> cells = new LinkedList<>(); // which contains cells that have been added to libraries but whose subcells haven't.
+		Queue<EDIFCell> cells = new LinkedList<>();
+		cells.add(cell);
+		while(!cells.isEmpty()){
+			EDIFCell curr = cells.poll();
+			EDIFLibrary destLib = getLibrary(curr.getLibrary().getName());
+			if(destLib == null){
+				if(curr.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)){
+					destLib = getHDIPrimitivesLibrary();
+				}else{
+					destLib = getWorkLibrary();
+				}
+			}
 
+			if(!destLib.containsCell(curr)){
+				destLib.addCell(curr);
+			}
+
+			for(EDIFCellInst inst : curr.getCellInsts()){
+				cells.add(inst.getCellType());
+			}
+		}
+	}
+
+
+	public void migrateCellAndSubCells(EDIFCell cell, boolean uniqueifyCollisions){
+		if (!uniqueifyCollisions){
+			migrateCellAndSubCells(cell);
+			return;
+		}
+
+		Queue<EDIFCell> cells = new LinkedList<>(); // which contains cells that have been added to libraries but whose subcells haven't.
 		//Step 1: add the top cell to the library.
 		//If the top cell belongs to HDIPrimitivesLibrary && the top cell exists in HDIPrimitivesLibrary, return and do nothing.
 		//Otherwise, the code would add the top cell to the library; if repeat happens, using "parameterized" suffix to distinguish

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -285,25 +285,59 @@ public class EDIFNetlist extends EDIFName {
 
 	
 	public void migrateCellAndSubCells(EDIFCell cell){
-		Queue<EDIFCell> cells = new LinkedList<>();
+		Queue<EDIFCell> cells = new LinkedList<>(); // which contains cells that have been added to libraries but whose subcells haven't.
+
+		//Step 1: add the top cell to the library.
+		//If the top cell belongs to HDIPrimitivesLibrary && the top cell exists in HDIPrimitivesLibrary, return and do nothing.
+		//Otherwise, the code would add the top cell to the library; if repeat happens, using "parameterized" suffix to distinguish
+		EDIFLibrary destLibTop = getLibrary(cell.getLibrary().getName());
+		if(destLibTop == null){
+			if(cell.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)){
+				destLibTop = getHDIPrimitivesLibrary();
+			}else{
+				destLibTop = getWorkLibrary();
+			}
+		}
+		if (destLibTop.containsCell(cell) && destLibTop.getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME))
+			return;
+		int i=0;
+		String currentCellName = cell.getName();
+		while (destLibTop.containsCell(cell)) {
+			cell.setName(currentCellName + "_parameterized" + i);
+			cell.setView(currentCellName + "_parameterized" + i);
+			cell.updateEDIFRename();
+			i++;
+		}
+		destLibTop.addCell(cell);
 		cells.add(cell);
+
+		//Step 2: add the subcells, subsubcells... to the library.
+		//Do it like before, but updating the celltype of each cellInst should be noticed.
 		while(!cells.isEmpty()){
-			EDIFCell curr = cells.poll();
-			EDIFLibrary destLib = getLibrary(curr.getLibrary().getName());
-			if(destLib == null){
-				if(curr.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)){
-					destLib = getHDIPrimitivesLibrary();
-				}else{
-					destLib = getWorkLibrary();
+			EDIFCell pollFromCells = cells.poll();
+			for(EDIFCellInst inst : pollFromCells.getCellInsts()) {
+				EDIFCell instCellType = inst.getCellType();
+				EDIFLibrary destLibSub = getLibrary(instCellType.getLibrary().getName());
+				if (destLibSub == null) {
+					if (instCellType.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)) {
+						destLibSub = getHDIPrimitivesLibrary();
+					} else {
+						destLibSub = getWorkLibrary();
+					}
 				}
-			}
-			
-			if(!destLib.containsCell(curr)){
-				destLib.addCell(curr);
-			}
-			
-			for(EDIFCellInst inst : curr.getCellInsts()){
-				cells.add(inst.getCellType());
+				if (destLibSub.containsCell(instCellType) && destLibSub.getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME))
+					continue;
+				i=0;
+				currentCellName = instCellType.getName();
+				while (destLibSub.containsCell(instCellType)) {
+					instCellType.setName(currentCellName + "_parameterized" + i);
+					instCellType.setView(currentCellName + "_parameterized" + i);
+					instCellType.updateEDIFRename();
+					i++;
+				}
+				inst.setCellType(instCellType); // updating the celltype, which could be changed due to adding suffix
+				destLibSub.addCell(instCellType);
+				cells.add(instCellType);
 			}
 		}
 	}


### PR DESCRIPTION
Sometimes, we could have different cells with the same EDIFName, e.g. when trying to generate pre-implemented modules, we can use different generic parameters to generate different entities, and thus different cells despite the same EDIFName (entity name). When we then try to use these modules (which contains different cells with the same EDIFName) in RapidWright, there would be a conflict, and errors occur. 

I propose a reasonable way to solve this problem, the way that instead of skipping migrating cells whose EDIFNames have already existed in the library, we add suffixes to the EDIFNames of new cells to distinguish, and thus all new cells could be migrated. 

However, there is a drawback of this way that even an entirely same cell could also be migrated and renamed as a "different" one... 

I hope my pull request would help a little. Thanks.