### PR TITLE
interchange: Faster node discovery

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/ConstantDefinitions.java
+++ b/src/com/xilinx/rapidwright/interchange/ConstantDefinitions.java
@@ -174,29 +174,18 @@ public class ConstantDefinitions {
         return false;
     }
 
-    private static LongEnumerator getAllNodes(Device device) {
-        LongEnumerator allNodes = new LongEnumerator();
+    private static ArrayList<Long> getAllNodes(Device device) {
+        ArrayList<Long> allNodes = new ArrayList();
         for(Tile tile : device.getAllTiles()) {
             for(int i=0; i < tile.getWireCount(); i++) {
-                Wire wire = new Wire(tile, i);
+                Wire wire = new Wire(tile,i);
                 Node node = wire.getNode();
-                if(node != null) {
-                    allNodes.addObject(makeKey(node.getTile(), node.getWire()));
-                }
-            }
-            for(PIP p : tile.getPIPs()) {
-                Node start = p.getStartNode();
-                if(start != null) {
-                    allNodes.addObject(makeKey(start.getTile(), start.getWire()));
-                }
-
-                Node end = p.getEndNode();
-                if(end != null) {
-                    allNodes.addObject(makeKey(end.getTile(), end.getWire()));
-                }
+                if(node == null)
+                    continue;
+                if (node.getTile() == tile && node.getWire() == i)
+                    allNodes.add(makeKey(node.getTile(), node.getWire()));
             }
         }
-
         return allNodes;
     }
 
@@ -223,7 +212,7 @@ public class ConstantDefinitions {
 
         ConstantDefinitions constants = new ConstantDefinitions(allStrings, reader, tileTypes);
 
-        LongEnumerator allNodes = getAllNodes(device);
+        ArrayList<Long> allNodes = getAllNodes(device);
         for(int i=0; i < allNodes.size(); i++) {
             long nodeKey = allNodes.get(i);
             Tile tile = device.getTile((int)(nodeKey >>> 32));
@@ -286,7 +275,7 @@ public class ConstantDefinitions {
     }
 
     private static Map<TileTypeEnum, Set<Integer>> getTiedWires(Device device) {
-        LongEnumerator allNodes = getAllNodes(device);
+        ArrayList<Long> allNodes = getAllNodes(device);
 
         Map<TileTypeEnum, Set<Integer>> tileUntiedWires = new HashMap<TileTypeEnum, Set<Integer>>();
         Map<TileTypeEnum, Set<Integer>> tileTiedWires = new HashMap<TileTypeEnum, Set<Integer>>();

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -730,20 +730,10 @@ public class DeviceResourcesWriter {
                 allWires.addObject(makeKey(wire.getTile(), wire.getWireIndex()));
 
                 Node node = wire.getNode();
-                if(node != null) {
+                if(node == null)
+                    continue;
+                if (node.getTile() == tile)
                     allNodes.addObject(makeKey(node.getTile(), node.getWire()));
-                }
-            }
-
-            for(PIP p : tile.getPIPs()) {
-                Node start = p.getStartNode();
-                if(start != null) {
-                    allNodes.addObject(makeKey(start.getTile(), start.getWire()));
-                }
-                Node end = p.getEndNode();
-                if(end != null) {
-                    allNodes.addObject(makeKey(end.getTile(), end.getWire()));
-                }
             }
         }
 

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -721,8 +721,7 @@ public class DeviceResourcesWriter {
 
     public static void writeAllWiresAndNodesToBuilder(Device device, DeviceResources.Device.Builder devBuilder) {
         LongEnumerator allWires = new LongEnumerator();
-        LongEnumerator allNodes = new LongEnumerator();
-
+        ArrayList<Long> allNodes = new ArrayList();
 
         for(Tile tile : device.getAllTiles()) {
             for(int i=0; i < tile.getWireCount(); i++) {
@@ -732,8 +731,8 @@ public class DeviceResourcesWriter {
                 Node node = wire.getNode();
                 if(node == null)
                     continue;
-                if (node.getTile() == tile)
-                    allNodes.addObject(makeKey(node.getTile(), node.getWire()));
+                if (node.getTile() == tile && node.getWire() == i)
+                    allNodes.add(makeKey(node.getTile(), node.getWire()));
             }
         }
 


### PR DESCRIPTION
Most of the work to find nodes that the interchange export was doing seems unnecessary, based on previous code I used for nextpnr-xilinx that seemed to find everything fine.

Performance for xc7a35t without:

```
==============================================================================
==                  Device Resources Dump: xc7a35tcpg236-1                  ==
==============================================================================
             Load Device:     0.412s     64.791MBs
           populateEnums:     0.097s      4.725MBs
               SiteTypes:     0.063s      0.976MBs
               TileTypes:     0.088s      2.053MBs
                   Tiles:     0.023s      0.004MBs
INFO: Building uncommon Wire->Node cache...
      This might take a few seconds for large devices on the first call.  
      It is generally triggered when getting the Node from an uncommon Wire object.  
      To avoid printing this message, set Device.QUIET_MESSAGE=true or set the ENVIRONMENT variable RW_QUIET_MESSAGE=1.
INFO: Finished building uncommon Wire->Node cache
             Wires&Nodes:    28.003s   1165.958MBs
            Prims&Macros:     0.283s     76.566MBs
    Cell <-> BEL pin map:     6.342s      0.969MBs
                Packages:     0.009s      0.027MBs
               Constants:    10.514s      0.012MBs
              Wire Types:     0.002s      0.009MBs
                 Strings:     0.022s      0.001MBs
              Write File:     4.474s      0.003MBs
INFO: Building uncommon Wire->Node cache...
      This might take a few seconds for large devices on the first call.  
      It is generally triggered when getting the Node from an uncommon Wire object.  
      To avoid printing this message, set Device.QUIET_MESSAGE=true or set the ENVIRONMENT variable RW_QUIET_MESSAGE=1.
INFO: Finished building uncommon Wire->Node cache
             Verify file:    18.093s     91.672MBs
------------------------------------------------------------------------------
                 *Total*:    68.424s   1407.767MBs
./scripts/invoke_rapidwright.sh  xc7a35tcpg236-1  288.74s user 5.98s system 413% cpu 1:11.27 total
```

With this patch:
```
==============================================================================
==                  Device Resources Dump: xc7a35tcpg236-1                  ==
==============================================================================
             Load Device:     0.427s     64.791MBs
           populateEnums:     0.091s      4.725MBs
               SiteTypes:     0.060s      0.976MBs
               TileTypes:     0.110s      2.052MBs
                   Tiles:     0.029s      0.004MBs
INFO: Building uncommon Wire->Node cache...
      This might take a few seconds for large devices on the first call.  
      It is generally triggered when getting the Node from an uncommon Wire object.  
      To avoid printing this message, set Device.QUIET_MESSAGE=true or set the ENVIRONMENT variable RW_QUIET_MESSAGE=1.
INFO: Finished building uncommon Wire->Node cache
             Wires&Nodes:    15.619s   1011.871MBs
            Prims&Macros:     0.328s     76.566MBs
    Cell <-> BEL pin map:     5.553s      0.969MBs
                Packages:     0.008s      0.027MBs
               Constants:     1.019s      0.012MBs
              Wire Types:     0.002s      0.009MBs
                 Strings:     0.031s      0.002MBs
              Write File:     4.428s      0.003MBs
INFO: Building uncommon Wire->Node cache...
      This might take a few seconds for large devices on the first call.  
      It is generally triggered when getting the Node from an uncommon Wire object.  
      To avoid printing this message, set Device.QUIET_MESSAGE=true or set the ENVIRONMENT variable RW_QUIET_MESSAGE=1.
INFO: Finished building uncommon Wire->Node cache
             Verify file:     8.281s     91.672MBs
------------------------------------------------------------------------------
                 *Total*:    35.984s   1253.680MBs
./scripts/invoke_rapidwright.sh  xc7a35tcpg236-1  165.38s user 3.79s system 441% cpu 38.340 total
```
