### PR TITLE
add dependencies in Makefile to avoid unneeded recompilations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 
 BIN = bin
-JARS = $(shell find `pwd`/jars -name '*.jar' | egrep -v 'javadoc|win64' | tr '\n' ':')
+CLASSPATH = $(shell find `pwd`/jars -name '*.jar' | egrep -v 'javadoc|win64' | tr '\n' ':')
+JARFILES = $(shell find `pwd`/jars -name '*.jar' | egrep -v 'javadoc|win64' | tr '\n' ' ')
 
-compile:
+
+SOURCES := $(shell find ./src -name '*.java'  )
+CLASSES := $(shell find ./src -name '*.java' | grep -v package-info.java | sed 's=^./src=./bin=' | sed 's/.java$$/.class/')
+
+.PHONY: compile update_jars
+compile: $(CLASSES)
+$(CLASSES): $(SOURCES) $(JARFILES)
 	rm -rf $(BIN)
 	mkdir -p $(BIN)
-	javac `find src -name '*.java'` -d $(BIN) -cp $(JARS)
+	javac -source 8 -target 8 $(SOURCES) -d $(BIN) -cp $(CLASSPATH)
 	echo "export CLASSPATH=`pwd`/bin:$(shell echo `pwd`/jars/*.jar | tr ' ' ':')" > $(BIN)/rapidwright_classpath.sh
 
 update_jars:


### PR DESCRIPTION
also specify targeted java version

Signed-off-by: Jakob Wenzel <jakobw@xilinx.com>