### PR TITLE
correctly close leaked file descriptors

### DIFF
--- a/src/com/xilinx/rapidwright/device/PartNameTools.java
+++ b/src/com/xilinx/rapidwright/device/PartNameTools.java
@@ -35,7 +35,7 @@ import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.util.FileTools;
 
 /**
- * Generated on: Wed Jun 02 21:00:46 2021
+ * Generated on: Fri Jul 02 17:02:23 2021
  * by: com.xilinx.rapidwright.release.PartNamePopulator
  * 
  * Class to hold utility APIs dealing with Parts and device names.
@@ -47,55 +47,56 @@ public class PartNameTools {
 	}
 	static {
 		partMap = new HashMap<String,Part>();
-		UnsafeInput his = FileTools.getUnsafeInputStream(FileTools.getRapidWrightResourceInputStream(FileTools.PART_DB_PATH));
+		try (UnsafeInput his = FileTools.getUnsafeInputStream(FileTools.getRapidWrightResourceInputStream(FileTools.PART_DB_PATH))) {
 		
-		int version = his.readInt();
-		if(version != FileTools.PART_DB_FILE_VERSION) {
-			throw new RuntimeException("ERROR: " + FileTools.PART_DB_PATH
-				+ " file version is incorrect.  Expecting version "
-				+ FileTools.PART_DB_FILE_VERSION + ", found " + version + ".");
-		}
-		String[] strings = FileTools.readStringArray(his);
-		int partCount = 0;
-		partCount = his.readInt();
-		for(int i=0; i < partCount; i++){
-			int[] part = FileTools.readIntArray(his);
-			Part tmpPart = new Part(
-				strings[part[0]],
-				FamilyType.valueOf(strings[part[1]].toUpperCase()),
-				strings[part[2]],
-				FamilyType.valueOf(strings[part[3]].toUpperCase()),
-				strings[part[4]],
-				strings[part[5]],
-				strings[part[6]],
-				strings[part[7]],
-				strings[part[8]],
-				strings[part[9]],
-				strings[part[10]],
-				strings[part[11]],
-				strings[part[12]],
-				strings[part[13]],
-				strings[part[14]],
-				strings[part[15]],
-				strings[part[16]],
-				Series.valueOf(strings[part[17]])
-				);
-			addToPartMap(strings[part[0]], tmpPart);
-			if(!(strings[part[8]].isEmpty())) {
-				addToPartMap(strings[part[4]]+"-"+strings[part[8]], tmpPart);
-				if(!partMap.containsKey(strings[part[4]])) {
+			int version = his.readInt();
+			if(version != FileTools.PART_DB_FILE_VERSION) {
+				throw new RuntimeException("ERROR: " + FileTools.PART_DB_PATH
+					+ " file version is incorrect.  Expecting version "
+					+ FileTools.PART_DB_FILE_VERSION + ", found " + version + ".");
+			}
+			String[] strings = FileTools.readStringArray(his);
+			int partCount = 0;
+			partCount = his.readInt();
+			for(int i=0; i < partCount; i++){
+				int[] part = FileTools.readIntArray(his);
+				Part tmpPart = new Part(
+					strings[part[0]],
+					FamilyType.valueOf(strings[part[1]].toUpperCase()),
+					strings[part[2]],
+					FamilyType.valueOf(strings[part[3]].toUpperCase()),
+					strings[part[4]],
+					strings[part[5]],
+					strings[part[6]],
+					strings[part[7]],
+					strings[part[8]],
+					strings[part[9]],
+					strings[part[10]],
+					strings[part[11]],
+					strings[part[12]],
+					strings[part[13]],
+					strings[part[14]],
+					strings[part[15]],
+					strings[part[16]],
+					Series.valueOf(strings[part[17]])
+					);
+				addToPartMap(strings[part[0]], tmpPart);
+				if(!(strings[part[8]].isEmpty())) {
+					addToPartMap(strings[part[4]]+"-"+strings[part[8]], tmpPart);
+					if(!partMap.containsKey(strings[part[4]])) {
+						addToPartMap(strings[part[4]], tmpPart);
+						addToPartMap(strings[part[4]]+strings[part[5]], tmpPart);
+						addToPartMap(strings[part[4]]+strings[part[5]]+strings[part[6]], tmpPart);
+						addToPartMap(strings[part[4]]+"-"+strings[part[5]], tmpPart);
+						addToPartMap(strings[part[4]]+"-"+strings[part[5]]+strings[part[6]], tmpPart);
+					}
+				} else {
 					addToPartMap(strings[part[4]], tmpPart);
 					addToPartMap(strings[part[4]]+strings[part[5]], tmpPart);
 					addToPartMap(strings[part[4]]+strings[part[5]]+strings[part[6]], tmpPart);
 					addToPartMap(strings[part[4]]+"-"+strings[part[5]], tmpPart);
 					addToPartMap(strings[part[4]]+"-"+strings[part[5]]+strings[part[6]], tmpPart);
 				}
-			} else {
-				addToPartMap(strings[part[4]], tmpPart);
-				addToPartMap(strings[part[4]]+strings[part[5]], tmpPart);
-				addToPartMap(strings[part[4]]+strings[part[5]]+strings[part[6]], tmpPart);
-				addToPartMap(strings[part[4]]+"-"+strings[part[5]], tmpPart);
-				addToPartMap(strings[part[4]]+"-"+strings[part[5]]+strings[part[6]], tmpPart);
 			}
 		}
 	}

--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -51,7 +51,7 @@ import com.xilinx.rapidwright.util.MessageGenerator;
  * RapidWright, load it into Vivado first and then write it out from Vivado.
  * Created on: May 10, 2017
  */
