### PR TITLE
Adjust update instructions to include git pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,7 @@ http://www.rapidwright.io/docs/Automatic_Install.html#automatic-install
 
 ```
 cd $RAPIDWRIGHT_PATH
+git pull
+# resolve any issues
 make update_jars
 ```

--- a/interchange/README.md
+++ b/interchange/README.md
@@ -29,6 +29,8 @@ java com.xilinx.rapidwright.interchange.PhysicalNetlistExample pblock0.dcp pbloc
 ## How to Update RapidWright to the Most Recent Release (Assumes Linux)
 ```
 cd $RAPIDWRIGHT_PATH
+git pull
+# resolve any issues
 make update_jars
 ```
 


### PR DESCRIPTION
Since we want to keep `git pull` separate, then I think it may be a good idea to add it to the update instructions.

Signed-off-by: ReillyMcK <romckend@byu.edu>