### PR TITLE
fix jar build issues in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,4 @@
 apply plugin: 'java'
-jar.enabled = false
-
-project.buildDir = 'bin'
 
 sourceSets {
   main {


### PR DESCRIPTION
This is another attempt at getting Gradle to build Jar files, basically the same as #61, while (hopefully) addressing your issues with that PR.

Compiled classes are still kept in `/bin`. All other files Gradle creates (Manifest, Jar File, ...) end up in `/build`.