### PR TITLE
detect NPE from resource not found

### DIFF
--- a/src/com/xilinx/rapidwright/util/FileTools.java
+++ b/src/com/xilinx/rapidwright/util/FileTools.java
@@ -863,7 +863,12 @@ public class FileTools {
 			}
 		}
 		// Try getting it from inside the jar (classpath)
-		return FileTools.class.getResourceAsStream("/" + name.replace(File.separator, "/"));
+		InputStream res = FileTools.class.getResourceAsStream("/" + name.replace(File.separator, "/"));
+		if (res == null) {
+			System.err.println("ERROR: " + RAPIDWRIGHT_VARIABLE_NAME +
+					" is not set and Resource was not found in Classpath.");
+		}
+		return res;
 	}
 	
 	/**


### PR DESCRIPTION
When neither RAPIDWRIGHT_PATH is set, nor the resources are present on the classpath, a NullPointerException is thrown. This PR detects this case and prints an error message.

Normally, I would throw an exception here. However, exceptions seem to be frowned upon in RapidWright, so this PR just prints to `System.err`.

Kind Regards,
Jakob