### PR TITLE
Clear Cached Image in TileScene

### DIFF
--- a/src/com/xilinx/rapidwright/gui/TileScene.java
+++ b/src/com/xilinx/rapidwright/gui/TileScene.java
@@ -186,6 +186,9 @@ public class TileScene extends QGraphicsScene{
 				tileOccupantCount[y][x] = new HashSet<GUIModuleInst>();
 			}
 		}
+
+		//Clear cached image in case of reinitialization
+		qImage = null;
 	}
 
 	private QPainter createImage() {

--- a/src/com/xilinx/rapidwright/gui/TileScene.java
+++ b/src/com/xilinx/rapidwright/gui/TileScene.java
@@ -202,6 +202,7 @@ public class TileScene extends QGraphicsScene{
 
 		// Draw colored tiles onto QPixMap
 		qImage = new QImage(sceneSize, Format.Format_RGB16);
+		qImage.fill(0);
 		QPainter painter = new QPainter(qImage);
 		return painter;
 	}


### PR DESCRIPTION
This fixes the issue raised at https://groups.google.com/g/rapidwright/c/YyEYI0Mebu8

Also initialize the image to black before drawing on it. For me, there were some artifacts in the image otherwise.