### PR TITLE
Fix various bugs in device resource generation

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/DeviceResources.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResources.java
@@ -213,7 +213,7 @@ public final class DeviceResources {
     }
 
     public static class SiteType {
-      public static final org.capnproto.StructSize STRUCT_SIZE = new org.capnproto.StructSize((short)1,(short)5);
+      public static final org.capnproto.StructSize STRUCT_SIZE = new org.capnproto.StructSize((short)1,(short)6);
       public static final class Factory extends org.capnproto.StructFactory<Builder, Reader> {
         public Factory() {
         }
@@ -314,6 +314,18 @@ public final class DeviceResources {
         public final org.capnproto.StructList.Builder<com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteWire.Builder> initSiteWires(int size) {
           return _initPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteWire.listFactory, 4, size);
         }
+        public final boolean hasAltSiteTypes() {
+          return !_pointerFieldIsNull(5);
+        }
+        public final org.capnproto.PrimitiveList.Int.Builder getAltSiteTypes() {
+          return _getPointerField(org.capnproto.PrimitiveList.Int.factory, 5, null, 0);
+        }
+        public final void setAltSiteTypes(org.capnproto.PrimitiveList.Int.Reader value) {
+          _setPointerField(org.capnproto.PrimitiveList.Int.factory, 5, value);
+        }
+        public final org.capnproto.PrimitiveList.Int.Builder initAltSiteTypes(int size) {
+          return _initPointerField(org.capnproto.PrimitiveList.Int.factory, 5, size);
+        }
       }
 
       public static final class Reader extends org.capnproto.StructReader {
@@ -364,6 +376,161 @@ public final class DeviceResources {
           return _getPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteWire.listFactory, 4, null, 0);
         }
 
+        public final boolean hasAltSiteTypes() {
+          return !_pointerFieldIsNull(5);
+        }
+        public final org.capnproto.PrimitiveList.Int.Reader getAltSiteTypes() {
+          return _getPointerField(org.capnproto.PrimitiveList.Int.factory, 5, null, 0);
+        }
+
+      }
+
+    }
+
+
+    public static class ParentPins {
+      public static final org.capnproto.StructSize STRUCT_SIZE = new org.capnproto.StructSize((short)0,(short)1);
+      public static final class Factory extends org.capnproto.StructFactory<Builder, Reader> {
+        public Factory() {
+        }
+        public final Reader constructReader(org.capnproto.SegmentReader segment, int data,int pointers, int dataSize, short pointerCount, int nestingLimit) {
+          return new Reader(segment,data,pointers,dataSize,pointerCount,nestingLimit);
+        }
+        public final Builder constructBuilder(org.capnproto.SegmentBuilder segment, int data,int pointers, int dataSize, short pointerCount) {
+          return new Builder(segment, data, pointers, dataSize, pointerCount);
+        }
+        public final org.capnproto.StructSize structSize() {
+          return Device.ParentPins.STRUCT_SIZE;
+        }
+        public final Reader asReader(Builder builder) {
+          return builder.asReader();
+        }
+      }
+      public static final Factory factory = new Factory();
+      public static final org.capnproto.StructList.Factory<Builder,Reader> listFactory =
+        new org.capnproto.StructList.Factory<Builder, Reader>(factory);
+      public static final class Builder extends org.capnproto.StructBuilder {
+        Builder(org.capnproto.SegmentBuilder segment, int data, int pointers,int dataSize, short pointerCount){
+          super(segment, data, pointers, dataSize, pointerCount);
+        }
+        public final Reader asReader() {
+          return new Reader(segment, data, pointers, dataSize, pointerCount, 0x7fffffff);
+        }
+        public final boolean hasPins() {
+          return !_pointerFieldIsNull(0);
+        }
+        public final org.capnproto.PrimitiveList.Int.Builder getPins() {
+          return _getPointerField(org.capnproto.PrimitiveList.Int.factory, 0, null, 0);
+        }
+        public final void setPins(org.capnproto.PrimitiveList.Int.Reader value) {
+          _setPointerField(org.capnproto.PrimitiveList.Int.factory, 0, value);
+        }
+        public final org.capnproto.PrimitiveList.Int.Builder initPins(int size) {
+          return _initPointerField(org.capnproto.PrimitiveList.Int.factory, 0, size);
+        }
+      }
+
+      public static final class Reader extends org.capnproto.StructReader {
+        Reader(org.capnproto.SegmentReader segment, int data, int pointers,int dataSize, short pointerCount, int nestingLimit){
+          super(segment, data, pointers, dataSize, pointerCount, nestingLimit);
+        }
+
+        public final boolean hasPins() {
+          return !_pointerFieldIsNull(0);
+        }
+        public final org.capnproto.PrimitiveList.Int.Reader getPins() {
+          return _getPointerField(org.capnproto.PrimitiveList.Int.factory, 0, null, 0);
+        }
+
+      }
+
+    }
+
+
+    public static class SiteTypeInTileType {
+      public static final org.capnproto.StructSize STRUCT_SIZE = new org.capnproto.StructSize((short)1,(short)2);
+      public static final class Factory extends org.capnproto.StructFactory<Builder, Reader> {
+        public Factory() {
+        }
+        public final Reader constructReader(org.capnproto.SegmentReader segment, int data,int pointers, int dataSize, short pointerCount, int nestingLimit) {
+          return new Reader(segment,data,pointers,dataSize,pointerCount,nestingLimit);
+        }
+        public final Builder constructBuilder(org.capnproto.SegmentBuilder segment, int data,int pointers, int dataSize, short pointerCount) {
+          return new Builder(segment, data, pointers, dataSize, pointerCount);
+        }
+        public final org.capnproto.StructSize structSize() {
+          return Device.SiteTypeInTileType.STRUCT_SIZE;
+        }
+        public final Reader asReader(Builder builder) {
+          return builder.asReader();
+        }
+      }
+      public static final Factory factory = new Factory();
+      public static final org.capnproto.StructList.Factory<Builder,Reader> listFactory =
+        new org.capnproto.StructList.Factory<Builder, Reader>(factory);
+      public static final class Builder extends org.capnproto.StructBuilder {
+        Builder(org.capnproto.SegmentBuilder segment, int data, int pointers,int dataSize, short pointerCount){
+          super(segment, data, pointers, dataSize, pointerCount);
+        }
+        public final Reader asReader() {
+          return new Reader(segment, data, pointers, dataSize, pointerCount, 0x7fffffff);
+        }
+        public final int getPrimaryType() {
+          return _getIntField(0);
+        }
+        public final void setPrimaryType(int value) {
+          _setIntField(0, value);
+        }
+
+        public final boolean hasPrimaryPinsToTileWires() {
+          return !_pointerFieldIsNull(0);
+        }
+        public final org.capnproto.PrimitiveList.Int.Builder getPrimaryPinsToTileWires() {
+          return _getPointerField(org.capnproto.PrimitiveList.Int.factory, 0, null, 0);
+        }
+        public final void setPrimaryPinsToTileWires(org.capnproto.PrimitiveList.Int.Reader value) {
+          _setPointerField(org.capnproto.PrimitiveList.Int.factory, 0, value);
+        }
+        public final org.capnproto.PrimitiveList.Int.Builder initPrimaryPinsToTileWires(int size) {
+          return _initPointerField(org.capnproto.PrimitiveList.Int.factory, 0, size);
+        }
+        public final boolean hasAltPinsToPrimaryPins() {
+          return !_pointerFieldIsNull(1);
+        }
+        public final org.capnproto.StructList.Builder<com.xilinx.rapidwright.interchange.DeviceResources.Device.ParentPins.Builder> getAltPinsToPrimaryPins() {
+          return _getPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.ParentPins.listFactory, 1, null, 0);
+        }
+        public final void setAltPinsToPrimaryPins(org.capnproto.StructList.Reader<com.xilinx.rapidwright.interchange.DeviceResources.Device.ParentPins.Reader> value) {
+          _setPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.ParentPins.listFactory, 1, value);
+        }
+        public final org.capnproto.StructList.Builder<com.xilinx.rapidwright.interchange.DeviceResources.Device.ParentPins.Builder> initAltPinsToPrimaryPins(int size) {
+          return _initPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.ParentPins.listFactory, 1, size);
+        }
+      }
+
+      public static final class Reader extends org.capnproto.StructReader {
+        Reader(org.capnproto.SegmentReader segment, int data, int pointers,int dataSize, short pointerCount, int nestingLimit){
+          super(segment, data, pointers, dataSize, pointerCount, nestingLimit);
+        }
+
+        public final int getPrimaryType() {
+          return _getIntField(0);
+        }
+
+        public final boolean hasPrimaryPinsToTileWires() {
+          return !_pointerFieldIsNull(0);
+        }
+        public final org.capnproto.PrimitiveList.Int.Reader getPrimaryPinsToTileWires() {
+          return _getPointerField(org.capnproto.PrimitiveList.Int.factory, 0, null, 0);
+        }
+
+        public final boolean hasAltPinsToPrimaryPins() {
+          return !_pointerFieldIsNull(1);
+        }
+        public final org.capnproto.StructList.Reader<com.xilinx.rapidwright.interchange.DeviceResources.Device.ParentPins.Reader> getAltPinsToPrimaryPins() {
+          return _getPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.ParentPins.listFactory, 1, null, 0);
+        }
+
       }
 
     }
