### PR TITLE
Better Messages in JobQueue, Exceptions

### DIFF
--- a/src/com/xilinx/rapidwright/design/ModuleInst.java
+++ b/src/com/xilinx/rapidwright/design/ModuleInst.java
@@ -524,6 +524,9 @@ public class ModuleInst{
 		
 		Tile newTile = origLowerLeft.getDevice().getTile(origTilePrefix + newSuffix);
 		if(type == null){
+			if (newTile.getSites().length == 0) {
+				throw new RuntimeException("no sites in tile "+newTile+", orig lower left is "+origLowerLeft+" for mi " + getName());
+			}
 			return newTile.getSites()[0];
 		}
 		for(Site s : newTile.getSites()){

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -284,7 +284,11 @@ public class EDIFTools {
 		EDIFCellInst curr = netlist.getTopCellInst();
 		
 		for(String name : names){
-			curr = curr.getCellType().getCellInst(name);
+			EDIFCellInst next = curr.getCellType().getCellInst(name);
+			if (next == null) {
+				throw new NullPointerException("Did not find cell "+name+" in "+curr+" while trying to resolve hierarchical name "+hierarchicalName);
+			}
+			curr = next;
 		}
 		
 		return curr;

--- a/src/com/xilinx/rapidwright/util/JobQueue.java
+++ b/src/com/xilinx/rapidwright/util/JobQueue.java
@@ -88,7 +88,7 @@ public class JobQueue {
 			// it is running before we ask if it is finished
 			if(!launched || recentLSFJobLaunch){
 				try {
-					System.out.println("Waiting on " + running.size() + " jobs still running...");
+					System.out.println("Waiting on " + running.size() + " jobs still running, "+waitingToRun.size()+" not yet started...");
 					Thread.sleep(recentLSFJobLaunch ? 8000 : 2000);
 					if(recentLSFJobLaunch) recentLSFJobLaunch = false;
 				} catch (InterruptedException e) {


### PR DESCRIPTION
These are some random places where my broken designs caused `NullPointerException` crashes. This PR tries to improve these error messages.

Also include the number of Jobs yet to start in `JobQueue`.