### PR TITLE
Move strList in embedded primitive library to the root.

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -447,7 +447,10 @@ public class DeviceResourcesVerifier {
         }
 
         Netlist.Reader primLibs = dReader.getPrimLibs();
-        EDIFNetlist primsAndMacros = LogNetlistReader.getLogNetlist(primLibs, true);
+        LogNetlistReader netlistReader = new LogNetlistReader(allStrings);
+        EDIFNetlist primsAndMacros = netlistReader.readLogNetlist(primLibs,
+                /*skipTopStuff=*/true);
+
         Set<String> libsFound = new HashSet<String>();
         libsFound.addAll(primsAndMacros.getLibrariesMap().keySet());
         for(String libExpected : new String[] {EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME,

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -246,7 +246,9 @@ public class DeviceResourcesWriter {
         }
 
         Netlist.Builder netlistBuilder = devBuilder.getPrimLibs();
-        LogNetlistWriter.populateNetlistBuilder(netlist, netlistBuilder, true);
+        netlistBuilder.setName(netlist.getName());
+        LogNetlistWriter writer = new LogNetlistWriter(allStrings);
+        writer.populateNetlistBuilder(netlist, netlistBuilder);
 
         // Write macro exception map
         int size = EDIFNetlist.macroExpandExceptionMap.size();


### PR DESCRIPTION
This matches the plain text annotations.