### PR TITLE
interchange: Mark GENERIC intent as special wire type

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/WireType.java
+++ b/src/com/xilinx/rapidwright/interchange/WireType.java
@@ -30,6 +30,7 @@ public class WireType {
             case PADINPUT:
             case PADOUTPUT:
             case BUFINP2OUT:
+            case GENERIC:
             case NODE_CLE_CTRL:
             case NODE_IRI:
             case NODE_INTF_CTRL:


### PR DESCRIPTION
These aren't really part of the general, inter-tile routing graph, and are specifically used in the IOB->BUFG routing path so 'special' is more appropriate for these than 'general'.

