### PR TITLE
Gradle: Allow Building as Application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
-apply plugin: 'java'
+apply plugin: 'application'
+mainClassName = "com.xilinx.rapidwright.MainEntrypoint"
 
 sourceSets {
   main {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,9 @@ sourceSets {
   }
 }
 
+sourceCompatibility = 8
+targetCompatibility = 8
+
 dependencies {
   compile fileTree(dir: 'jars', include: ['*.jar'])
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'rapidwright'


### PR DESCRIPTION
This PR allows building RapidWright as a Gradle Application. These new tasks are available:

* `run`: Directly run RapidWright
* `installDist`: Create a Distribution containing all Java Code as well as Start Scripts. This task is confusingly named for people coming from make. It does not install anything. It only creates a distribution inside the build directory.
* `distZip`/`distTar`: Create a Zip/Tar from the Distribution.

Since we have many Main-Files in RapidWright, this PR also creates a new Single Entrypoint that delegates to the other main classes by looking at the first argument.

I just set the arguments to be the same as the class names. This is good for most classes, but may require some more thought for some classes like [RapidWright](https://github.com/Xilinx/RapidWright/blob/b6ba4cf6d702ae6e826bea73723c4d0abcc25126/src/com/xilinx/rapidwright/util/RapidWright.java).