### PR TITLE
Fix jar build issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ project.buildDir = 'bin'
 
 sourceSets {
   main {
-    java.outputDir = file('compiled')
+    java.outputDir = file('bin/compiled')
     java {
       srcDirs = ['src']
     }    

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'java'
-jar.enabled = false
+jar.enabled = true
 
 project.buildDir = 'bin'
 
 sourceSets {
   main {
-    java.outputDir = file('bin')
+    java.outputDir = file('compiled')
     java {
       srcDirs = ['src']
     }    


### PR DESCRIPTION
[This post](https://discuss.gradle.org/t/gradle-hangs-and-create-inifinitely-long-jar/653) indicated that the build hang might be because multiple sections had the same output directories. I changed the java compilation to go into `compiled` instead of `bin`, and the jar file builds instantly!

I can easily change the target directory name if you don't like `compiled`.