### PR TITLE
interchange: Use fixed names for macro and primitive libraries

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -69,6 +69,7 @@ import com.xilinx.rapidwright.interchange.DeviceResources.Device.ParameterFormat
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist;
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist.Direction;
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist.PropertyMap;
+import com.xilinx.rapidwright.interchange.LogNetlistWriter;
 
 public class DeviceResourcesVerifier {
     private static Enumerator<String> allStrings;
@@ -450,14 +451,17 @@ public class DeviceResourcesVerifier {
         }
 
         Netlist.Reader primLibs = dReader.getPrimLibs();
-        LogNetlistReader netlistReader = new LogNetlistReader(allStrings);
+        LogNetlistReader netlistReader = new LogNetlistReader(allStrings, new HashMap<String, String>() {{
+                    put(LogNetlistWriter.DEVICE_PRIMITIVES_LIB, EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME);
+                }}
+            );
         EDIFNetlist primsAndMacros = netlistReader.readLogNetlist(primLibs,
                 /*skipTopStuff=*/true);
 
         Set<String> libsFound = new HashSet<String>();
         libsFound.addAll(primsAndMacros.getLibrariesMap().keySet());
         for(String libExpected : new String[] {EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME,
-            device.getSeries()+"_"+EDIFTools.MACRO_PRIMITIVES_LIB}) {
+            LogNetlistWriter.DEVICE_MACROS_LIB}) {
             if(!libsFound.remove(libExpected)) {
                 throw new RuntimeException("Missing expected library: " + libExpected);
             }

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -56,6 +56,7 @@ import com.xilinx.rapidwright.edif.EDIFLibrary;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFPort;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
+import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.interchange.EnumerateCellBelMapping;
 import com.xilinx.rapidwright.interchange.DeviceResources.Device.BELCategory;
 import com.xilinx.rapidwright.interchange.DeviceResources.Device.BELInverter;
@@ -348,7 +349,11 @@ public class DeviceResourcesWriter {
 
         Netlist.Builder netlistBuilder = devBuilder.getPrimLibs();
         netlistBuilder.setName(netlist.getName());
-        LogNetlistWriter writer = new LogNetlistWriter(allStrings);
+        LogNetlistWriter writer = new LogNetlistWriter(allStrings, new HashMap<String, String>() {{
+                    put(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME, LogNetlistWriter.DEVICE_PRIMITIVES_LIB);
+                    put(device.getSeries()+"_"+EDIFTools.MACRO_PRIMITIVES_LIB, LogNetlistWriter.DEVICE_MACROS_LIB);
+                }}
+            );
         writer.populateNetlistBuilder(netlist, netlistBuilder);
 
         writeCellParameterDefinitions(device.getSeries(), netlist, devBuilder.getParameterDefs());

--- a/src/com/xilinx/rapidwright/interchange/LogNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/LogNetlistReader.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.capnproto.MessageReader;
 import org.capnproto.PrimitiveList;
@@ -40,13 +41,21 @@ public class LogNetlistReader {
     private List<EDIFPort> allPorts;
     private List<EDIFCell> allCells;
     private List<EDIFCellInst> allInsts;
+    private Map<String, String> libraryRename;
 
     public LogNetlistReader() {
         allStrings = new Enumerator<String>();
+        libraryRename = Collections.emptyMap();
     }
 
     public LogNetlistReader(Enumerator<String> otherAllStrings) {
         allStrings = otherAllStrings;
+        libraryRename = Collections.emptyMap();
+    }
+
+    public LogNetlistReader(Enumerator<String> otherAllStrings, Map<String, String> libraryRename) {
+        allStrings = otherAllStrings;
+        this.libraryRename = libraryRename;
     }
 
     /**
@@ -267,6 +276,8 @@ public class LogNetlistReader {
         for(int i = 0; i < cellDeclsReader.size(); ++i) {
             Netlist.CellDeclaration.Reader cellReader = cellDeclsReader.get(i);
             String libraryName = allStrings.get(cellReader.getLib());
+            libraryName = libraryRename.getOrDefault(libraryName, libraryName);
+
             EDIFLibrary library = n.getLibrary(libraryName);
             if(library == null) {
                 library = new EDIFLibrary(libraryName);


### PR DESCRIPTION
This is the complement to SymbiFlow/fpga-interchange-schema#43.

The renaming is done while reading/writing the logical netlist structure itself, as the `hdi_primitives` name is expected to be used for the primitives library in a lot of the EDIF related code. Hopefully this is reasonable.