@@ -407,14 +574,14 @@ public final class DeviceResources {
         public final boolean hasSiteTypes() {
           return !_pointerFieldIsNull(0);
         }
-        public final org.capnproto.PrimitiveList.Int.Builder getSiteTypes() {
-          return _getPointerField(org.capnproto.PrimitiveList.Int.factory, 0, null, 0);
+        public final org.capnproto.StructList.Builder<com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteTypeInTileType.Builder> getSiteTypes() {
+          return _getPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteTypeInTileType.listFactory, 0, null, 0);
         }
-        public final void setSiteTypes(org.capnproto.PrimitiveList.Int.Reader value) {
-          _setPointerField(org.capnproto.PrimitiveList.Int.factory, 0, value);
+        public final void setSiteTypes(org.capnproto.StructList.Reader<com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteTypeInTileType.Reader> value) {
+          _setPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteTypeInTileType.listFactory, 0, value);
         }
-        public final org.capnproto.PrimitiveList.Int.Builder initSiteTypes(int size) {
-          return _initPointerField(org.capnproto.PrimitiveList.Int.factory, 0, size);
+        public final org.capnproto.StructList.Builder<com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteTypeInTileType.Builder> initSiteTypes(int size) {
+          return _initPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteTypeInTileType.listFactory, 0, size);
         }
         public final boolean hasWires() {
           return !_pointerFieldIsNull(1);
@@ -454,8 +621,8 @@ public final class DeviceResources {
         public final boolean hasSiteTypes() {
           return !_pointerFieldIsNull(0);
         }
-        public final org.capnproto.PrimitiveList.Int.Reader getSiteTypes() {
-          return _getPointerField(org.capnproto.PrimitiveList.Int.factory, 0, null, 0);
+        public final org.capnproto.StructList.Reader<com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteTypeInTileType.Reader> getSiteTypes() {
+          return _getPointerField(com.xilinx.rapidwright.interchange.DeviceResources.Device.SiteTypeInTileType.listFactory, 0, null, 0);
         }
 
         public final boolean hasWires() {
@@ -1024,18 +1191,11 @@ public final class DeviceResources {
           _setShortField(2, (short)value.ordinal());
         }
 
-        public final int getSitewire() {
+        public final int getBelpin() {
           return _getIntField(2);
         }
-        public final void setSitewire(int value) {
-          _setIntField(2, value);
-        }
-
-        public final int getBelpin() {
-          return _getIntField(3);
-        }
         public final void setBelpin(int value) {
-          _setIntField(3, value);
+          _setIntField(2, value);
         }
 
       }
@@ -1058,12 +1218,8 @@ public final class DeviceResources {
           }
         }
 
-        public final int getSitewire() {
-          return _getIntField(2);
-        }
-
         public final int getBelpin() {
-          return _getIntField(3);
+          return _getIntField(2);
         }
 
       }
@@ -1363,46 +1519,55 @@ public static final org.capnproto.SegmentReader b_ffa75a3a3e5ace96 =
    "\u0009\u0000\u0007\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0015\u0000\u0000\u0000\u00ea\u0000\u0000\u0000" +
-   "\u0021\u0000\u0000\u0000\u00e7\u0000\u0000\u0000" +
+   "\u0021\u0000\u0000\u0000\u0007\u0001\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00dd\u0000\u0000\u0000\u00ff\u0001\u0000\u0000" +
+   "\u0001\u0001\u0000\u0000\u00ff\u0001\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0044\u0065\u0076\u0069\u0063\u0065\u0052\u0065" +
    "\u0073\u006f\u0075\u0072\u0063\u0065\u0073\u002e" +
    "\u0063\u0061\u0070\u006e\u0070\u003a\u0044\u0065" +
    "\u0076\u0069\u0063\u0065\u0000\u0000\u0000\u0000" +
-   "\u0038\u0000\u0000\u0000\u0001\u0000\u0001\u0000" +
+   "\u0040\u0000\u0000\u0000\u0001\u0000\u0001\u0000" +
    "\u00da\u0076\u0065\u008a\u0054\u00fd\u0054\u00e1" +
-   "\u0069\u0000\u0000\u0000\u004a\u0000\u0000\u0000" +
+   "\u0079\u0000\u0000\u0000\u004a\u0000\u0000\u0000" +
+   "\u00db\u008d\u00cf\u00c0\u007d\u00a1\u0044\u00a2" +
+   "\u0079\u0000\u0000\u0000\u005a\u0000\u0000\u0000" +
+   "\u00f6\u00f5\u0062\u00cf\u0067\u0097\u00b9\u00a0" +
+   "\u0079\u0000\u0000\u0000\u009a\u0000\u0000\u0000" +
    "\u0011\u00f8\u0098\u00b1\u00e1\u0081\u0041\u00fb" +
-   "\u0069\u0000\u0000\u0000\u004a\u0000\u0000\u0000" +
+   "\u007d\u0000\u0000\u0000\u004a\u0000\u0000\u0000" +
    "\u00ab\u0046\u004d\u0018\u0008\u0046\u001f\u00ad" +
-   "\u0069\u0000\u0000\u0000\"\u0000\u0000\u0000" +
+   "\u007d\u0000\u0000\u0000\"\u0000\u0000\u0000" +
    "\u0011\u0052\u001c\u0027\u0064\u00d6\u00f9\u00e6" +
-   "\u0065\u0000\u0000\u0000\u0062\u0000\u0000\u0000" +
+   "\u0079\u0000\u0000\u0000\u0062\u0000\u0000\u0000" +
    "\u004c\u007a\\\u00e5\u005d\u0000\u00ae\u009a" +
-   "\u0065\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
+   "\u0079\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
    "\u00e9\u0012\u002b\u0062\u0001\u00c7\u0066\u00ee" +
-   "\u0061\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
+   "\u0075\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
    "\u0087\u0005\u00aa\u0069\u0015\u0084\u00b1\u00ee" +
-   "\u005d\u0000\u0000\u0000\u003a\u0000\u0000\u0000" +
+   "\u0071\u0000\u0000\u0000\u003a\u0000\u0000\u0000" +
    "\u0045\u00d1\u00d8\u00bc\u0068\u004e\u000b\u00d4" +
-   "\u0059\u0000\u0000\u0000\u004a\u0000\u0000\u0000" +
+   "\u006d\u0000\u0000\u0000\u004a\u0000\u0000\u0000" +
    "\u0051\u00d1\u0079\u0066\u00b1\u00b0\u0045\u0096" +
-   "\u0059\u0000\u0000\u0000\u0042\u0000\u0000\u0000" +
+   "\u006d\u0000\u0000\u0000\u0042\u0000\u0000\u0000" +
    "\u00a4\u00a3\u00c1\u009c\u007e\u00bd\u00a9\u00a8" +
-   "\u0055\u0000\u0000\u0000\u0042\u0000\u0000\u0000" +
+   "\u0069\u0000\u0000\u0000\u0042\u0000\u0000\u0000" +
    "\u0035\u002b\u0042\u00c7\u0049\u00ee\u0048\u00e6" +
-   "\u0051\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
+   "\u0065\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
    "\u00b2\u0023\u003f\u00b9\u0056\u0062\u001a\u00ec" +
-   "\u004d\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
+   "\u0061\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
    "\u00dc\\\u00a3\u003e\u0035\u005b\u0068\u00e5" +
-   "\u0049\u0000\u0000\u0000\"\u0000\u0000\u0000" +
+   "\u005d\u0000\u0000\u0000\"\u0000\u0000\u0000" +
    "\u00cd\u00a3\u00be\u00ee\u0080\u001c\u009d\u00b0" +
-   "\u0045\u0000\u0000\u0000\u00aa\u0000\u0000\u0000" +
+   "\u0059\u0000\u0000\u0000\u00aa\u0000\u0000\u0000" +
    "\u0053\u0069\u0074\u0065\u0054\u0079\u0070\u0065" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0050\u0061\u0072\u0065\u006e\u0074\u0050\u0069" +
+   "\u006e\u0073\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0053\u0069\u0074\u0065\u0054\u0079\u0070\u0065" +
+   "\u0049\u006e\u0054\u0069\u006c\u0065\u0054\u0079" +
+   "\u0070\u0065\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0054\u0069\u006c\u0065\u0054\u0079\u0070\u0065" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0042\u0045\u004c\u0000\u0000\u0000\u0000\u0000" +
@@ -1596,12 +1761,12 @@ public static final org.capnproto.SegmentReader b_e154fd548a6576da =
    "\u00da\u0076\u0065\u008a\u0054\u00fd\u0054\u00e1" +
    "\u001d\u0000\u0000\u0000\u0001\u0000\u0001\u0000" +
    "\u0096\u00ce\u005a\u003e\u003a\u005a\u00a7\u00ff" +
-   "\u0005\u0000\u0007\u0000\u0000\u0000\u0000\u0000" +
+   "\u0006\u0000\u0007\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0015\u0000\u0000\u0000\u0032\u0001\u0000\u0000" +
    "\u0025\u0000\u0000\u0000\u0007\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0021\u0000\u0000\u0000\u008f\u0001\u0000\u0000" +
+   "\u0021\u0000\u0000\u0000\u00c7\u0001\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0044\u0065\u0076\u0069\u0063\u0065\u0052\u0065" +
@@ -1610,56 +1775,63 @@ public static final org.capnproto.SegmentReader b_e154fd548a6576da =
    "\u0076\u0069\u0063\u0065\u002e\u0053\u0069\u0074" +
    "\u0065\u0054\u0079\u0070\u0065\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000" +
-   "\u001c\u0000\u0000\u0000\u0003\u0000\u0004\u0000" +
+   "\u0020\u0000\u0000\u0000\u0003\u0000\u0004\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00b5\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00b0\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u00bc\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
-   "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00b9\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00b4\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u00d0\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
-   "\u0002\u0000\u0000\u0000\u0001\u0000\u0000\u0000" +
-   "\u0000\u0000\u0001\u0000\u0002\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00cd\u0000\u0000\u0000\u0052\u0000\u0000\u0000" +
+   "\u00d1\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u00cc\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
    "\u00d8\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
-   "\u0003\u0000\u0000\u0000\u0001\u0000\u0000\u0000" +
-   "\u0000\u0000\u0001\u0000\u0003\u0000\u0000\u0000" +
+   "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u00d5\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u00d0\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
    "\u00ec\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0002\u0000\u0000\u0000\u0001\u0000\u0000\u0000" +
+   "\u0000\u0000\u0001\u0000\u0002\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u00e9\u0000\u0000\u0000\u0052\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u00e8\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u00f4\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0003\u0000\u0000\u0000\u0001\u0000\u0000\u0000" +
+   "\u0000\u0000\u0001\u0000\u0003\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u00f1\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u00ec\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0008\u0001\u0000\u0000\u0002\u0000\u0001\u0000" +
    "\u0004\u0000\u0000\u0000\u0002\u0000\u0000\u0000" +
    "\u0000\u0000\u0001\u0000\u0004\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00e9\u0000\u0000\u0000\u0042\u0000\u0000\u0000" +
+   "\u0005\u0001\u0000\u0000\u0042\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00e4\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u0000\u0001\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0000\u0001\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u001c\u0001\u0000\u0000\u0002\u0000\u0001\u0000" +
    "\u0005\u0000\u0000\u0000\u0003\u0000\u0000\u0000" +
    "\u0000\u0000\u0001\u0000\u0005\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00fd\u0000\u0000\u0000\u004a\u0000\u0000\u0000" +
+   "\u0019\u0001\u0000\u0000\u004a\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u00fc\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u0018\u0001\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0018\u0001\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0034\u0001\u0000\u0000\u0002\u0000\u0001\u0000" +
    "\u0006\u0000\u0000\u0000\u0004\u0000\u0000\u0000" +
    "\u0000\u0000\u0001\u0000\u0006\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0015\u0001\u0000\u0000\u0052\u0000\u0000\u0000" +
+   "\u0031\u0001\u0000\u0000\u0052\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0014\u0001\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u0030\u0001\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0030\u0001\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u004c\u0001\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0007\u0000\u0000\u0000\u0005\u0000\u0000\u0000" +
+   "\u0000\u0000\u0001\u0000\u0007\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0049\u0001\u0000\u0000\u006a\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0048\u0001\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0064\u0001\u0000\u0000\u0002\u0000\u0001\u0000" +
    "\u006e\u0061\u006d\u0065\u0000\u0000\u0000\u0000" +
    "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
@@ -1738,6 +1910,139 @@ public static final org.capnproto.SegmentReader b_e154fd548a6576da =
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0061\u006c\u0074\u0053\u0069\u0074\u0065\u0054" +
+   "\u0079\u0070\u0065\u0073\u0000\u0000\u0000\u0000" +
+   "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" + "");
+public static final org.capnproto.SegmentReader b_a244a17dc0cf8ddb =
+   org.capnproto.GeneratedClassSupport.decodeRawBytes(
+   "\u0000\u0000\u0000\u0000\u0005\u0000\u0006\u0000" +
+   "\u00db\u008d\u00cf\u00c0\u007d\u00a1\u0044\u00a2" +
+   "\u001d\u0000\u0000\u0000\u0001\u0000\u0000\u0000" +
+   "\u0096\u00ce\u005a\u003e\u003a\u005a\u00a7\u00ff" +
+   "\u0001\u0000\u0007\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0015\u0000\u0000\u0000\u0042\u0001\u0000\u0000" +
+   "\u0025\u0000\u0000\u0000\u0007\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0021\u0000\u0000\u0000\u003f\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0044\u0065\u0076\u0069\u0063\u0065\u0052\u0065" +
+   "\u0073\u006f\u0075\u0072\u0063\u0065\u0073\u002e" +
+   "\u0063\u0061\u0070\u006e\u0070\u003a\u0044\u0065" +
+   "\u0076\u0069\u0063\u0065\u002e\u0050\u0061\u0072" +
+   "\u0065\u006e\u0074\u0050\u0069\u006e\u0073\u0000" +
+   "\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000" +
+   "\u0004\u0000\u0000\u0000\u0003\u0000\u0004\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\r\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0008\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0024\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0070\u0069\u006e\u0073\u0000\u0000\u0000\u0000" +
+   "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" + "");
+public static final org.capnproto.SegmentReader b_a0b99767cf62f5f6 =
+   org.capnproto.GeneratedClassSupport.decodeRawBytes(
+   "\u0000\u0000\u0000\u0000\u0005\u0000\u0006\u0000" +
+   "\u00f6\u00f5\u0062\u00cf\u0067\u0097\u00b9\u00a0" +
+   "\u001d\u0000\u0000\u0000\u0001\u0000\u0001\u0000" +
+   "\u0096\u00ce\u005a\u003e\u003a\u005a\u00a7\u00ff" +
+   "\u0002\u0000\u0007\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0015\u0000\u0000\u0000\u0082\u0001\u0000\u0000" +
+   "\u0029\u0000\u0000\u0000\u0007\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0025\u0000\u0000\u0000\u00af\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0044\u0065\u0076\u0069\u0063\u0065\u0052\u0065" +
+   "\u0073\u006f\u0075\u0072\u0063\u0065\u0073\u002e" +
+   "\u0063\u0061\u0070\u006e\u0070\u003a\u0044\u0065" +
+   "\u0076\u0069\u0063\u0065\u002e\u0053\u0069\u0074" +
+   "\u0065\u0054\u0079\u0070\u0065\u0049\u006e\u0054" +
+   "\u0069\u006c\u0065\u0054\u0079\u0070\u0065\u0000" +
+   "\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000" +
+   "\u000c\u0000\u0000\u0000\u0003\u0000\u0004\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0045\u0000\u0000\u0000\u0062\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0044\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0050\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u004d\u0000\u0000\u0000\u00ba\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0050\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u006c\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0002\u0000\u0000\u0000\u0001\u0000\u0000\u0000" +
+   "\u0000\u0000\u0001\u0000\u0002\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0069\u0000\u0000\u0000\u00aa\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u006c\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0088\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0070\u0072\u0069\u006d\u0061\u0072\u0079\u0054" +
+   "\u0079\u0070\u0065\u0000\u0000\u0000\u0000\u0000" +
+   "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0070\u0072\u0069\u006d\u0061\u0072\u0079\u0050" +
+   "\u0069\u006e\u0073\u0054\u006f\u0054\u0069\u006c" +
+   "\u0065\u0057\u0069\u0072\u0065\u0073\u0000\u0000" +
+   "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0061\u006c\u0074\u0050\u0069\u006e\u0073\u0054" +
+   "\u006f\u0050\u0072\u0069\u006d\u0061\u0072\u0079" +
+   "\u0050\u0069\u006e\u0073\u0000\u0000\u0000\u0000" +
+   "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0010\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u00db\u008d\u00cf\u00c0\u007d\u00a1\u0044\u00a2" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" + "");
 public static final org.capnproto.SegmentReader b_fb4181e1b198f811 =
    org.capnproto.GeneratedClassSupport.decodeRawBytes(
@@ -1802,8 +2107,8 @@ public static final org.capnproto.SegmentReader b_fb4181e1b198f811 =
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u0010\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
+   "\u00f6\u00f5\u0062\u00cf\u0067\u0097\u00b9\u00a0" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u000e\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
@@ -2304,7 +2609,7 @@ public static final org.capnproto.SegmentReader b_a8a9bd7e9cc1a3a4 =
    "\u0015\u0000\u0000\u0000\u002a\u0001\u0000\u0000" +
    "\u0025\u0000\u0000\u0000\u0007\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0021\u0000\u0000\u0000\u00e7\u0000\u0000\u0000" +
+   "\u0021\u0000\u0000\u0000\u00af\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0044\u0065\u0076\u0069\u0063\u0065\u0052\u0065" +
@@ -2313,35 +2618,28 @@ public static final org.capnproto.SegmentReader b_a8a9bd7e9cc1a3a4 =
    "\u0076\u0069\u0063\u0065\u002e\u0053\u0069\u0074" +
    "\u0065\u0050\u0069\u006e\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000" +
-   "\u0010\u0000\u0000\u0000\u0003\u0000\u0004\u0000" +
+   "\u000c\u0000\u0000\u0000\u0003\u0000\u0004\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0061\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
+   "\u0045\u0000\u0000\u0000\u002a\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\\\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u0068\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0040\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u004c\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
    "\u0001\u0000\u0000\u0000\u0002\u0000\u0000\u0000" +
    "\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0065\u0000\u0000\u0000\"\u0000\u0000\u0000" +
+   "\u0049\u0000\u0000\u0000\"\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0060\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u006c\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0044\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0050\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
    "\u0002\u0000\u0000\u0000\u0002\u0000\u0000\u0000" +
    "\u0000\u0000\u0001\u0000\u0002\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0069\u0000\u0000\u0000\u004a\u0000\u0000\u0000" +
+   "\u004d\u0000\u0000\u0000\u003a\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0068\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u0074\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
-   "\u0003\u0000\u0000\u0000\u0003\u0000\u0000\u0000" +
-   "\u0000\u0000\u0001\u0000\u0003\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0071\u0000\u0000\u0000\u003a\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u006c\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
-   "\u0078\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
+   "\u0048\u0000\u0000\u0000\u0003\u0000\u0001\u0000" +
+   "\u0054\u0000\u0000\u0000\u0002\u0000\u0001\u0000" +
    "\u006e\u0061\u006d\u0065\u0000\u0000\u0000\u0000" +
    "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
@@ -2356,15 +2654,6 @@ public static final org.capnproto.SegmentReader b_a8a9bd7e9cc1a3a4 =
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u000f\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0073\u0069\u0074\u0065\u0077\u0069\u0072\u0065" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
-   "\u0008\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" +
    "\u0062\u0065\u006c\u0070\u0069\u006e\u0000\u0000" +

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesExample.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesExample.java
@@ -26,7 +26,7 @@ public class DeviceResourcesExample {
             Device device = Device.getDevice(args[0]);
             t.stop();
             // Write Netlist to Cap'n Proto Serialization file
-            DeviceResourcesWriter.writeDeviceResourcesFile(device, t, capnProtoFileName);            
+            DeviceResourcesWriter.writeDeviceResourcesFile(args[0], device, t, capnProtoFileName);            
             Device.releaseDeviceReferences();
         }
         

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -224,8 +224,8 @@ public class DeviceResourcesVerifier {
             if( (isInput != (dir == Direction.INPUT)) || (isOutput != (dir == Direction.OUTPUT)) ){
                 throw new RuntimeException("ERROR: Mismatch on site pin direction");
             }
-            Integer siteWireIndex = site.getSiteWireIndex(pinName);
-            expect(siteWireIndex == null ? -1 : siteWireIndex, spReader.getSitewire());
+            String tileWireName = site.getTileWireNameFromPinName(pinName);
+            expect(tileWireName == null ? -1 : allStrings.getIndex(tileWireName), spReader.getSitewire());
         }
         expect(highestIndexInputPin, stReader.getLastInput());
         

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -241,8 +241,8 @@ public class DeviceResourcesWriter {
                 SitePin.Builder pin = pins.get(j);
                 pin.setName(allStrings.getIndex(pinNames.get(j)));
                 pin.setDir(j <= highestIndexInputPin ? Direction.INPUT : Direction.OUTPUT);
-                Integer siteWireIdx = site.getSiteWireIndex(pinNames.get(j));
-                pin.setSitewire(siteWireIdx == null ? -1 : siteWireIdx);
+                String tileWireName = site.getTileWireNameFromPinName(pinNames.get(j));
+                pin.setSitewire(tileWireName == null ? -1 : allStrings.getIndex(tileWireName));
             }
             
             // SitePIPs

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -378,7 +378,7 @@ public class DeviceResourcesWriter {
             Wire wire = new Wire(device.getTile((int)(wireKey >>> 32)), (int)(wireKey & 0xffffffff));
             //Wire wire = allWires.get(i);
             wireBuilder.setTile(allStrings.getIndex(wire.getTile().getName()));
-            wireBuilder.setWire(wire.getWireIndex());
+            wireBuilder.setWire(allStrings.getIndex(wire.getWireName()));
         }
         
         StructList.Builder<DeviceResources.Device.Node.Builder> nodeBuilders = 

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -54,22 +54,22 @@ public class DeviceResourcesWriter {
     private static HashMap<TileTypeEnum,Tile> tileTypes;
     private static HashMap<SiteTypeEnum,Site> siteTypes;
 
-    public static void populateSiteEnumerations(SiteInst site_inst, Site site) {
-        if(!siteTypes.containsKey(site_inst.getSiteTypeEnum())) {
-            siteTypes.put(site_inst.getSiteTypeEnum(), site);
-            allStrings.addObject(site_inst.getSiteTypeEnum().toString());
+    public static void populateSiteEnumerations(SiteInst siteInst, Site site) {
+        if(!siteTypes.containsKey(siteInst.getSiteTypeEnum())) {
+            siteTypes.put(siteInst.getSiteTypeEnum(), site);
+            allStrings.addObject(siteInst.getSiteTypeEnum().toString());
 
-            for(String siteWire : site_inst.getSiteWires()) {
+            for(String siteWire : siteInst.getSiteWires()) {
                 allStrings.addObject(siteWire);
             }
-            for(BEL bel : site_inst.getBELs()) {
+            for(BEL bel : siteInst.getBELs()) {
                 allStrings.addObject(bel.getName());
                 allStrings.addObject(bel.getBELType());
                 for(BELPin belPin : bel.getPins()) {
                     allStrings.addObject(belPin.getName());
                 }
             }
-            for(String sitePin : site_inst.getSitePinNames()) {
+            for(String sitePin : siteInst.getSitePinNames()) {
                 allStrings.addObject(sitePin);
             }
         }
@@ -220,15 +220,15 @@ public class DeviceResourcesWriter {
         for(Entry<SiteTypeEnum,Site> e : siteTypes.entrySet()) {
             SiteType.Builder siteType = siteTypesList.get(i);
             Site site = e.getValue();
-            SiteInst site_inst = design.createSiteInst("site_instance", e.getKey(), site);
-            Tile tile = site_inst.getTile();
+            SiteInst siteInst = design.createSiteInst("site_instance", e.getKey(), site);
+            Tile tile = siteInst.getTile();
             siteType.setName(allStrings.getIndex(e.getKey().name()));
             allSiteTypes.addObject(e.getKey().name());
             // BELs & BELPins
             Enumerator<BELPin> allBELPins = new Enumerator<BELPin>();
-            StructList.Builder<Builder> belBuilders = siteType.initBels(site_inst.getBELs().length);
-            for(int j=0; j < site_inst.getBELs().length; j++) {
-                BEL bel = site_inst.getBELs()[j];
+            StructList.Builder<Builder> belBuilders = siteType.initBels(siteInst.getBELs().length);
+            for(int j=0; j < siteInst.getBELs().length; j++) {
+                BEL bel = siteInst.getBELs()[j];
                 Builder belBuilder = belBuilders.get(j);
                 belBuilder.setName(allStrings.getIndex(bel.getName()));
                 belBuilder.setType(allStrings.getIndex(bel.getBELType()));
@@ -251,16 +251,16 @@ public class DeviceResourcesWriter {
                 belPinBuilder.setDir(getBELPinDirection(belPin));
                 belPinBuilder.setBel(allStrings.getIndex(belPin.getBEL().getName()));
 
-                SitePIP sitePip = site_inst.getSitePIP(belPin);
+                SitePIP sitePip = siteInst.getSitePIP(belPin);
                 if(sitePip != null) {
                     allSitePIPs.addObject(sitePip);
                 }
             }
 
             // SitePins
-            int highestIndexInputPin = site_inst.getHighestSitePinInputIndex();
+            int highestIndexInputPin = siteInst.getHighestSitePinInputIndex();
             ArrayList<String> pinNames = new ArrayList<String>();
-            for(String pinName : site_inst.getSitePinNames()) {
+            for(String pinName : siteInst.getSitePinNames()) {
                 pinNames.add(pinName);
             }
             siteType.setLastInput(highestIndexInputPin);
@@ -270,7 +270,7 @@ public class DeviceResourcesWriter {
                 String primarySitePinName = pinNames.get(j);
                 int sitePinIndex = site.getPinIndex(pinNames.get(j));
                 if(sitePinIndex == -1) {
-                    primarySitePinName = site_inst.getPrimarySitePinName(pinNames.get(j));
+                    primarySitePinName = siteInst.getPrimarySitePinName(pinNames.get(j));
                     sitePinIndex = site.getPinIndex(primarySitePinName);
                 }
 
@@ -297,21 +297,21 @@ public class DeviceResourcesWriter {
             }
 
             // SiteWires
-            String[] siteWires = site_inst.getSiteWires();
+            String[] siteWires = siteInst.getSiteWires();
             StructList.Builder<SiteWire.Builder> swBuilders =
                     siteType.initSiteWires(siteWires.length);
             for(int j=0; j < siteWires.length; j++) {
                 SiteWire.Builder swBuilder = swBuilders.get(j);
                 String siteWireName = siteWires[j];
                 swBuilder.setName(allStrings.getIndex(siteWireName));
-                BELPin[] swPins = site_inst.getSiteWirePins(siteWireName);
+                BELPin[] swPins = siteInst.getSiteWirePins(siteWireName);
                 PrimitiveList.Int.Builder bpBuilders = swBuilder.initPins(swPins.length);
                 for(int k=0; k < swPins.length; k++) {
                     bpBuilders.set(k, allBELPins.getIndex(swPins[k]));
                 }
             }
 
-            design.removeSiteInst(site_inst);
+            design.removeSiteInst(siteInst);
             i++;
         }
 

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -238,11 +238,13 @@ public class DeviceResourcesWriter {
             siteType.setLastInput(highestIndexInputPin);
             StructList.Builder<SitePin.Builder> pins = siteType.initPins(pinNames.size());
             for(int j=0; j < pinNames.size(); j++) {
+                com.xilinx.rapidwright.device.SitePin site_pin = new com.xilinx.rapidwright.device.SitePin(site, pinNames.get(j));
                 SitePin.Builder pin = pins.get(j);
                 pin.setName(allStrings.getIndex(pinNames.get(j)));
                 pin.setDir(j <= highestIndexInputPin ? Direction.INPUT : Direction.OUTPUT);
                 String tileWireName = site.getTileWireNameFromPinName(pinNames.get(j));
                 pin.setSitewire(tileWireName == null ? -1 : allStrings.getIndex(tileWireName));
+                pin.setBelpin(allBELPins.getIndex(site_pin.getBELPin()));
             }
             
             // SitePIPs

--- a/src/com/xilinx/rapidwright/interchange/Enumerator.java
+++ b/src/com/xilinx/rapidwright/interchange/Enumerator.java
@@ -10,7 +10,7 @@ public class Enumerator<T> extends ArrayList<T> {
     private static final long serialVersionUID = 5235125492429382642L;
 
     private HashMap<String, Integer> map = new HashMap<String, Integer>();
-    
+
     private String getKey(T obj) {
         String key = null;
         if(obj instanceof EDIFEnumerable) {
@@ -20,7 +20,12 @@ public class Enumerator<T> extends ArrayList<T> {
         }
         return key;
     }
-    
+
+    public Integer maybeGetIndex(T obj) {
+        String key = getKey(obj);
+        return map.get(key);
+    }
+
     public Integer getIndex(T obj) {
         String key = getKey(obj);
         Integer idx = map.get(key);
@@ -31,29 +36,29 @@ public class Enumerator<T> extends ArrayList<T> {
         }
         return idx;
     }
-    
+
     public void addObject(T obj) {
         getIndex(obj);
     }
-    
+
     public void update(T obj, int index) {
         set(index, obj);
         map.put(getKey(obj), index);
     }
-    
+
     public void ensureSize(int size) {
         ensureCapacity(size);
         while(size() < size) {
             add(null);
         }
     }
-    
+
     @Override
     public T get(int index) {
         if(size() -1 < index) return null;
         return super.get(index);
     }
-    
+
     @Override
     public void clear() {
         super.clear();


### PR DESCRIPTION
The schema indicates that the wire table is StringIdx, StringIdx: 

https://github.com/Xilinx/RapidWright/blob/58f91e011e449be78c09b3f4302b341396c7b57c/interchange/DeviceResources.capnp#L105-L108

This fixes the DeviceResourceWriter to match the schema.