### PR TITLE
TimingGroup: Make 'add' functions public

### DIFF
--- a/src/com/xilinx/rapidwright/timing/TimingGroup.java
+++ b/src/com/xilinx/rapidwright/timing/TimingGroup.java
@@ -200,7 +200,7 @@ public class TimingGroup implements Comparable<TimingGroup> {
      * @param n Node to be added.
      * @param c IntentCode is the Vivado-assigned Type for the given node.
      */
-    protected void add(Node n, IntentCode c) {
+    public void add(Node n, IntentCode c) {
         nodes.add(n);
         if (c == IntentCode.NODE_PINFEED)
             hasPinFeed = true;
@@ -215,7 +215,7 @@ public class TimingGroup implements Comparable<TimingGroup> {
      * Used for adding a PIP into a TimingGroup.
      * @param p PIP to be added.
      */
-    protected void add(PIP p) {
+    public void add(PIP p) {
         pips.add(p);
     }
 


### PR DESCRIPTION
I am working on integrating RapidWright timing with nextpnr. AIUI, there is no way at the moment to work out timing for an incomplete part of routing, which would be needed to provide some kind of timing model in the nextpnr database for the router to use and these functions seem to be helpful for. I appreciate this may not end up being as accurate as doing it on full nets, but this is only to provide a guide for the nextpnr router with Vivado still useful for signoff timing.