### PR TITLE
Bugfixes for migrateCellAndSubCells

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
@@ -193,12 +193,11 @@ public class EDIFLibrary extends EDIFName {
 	 */
 	public void uniqueifyCellsWithPrefix(String name){
 		ArrayList<EDIFCell> renamedCells = new ArrayList<>(getCells());
-		String validEDIFPrefix = EDIFTools.makeNameEDIFCompatible(name);
 		cells.clear();
 		for(EDIFCell c : renamedCells){
 			c.setName(name + c.getName());
 			if(c.getEDIFName() != null){
-				c.setEDIFRename(validEDIFPrefix + c.getEDIFName()); 
+				c.setEDIFRename(EDIFTools.makeNameEDIFCompatible(name + c.getEDIFName()));
 			}
 			addCell(c);
 		}


### PR DESCRIPTION
This is a collection of issues I encountered while merging some EDIFNetlists.

Without this PR, `migrateCellAndSubCells` leaves the design in a somewhat inconsistent state:
* If a cell is newly inserted to the netlist, CellInsts will refer to it
* If a cell of the same name is already part of the design, CellInsts will refer to the old Cell that is not part of the Netlist

This PR tries to fix that by always having CellInsts refer to the cell that is part of the netlist.

Some discussion pointers:
* `migrateCellAndSubCells` gets called from closed source code. Therefore I cannot change its function signature. I had to introduce a helper function. This is not needed when you are able to recompile the closed source. Should I leave it as is, or replace with a version that will only work with recompiled closed source binaries?
* I had to change the function to be recursive. Is this a problem?