### PR TITLE
Fixed getLUTSize. Returns actual size instead of ASCII value

### DIFF
--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -94,7 +94,7 @@ public class LUTTools {
 	 */
 	public static int getLUTSize(EDIFCellInst c){
 		if(!isCellALUT(c)) return 0;
-		return c.getCellType().getName().charAt(3);
+		return Character.getNumericValue(c.getCellType().getName().charAt(3));
 	}
 	
 	/**


### PR DESCRIPTION
Instead of the actual size the ASCII value of the digit was used (for instance 51 instead of 3). So the configuration of LUTs was very slow because the equation was evaluated 2^51 times instead of 2^3 times.
This was fixed by not using the ASCII character value but to parse the value correctly.