### PR TITLE
PR testing reports: Correctly specify workflow name

### DIFF
--- a/.github/workflows/upload-test-results.yml
+++ b/.github/workflows/upload-test-results.yml
@@ -2,7 +2,7 @@ name: Unit Test Results
 
 on:
   workflow_run:
-    workflows: ["Build"]
+    workflows: ["build"]
     types:
       - completed
 


### PR DESCRIPTION
Workflow name seems to be the filename, not the given name within the
file