### PR TITLE
7 series PBlock generation

### DIFF
--- a/src/com/xilinx/rapidwright/design/blocks/PBlockGenerator.java
+++ b/src/com/xilinx/rapidwright/design/blocks/PBlockGenerator.java
@@ -164,17 +164,14 @@ public class PBlockGenerator {
 			RAMLUTS_PER_CLE = 4;
 			SLICES_PER_TILE = 2;
 		}
-		//if(debug){ // ELA
+		if(debug){ 
 			System.out.println("Parsed report: " + reportFileName);
 			System.out.println("  Device: " + dev.getName());
-			System.out.println("Ela    CARRY: " + carryCount);
-			System.out.println("Ela    lutRAMCount: " + lutRAMCount);
-			System.out.println("Ela  regCount:  " + regCount);
 			System.out.println("    LUTs: " + lutCount);
 			System.out.println("    DSPs: " + dspCount);
 			System.out.println("18kBRAMs: " + bram18kCount);
 			System.out.println("36kBRAMs: " + bram36kCount);
-		//} // ELA
+		} 
 		if(lutCount < LUTS_PER_CLE) lutCount = LUTS_PER_CLE;
 	}
 	
@@ -811,33 +808,26 @@ public class PBlockGenerator {
 		
 		// Let's calculate exactly how many sites we need of each type
 		int slicesLUTSRequired = Math.round((((float)(lutCount-lutRAMCount) / (float)LUTS_PER_CLE)*SLICES_PER_TILE * OVERHEAD_RATIO) + 0.5f); // Multiply with SLICES_PER_TILE for 7 series, where one CLB has 2 slices
-		System.out.println("ela . based on luts slicesLUTSRequired = "+slicesLUTSRequired);
 		// Let's calculate how many FF & carry slices we need
 		int slicesFFCarryRequired = Math.round((((float)regCount / (float)FF_PER_CLE)*SLICES_PER_TILE * OVERHEAD_RATIO) + 0.5f);		
-		System.out.println("ela . based on regs slicesFFCarryRequired = "+slicesFFCarryRequired);
 		if(carryCount/CARRY_PER_CLE > slicesFFCarryRequired/SLICES_PER_TILE){
 			slicesFFCarryRequired = Math.round((((float)carryCount / (float)CARRY_PER_CLE)*SLICES_PER_TILE*OVERHEAD_RATIO)+ 0.5f);
 		}
-		System.out.println("ela . based on regs+carry slicesFFCarryRequired = "+slicesFFCarryRequired);
 		int dspsRequired = dspCount;
 		if((dspsRequired & 0x1) == 0x1){
 			// if we have an odd number of dsp, round up by 1 more
 			dspsRequired++;
 		} 
 		int ramb36sRequired = bram36kCount + (int)Math.ceil((float)bram18kCount / 2.0);
-		System.out.println("ela . ramb36sRequired= "+ramb36sRequired);
 		int sliceMsRequired = (int)Math.ceil((float)lutRAMCount / (float)RAMLUTS_PER_CLE); // Not multiplying with SLICES_PER_TILE, as in one M-CLB Tile, there is only one slice having LUTRAM 
-		System.out.println("ela . sliceMsRequired= "+sliceMsRequired);
 		
 		// now compute Nr slices: 
 		int slicesRequired = slicesLUTSRequired + (slicesFFCarryRequired - (slicesLUTSRequired+sliceMsRequired));
-		System.out.println("ela . slicesRequired= "+slicesRequired);
 		int pblockCLEHeight = 0;
 		//Figure out how tall we need to make the pblock
 		//Make DSPs and BRAMs upto as tall as a region before creating a new column
 		int dspCLECount = (int) Math.ceil(dspsRequired * CLES_PER_DSP);
 		int bramCLECount = (int) Math.ceil(ramb36sRequired * CLES_PER_BRAM);
-		System.out.println("ela . ramb36sRequired = "+ramb36sRequired+" bramCLECount= "+bramCLECount);
 		
 		if(dspCLECount == 0 && bramCLECount == 0){
 			// ASPECT_RATIO = width(X) / height(Y)
@@ -850,7 +840,6 @@ public class PBlockGenerator {
 			}else{
 				pblockCLEHeight = (int) Math.ceil(Math.sqrt(sliceMsRequired/(SLICES_PER_TILE*ASPECT_RATIO)));
 			}
-			System.out.println("ela . slicesRequired= "+slicesRequired+ " and sliceMsRequired = " +sliceMsRequired+" thus pblockCLEHeight= "+pblockCLEHeight);
 			
 		}else if(dspCLECount > bramCLECount){
 			pblockCLEHeight = dspCLECount;
@@ -871,7 +860,6 @@ public class PBlockGenerator {
 		//                      h = sqrt(A / r)
 		//
 		int checkedCLEHeight = (int) Math.ceil(Math.sqrt(((double) Math.max(slicesRequired,sliceMsRequired)) / (SLICES_PER_TILE*ASPECT_RATIO)));
-		System.out.println("ela . checkedCLEHeight= "+checkedCLEHeight);
 		if(pblockCLEHeight < checkedCLEHeight){
 			pblockCLEHeight = checkedCLEHeight;
 		}
@@ -887,10 +875,8 @@ public class PBlockGenerator {
 		// Now, given an aspect ratio, we know how many columns of each we'll need
 		int numSLICEColumns = (int) Math.ceil((float)slicesRequired / pblockCLEHeight);
 		numSLICEColumns = (numSLICEColumns > 0) ? numSLICEColumns : 1;
-		System.out.println("ela . numSLICEColumns= "+numSLICEColumns);
 		int numSLICEMColumns = (int) Math.ceil((float)sliceMsRequired / pblockCLEHeight);
 		numSLICEMColumns = (sliceMsRequired > 0 && numSLICEMColumns == 0) ? 1 : numSLICEMColumns;
-		System.out.println("ela . numSLICEMColumns= "+numSLICEMColumns);
 		int numBRAMColumns = (int) Math.ceil(((float)ramb36sRequired * CLES_PER_BRAM) / pblockCLEHeight);;
 		numBRAMColumns = (ramb36sRequired > 0 && numBRAMColumns == 0) ? 1 : numBRAMColumns;
 		
@@ -901,11 +887,9 @@ public class PBlockGenerator {
 		if(dspCLECount == 0 && bramCLECount == 0){
 			int areaSLICEExcess = (numSLICEColumns * pblockCLEHeight) - slicesRequired;
 			int areaSLICEMExcess = numSLICEMColumns * pblockCLEHeight - sliceMsRequired;
-			System.out.println("ela . areaSLICEExcess= "+areaSLICEExcess + " and areaSLICEMExcess "+areaSLICEMExcess);
 			
 			int sliceExcessHeight = numSLICEColumns > 0 ? areaSLICEExcess / numSLICEColumns : 0; 
 			int sliceMExcessHeight = numSLICEMColumns > 0 ? areaSLICEMExcess / numSLICEMColumns : 0;
-			System.out.println("ela . sliceExcessHeight= "+sliceExcessHeight+" sliceMExcessHeight = "+sliceMExcessHeight);
 			
 			if(numSLICEColumns > 0 && numSLICEMColumns == 0){
 				pblockCLEHeight -= sliceExcessHeight;
@@ -913,7 +897,6 @@ public class PBlockGenerator {
 				pblockCLEHeight -= sliceMExcessHeight;
 			}else if(numSLICEColumns > 0 && numSLICEMColumns > 0){
 				pblockCLEHeight -= Integer.min(sliceExcessHeight, sliceMExcessHeight);
-				System.out.println("ela . pblockCLEHeight first update = "+pblockCLEHeight);
 				// In the case where we have both SLICEL and SLICEM, extra SLICEM spots
 				// can absorb some SLICELs, further reducing height
 				areaSLICEMExcess = numSLICEMColumns * pblockCLEHeight - sliceMsRequired;
@@ -921,8 +904,6 @@ public class PBlockGenerator {
 				if(excessHeight > 0){
 					pblockCLEHeight -= excessHeight;
 				}
-
-				System.out.println("ela . pblockCLEHeight second update = "+pblockCLEHeight);
 			}
 		}
 		
@@ -930,13 +911,11 @@ public class PBlockGenerator {
 		if(tallestShape > pblockCLEHeight){
 			pblockCLEHeight = tallestShape;
 		}
-		System.out.println("ela . tallestShape= "+tallestShape);
 		
 		if(widestShape > (numSLICEColumns+numSLICEMColumns)){
 			int extra = numSLICEColumns+numSLICEMColumns - widestShape;
 			numSLICEColumns = numSLICEColumns + extra;
 		}
-		System.out.println("ela . widestShape= "+widestShape);
 		int pblockArea = (numSLICEColumns+numSLICEMColumns) * pblockCLEHeight;
 		
 		if(shapeArea > pblockArea){
@@ -944,7 +923,6 @@ public class PBlockGenerator {
 			double areaShortage = shapeArea - pblockArea;
 			int increaseHeightBy = (int) Math.ceil(areaShortage  / (numSLICEColumns+numSLICEMColumns));
 			pblockCLEHeight += increaseHeightBy;
-			System.out.println("ela . pblockCLEHeight = "+pblockCLEHeight+" updated by shapeArea = "+shapeArea);
 		}
 		
 		

--- a/src/com/xilinx/rapidwright/design/blocks/PBlockGenerator.java
+++ b/src/com/xilinx/rapidwright/design/blocks/PBlockGenerator.java
@@ -821,8 +821,11 @@ public class PBlockGenerator {
 		int ramb36sRequired = bram36kCount + (int)Math.ceil((float)bram18kCount / 2.0);
 		int sliceMsRequired = (int)Math.ceil((float)lutRAMCount / (float)RAMLUTS_PER_CLE); // Not multiplying with SLICES_PER_TILE, as in one M-CLB Tile, there is only one slice having LUTRAM 
 		
-		// now compute Nr slices: 
-		int slicesRequired = slicesLUTSRequired + (slicesFFCarryRequired - (slicesLUTSRequired+sliceMsRequired));
+		// now compute Nr slices. If nr of FF & carry slices is smaller than current total nr of slices given by LUTs, than these could be mapped in the same slices. 
+		// Update if more slices are needed for FF & carry
+		int slicesRequired = slicesLUTSRequired;
+		if (slicesFFCarryRequired > (slicesLUTSRequired+sliceMsRequired))
+			slicesRequired += (slicesFFCarryRequired - (slicesLUTSRequired+sliceMsRequired));
 		int pblockCLEHeight = 0;
 		//Figure out how tall we need to make the pblock
 		//Make DSPs and BRAMs upto as tall as a region before creating a new column

--- a/src/com/xilinx/rapidwright/design/blocks/PBlockGenerator.java
+++ b/src/com/xilinx/rapidwright/design/blocks/PBlockGenerator.java
@@ -159,7 +159,7 @@ public class PBlockGenerator {
 			}
 		}
 		
-		if (if (dev.getSeries() == Series.Series7) {
+		if (dev.getSeries() == Series.Series7) {
 			CARRY_PER_CLE = 2;
 			RAMLUTS_PER_CLE = 4;
 			SLICES_PER_TILE = 2;

--- a/src/com/xilinx/rapidwright/design/blocks/PBlockGenerator.java
+++ b/src/com/xilinx/rapidwright/design/blocks/PBlockGenerator.java
@@ -159,7 +159,7 @@ public class PBlockGenerator {
 			}
 		}
 		
-		if (dev.getName().contains("xc7")) {
+		if (if (dev.getSeries() == Series.Series7) {
 			CARRY_PER_CLE = 2;
 			RAMLUTS_PER_CLE = 4;
 			SLICES_PER_TILE = 2;


### PR DESCRIPTION
The pull request: 
-> takes into account that 7 series and Ultrascale devices have a different number of CARRY_PER_CLE, RAMLUTS_PER_CLE, 	SLICES_PER_TILE.
-> considers that FF & Carry can be placed in a SLICE together with LUTS (including LUTRAM) => different method of computing required nr. of Slices
-> in case of horizontal density algorithm, it adds some checks to avoid endless loop in special cases. For example, if provided patterns are unfeasible (unfeasible meaning cases like dev.getSite("SLICE_X"+xr+"Y"+yd)=null)