-public class EDIFParser {
+public class EDIFParser implements AutoCloseable{
 
 	private Path fileName;
 	
@@ -785,5 +785,12 @@ public class EDIFParser {
 		p.stop().start("Write EDIF");
 		if(args.length > 1) n.exportEDIF(args[1]);
 		p.stop().printSummary();
+	}
+
+	@Override
+	public void close() throws IOException {
+		if(in!=null) {
+			in.close();
+		}
 	}
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -697,13 +697,11 @@ public class EDIFTools {
 	}
 
 	public static EDIFNetlist loadEDIFFile(Path fileName) {
-		EDIFParser p = null;
-		try {
-			p = new EDIFParser(fileName);
+		try (EDIFParser p = new EDIFParser(fileName)) {
+			return p.parseEDIFNetlist();
 		} catch (IOException e) {
 			throw new UncheckedIOException("ERROR: Couldn't read file : " + fileName, e);
 		}
-		return p.parseEDIFNetlist();
 	}
 
 	public static EDIFNetlist loadEDIFFile(String fileName){
@@ -755,12 +753,13 @@ public class EDIFTools {
 					+ "be passed to resulting DCP load script.");
 			}
 		}
-		if(EDIFTools.EDIF_DEBUG && FileTools.isFileNewer(FileTools.appendExtension(edifFileName , ".dat"), edifFileName)){
-			edif = FileTools.readObjectFromKryoFile(edifFileName + ".dat", EDIFNetlist.class);
+		Path kryoFile = FileTools.appendExtension(edifFileName , ".dat");
+		if(EDIFTools.EDIF_DEBUG && FileTools.isFileNewer(kryoFile, edifFileName)){
+			edif = FileTools.readObjectFromKryoFile(kryoFile, EDIFNetlist.class);
 		}else{
 			edif = loadEDIFFile(edifFileName);
-			if(!(new File(edifFileName + ".dat").exists()) || FileTools.isFileNewer(edifFileName, FileTools.appendExtension(edifFileName , ".dat")) ){
-				if(EDIFTools.EDIF_DEBUG) FileTools.writeObjectToKryoFile(edifFileName + ".dat", edif);			
+			if(!Files.exists(kryoFile) || FileTools.isFileNewer(edifFileName, kryoFile)){
+				if(EDIFTools.EDIF_DEBUG) FileTools.writeObjectToKryoFile(kryoFile, edif);
 			}
 		}
 		if(edifDirectoryName != null) {

--- a/src/com/xilinx/rapidwright/util/Installer.java
+++ b/src/com/xilinx/rapidwright/util/Installer.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -229,8 +230,8 @@ public class Installer {
 		Path root = FileSystems.getDefault().getPath(dir);
 		List<String> javaSrcs = null;
 		
-		try{
-			javaSrcs = Files.walk(root)
+		try (final Stream<Path> walk = Files.walk(root)){
+			javaSrcs = walk
 			        .filter(foundPath -> foundPath.toString().endsWith(".java"))
 			        .map(javaPath -> javaPath.toAbsolutePath().toString())
 			        .collect(Collectors.toList());			

--- a/test/com/xilinx/rapidwright/checker/CheckOpenFiles.java
+++ b/test/com/xilinx/rapidwright/checker/CheckOpenFiles.java
@@ -1,0 +1,14 @@
+package com.xilinx.rapidwright.checker;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(CheckOpenFilesExtension.class)
+public @interface CheckOpenFiles {
+}

--- a/test/com/xilinx/rapidwright/checker/CheckOpenFilesExtension.java
+++ b/test/com/xilinx/rapidwright/checker/CheckOpenFilesExtension.java
@@ -1,0 +1,93 @@
+package com.xilinx.rapidwright.checker;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Check that a testcase does leak open files
+ *
+ * Only works on Linux. On other OSes it cannot detect errors and will fail silently.
+ */
+public class CheckOpenFilesExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+    private String getOwnPid() {
+        final RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
+        String name = runtimeBean.getName();
+        int atPosition = name.indexOf("@");
+        if (atPosition<=1) {
+            return name;
+        }
+        return name.substring(0,atPosition);
+    }
+    private List<String> getOpenFiles() {
+        final Path fdList = Paths.get("/proc/" + getOwnPid() + "/fd");
+        if (!Files.exists(fdList)) {
+            //We are probably not on Linux, fail silently
+            return Collections.emptyList();
+        }
+        try (final Stream<Path> list = Files.list(fdList)) {
+            return list.map(p -> {
+                try {
+                    final Path linkTarget = Files.readSymbolicLink(p);
+                    return linkTarget.toString();
+                } catch (IOException e) {
+                    return p.toString();
+                }
+            })
+                    .filter(this::checkIgnore)
+                    .sorted()
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean checkIgnore(String path) {
+        //Ignore Random Device
+        if (path.equals("/dev/random") || path.equals("/dev/urandom")) {
+            return false;
+        }
+        //Socket for debugging should be ignored
+        if (path.startsWith("socket:")) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create("com", "xilinx", "rapidwright", "checker");
+    private static final String OPEN_FILES = "openFiles";
+
+    @Override
+    public void afterTestExecution(ExtensionContext extensionContext) {
+        final List<String> afterList = getOpenFiles();
+        List<String> beforeList = extensionContext.getStore(NAMESPACE).get(OPEN_FILES, List.class);
+
+
+        if (!beforeList.equals(afterList)) {
+            final Stream<String> newlyOpened = afterList.stream().filter(s -> !beforeList.contains(s)).map(s -> "Newly opened: " + s);
+            final Stream<String> closed = beforeList.stream().filter(s -> !afterList.contains(s)).map(s -> "Closed: " + s);
+
+            final String res = Stream.concat(newlyOpened, closed)
+                    .collect(Collectors.joining("\n","List of open Files changed: \n", ""));
+            Assertions.fail(res);
+        }
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext extensionContext) {
+        extensionContext.getStore(NAMESPACE).put(OPEN_FILES, getOpenFiles());
+    }
+}

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -18,17 +18,18 @@ import org.junit.jupiter.api.io.TempDir;
  * so we just try to catch obvious issues.
  */
 public class TestDesign {
+    public static final String DEVICE = "xc7a12t";
 
-    private static final String SITE = "SLICE_X42Y42";
+    private static final String SITE = "SLICE_X20Y42";
 
     private Design createSampleDesign() {
         final EDIFNetlist netlist = TestEDIF.createEmptyNetlist();
         final Design design = new Design(netlist);
 
         final Cell myCell = design.createCell("myCell", Unisim.FDRE);
-        System.out.println("myCell.getBEL() = " + myCell.getBEL());
+
         final Site site = design.getDevice().getSite(SITE);
-        final SiteInst siteInst = design.createSiteInst(site);
+        design.createSiteInst(site);
         final BEL bel = site.getBEL("AFF");
         Assertions.assertNotNull(bel);
         design.placeCell(myCell, site, bel);
@@ -40,7 +41,7 @@ public class TestDesign {
     @CheckOpenFiles
     public void checkDcpRoundtrip(@TempDir Path tempDir) throws IOException {
         //Keep a reference to the device to avoid it being garbage collected during testcase execution
-        Device device = Device.getDevice(TestRelocation.DEVICE_ULTRASCALE);
+        Device device = Device.getDevice(DEVICE);
 
         //Use separate files for writing/reading so we can identify identify leaking file handles by filename
         final Path filenameWrite = tempDir.resolve("testWrite.dcp");
@@ -50,7 +51,7 @@ public class TestDesign {
         Files.copy(filenameWrite, filenameRead);
 
         Design design = Design.readCheckpoint(filenameRead);
-        TestEDIF.verifyNetlist(design.getNetlist());
+        TestEDIF.verifyNetlist(design.getNetlist(), "myCell");
 
         final Cell cell = design.getCell("myCell");
         Assertions.assertNotNull(cell);

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -1,0 +1,56 @@
+package com.xilinx.rapidwright.design;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.xilinx.rapidwright.checker.CheckOpenFiles;
+import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test that we can write a DCP file and read it back in. We currently don't have a way to check designs for equality,
+ * so we just try to catch obvious issues.
+ */
+public class TestDesign {
+
+    private static final String SITE = "SLICE_X42Y42";
+
+    private Design createSampleDesign() {
+        final EDIFNetlist netlist = TestEDIF.createEmptyNetlist();
+        final Design design = new Design(netlist);
+
+        final Cell myCell = design.createCell("myCell", Unisim.FDRE);
+        System.out.println("myCell.getBEL() = " + myCell.getBEL());
+        final Site site = design.getDevice().getSite(SITE);
+        final SiteInst siteInst = design.createSiteInst(site);
+        final BEL bel = site.getBEL("AFF");
+        Assertions.assertNotNull(bel);
+        design.placeCell(myCell, site, bel);
+
+        return design;
+    }
+
+    @Test
+    @CheckOpenFiles
+    public void checkDcpRoundtrip(@TempDir Path tempDir) throws IOException {
+        //Use separate files for writing/reading so we can identify identify leaking file handles by filename
+        final Path filenameWrite = tempDir.resolve("testWrite.dcp");
+        final Path filenameRead = tempDir.resolve("testRead.dcp");
+
+        createSampleDesign().writeCheckpoint(filenameWrite);
+        Files.copy(filenameWrite, filenameRead);
+
+        Design design = Design.readCheckpoint(filenameRead);
+        TestEDIF.verifyNetlist(design.getNetlist());
+
+        final Cell cell = design.getCell("myCell");
+        Assertions.assertNotNull(cell);
+        Assertions.assertEquals(SITE, cell.getSiteInst().getSite().getName());
+
+    }
+}

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 
 import com.xilinx.rapidwright.checker.CheckOpenFiles;
 import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import org.junit.jupiter.api.Assertions;
@@ -38,6 +39,9 @@ public class TestDesign {
     @Test
     @CheckOpenFiles
     public void checkDcpRoundtrip(@TempDir Path tempDir) throws IOException {
+        //Keep a reference to the device to avoid it being garbage collected during testcase execution
+        Device device = Device.getDevice(TestRelocation.DEVICE_ULTRASCALE);
+
         //Use separate files for writing/reading so we can identify identify leaking file handles by filename
         final Path filenameWrite = tempDir.resolve("testWrite.dcp");
         final Path filenameRead = tempDir.resolve("testRead.dcp");

--- a/test/com/xilinx/rapidwright/design/TestEDIF.java
+++ b/test/com/xilinx/rapidwright/design/TestEDIF.java
@@ -9,10 +9,7 @@ import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFDesign;
 import com.xilinx.rapidwright.edif.EDIFLibrary;
-import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
-import com.xilinx.rapidwright.edif.EDIFPort;
-import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,7 +28,7 @@ public class TestEDIF {
         final EDIFCell topCell = new EDIFCell(workLibrary, "myTestCell");
         netlist.getDesign().setTopCell(topCell);
 
-        EDIFTools.ensureCorrectPartInEDIF(netlist, TestRelocation.DEVICE_ULTRASCALE);
+        EDIFTools.ensureCorrectPartInEDIF(netlist, TestDesign.DEVICE);
 
         return netlist;
     }
@@ -51,11 +48,11 @@ public class TestEDIF {
 
         final EDIFNetlist netlist = EDIFTools.readEdifFile(filenameRead);
 
-        verifyNetlist(netlist);
+        verifyNetlist(netlist, "inst");
 
     }
 
-    public static void verifyNetlist(EDIFNetlist netlist) {
+    public static void verifyNetlist(EDIFNetlist netlist, String expectedName) {
         final EDIFLibrary workLibrary = netlist.getWorkLibrary();
         Assertions.assertNotNull(workLibrary);
 
@@ -65,6 +62,6 @@ public class TestEDIF {
 
         Assertions.assertEquals(cell.getCellInsts().size(),1);
         final EDIFCellInst inst = cell.getCellInsts().iterator().next();
-        Assertions.assertEquals("inst", inst.getName());
+        Assertions.assertEquals(expectedName, inst.getName());
     }
 }

--- a/test/com/xilinx/rapidwright/design/TestEDIF.java
+++ b/test/com/xilinx/rapidwright/design/TestEDIF.java
@@ -1,0 +1,70 @@
+package com.xilinx.rapidwright.design;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.xilinx.rapidwright.checker.CheckOpenFiles;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFDesign;
+import com.xilinx.rapidwright.edif.EDIFLibrary;
+import com.xilinx.rapidwright.edif.EDIFNet;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPort;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test that we can write an EDIF file and read it back in. We currently don't have a way to check designs for equality,
+ * so we just try to catch obvious issues.
+ */
+public class TestEDIF {
+
+    public static EDIFNetlist createEmptyNetlist() {
+        EDIFNetlist netlist = new EDIFNetlist("test");
+        netlist.setDesign(new EDIFDesign("test"));
+        final EDIFLibrary workLibrary = netlist.getWorkLibrary();
+        final EDIFCell topCell = new EDIFCell(workLibrary, "myTestCell");
+        netlist.getDesign().setTopCell(topCell);
+
+        EDIFTools.ensureCorrectPartInEDIF(netlist, TestRelocation.DEVICE_ULTRASCALE);
+
+        return netlist;
+    }
+
+    @Test
+    @CheckOpenFiles
+    public void checkEdifRoundtrip(@TempDir Path tempDir) throws IOException {
+        //Use separate files for writing/reading so we can identify identify leaking file handles by filename
+        final Path filenameWrite = tempDir.resolve("testWrite.edf");
+        final Path filenameRead = tempDir.resolve("testRead.edf");
+
+        final EDIFNetlist original = createEmptyNetlist();
+
+        EDIFCellInst inst = Design.createUnisimInst(original.getTopCell(), "inst", Unisim.FDRE);
+        original.exportEDIF(filenameWrite);
+        Files.copy(filenameWrite, filenameRead);
+
+        final EDIFNetlist netlist = EDIFTools.readEdifFile(filenameRead);
+
+        verifyNetlist(netlist);
+
+    }
+
+    public static void verifyNetlist(EDIFNetlist netlist) {
+        final EDIFLibrary workLibrary = netlist.getWorkLibrary();
+        Assertions.assertNotNull(workLibrary);
+
+        final EDIFCell cell = workLibrary.getCell("myTestCell");
+        Assertions.assertNotNull(cell);
+        Assertions.assertEquals(cell, netlist.getTopCell());
+
+        Assertions.assertEquals(cell.getCellInsts().size(),1);
+        final EDIFCellInst inst = cell.getCellInsts().iterator().next();
+        Assertions.assertEquals("inst", inst.getName());
+    }
+}

--- a/test/com/xilinx/rapidwright/design/TestRelocation.java
+++ b/test/com/xilinx/rapidwright/design/TestRelocation.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class TestRelocation {
 
 
-    public static final String DEVICE_VERSAL = "xcvc1902";
-    public static final String DEVICE_ULTRASCALE = "xcvu3p";
+    private static final String DEVICE_VERSAL = "xcvc1902";
+    private static final String DEVICE_ULTRASCALE = "xcvu3p";
 
     private void testRelocateTile(Device device, String templateStr, String newAnchorStr, String oldAnchorStr, String expectedResultStr) {
         Tile template = device.getTile(templateStr);


### PR DESCRIPTION
This PR addresses multiple instances of File Descriptors not being closed. It includes simple testcases for writing out and reading back in both EDIF and DCP files without leaking file descriptors. As we don't have a way to test designs for equality, I just check for very obvious problems.

This PR is dependent on #197. Github's view for this PR will include all of #197's diff until that one is merged.