### PR TITLE
Ensure that highlighted tile numbers are drawn above tile highlighting

### DIFF
--- a/src/com/xilinx/rapidwright/gui/NumberedHighlightedTile.java
+++ b/src/com/xilinx/rapidwright/gui/NumberedHighlightedTile.java
@@ -58,6 +58,8 @@ public class NumberedHighlightedTile  extends QGraphicsRectItem{
 		this.moveBy(x, y);
 		this.scene.addItem(this);
 		this.scene.addItem(text);
+
+		this.text.setZValue(this.zValue() + 1);
 	}
 	
 	public void remove(){


### PR DESCRIPTION
Even if the text item is added to the scene after 'this' (the tile
highlighting), It may happen that the text item is drawn before the tile
highlighting. As such, the text will not be visible.

Usually, this would be automatically handled if the text item is created
as a child of 'this' (the tile highlighting).
However, this does not seem to be working in QtJambi and the text item
has to be created without a parent and manually added to the scene.
Instead, we manually set the Z value of the text item to be greater than
the highlighting, to ensure that it is always drawn above the highlighting.

Signed-off-by: Morten Borup Petersen <morten_bp@live.dk>