### PR TITLE
Use EDIFCellInst instead of String hierarchy in EDIFHier classes

### DIFF
--- a/src/com/xilinx/rapidwright/debug/DesignInstrumentor.java
+++ b/src/com/xilinx/rapidwright/debug/DesignInstrumentor.java
@@ -155,7 +155,7 @@ public class DesignInstrumentor {
 				String debugNetName = portPrefix + "_debug_net_" + probeCount;
 				EDIFNet debugNet = EDIFTools.addDebugPortAndNet(debugNetName, topCell, currDebugPort, debugCore);
 				String debugPortName = portPrefix + "_debug_port_" + probeCount;
-				EDIFHierCellInst topInst = new EDIFHierCellInst("", design.getNetlist().getTopCellInst());
+				EDIFHierCellInst topInst = design.getNetlist().getTopHierCellInst();
 				EDIFTools.connectDebugProbe(debugNet, routedNetName, debugPortName, topInst, design.getNetlist(), instMap);				
 			}
 
@@ -182,7 +182,7 @@ public class DesignInstrumentor {
 			edifClockNet = EDIFTools.addDebugPortAndNet(clkDebugNet, topCell, clkPort, debugCore);
 			clockNet = clockPin.getNet();
 			String routedClkNetName = clockNet.getName();
-			EDIFHierCellInst topInst = new EDIFHierCellInst("", design.getNetlist().getTopCellInst());
+			EDIFHierCellInst topInst = design.getNetlist().getTopHierCellInst();
 			EDIFTools.connectDebugProbe(edifClockNet, routedClkNetName, clkDebugPort, topInst, design.getNetlist(), instMap);
 			
 			// Connect clock

--- a/src/com/xilinx/rapidwright/debug/ProbeRouter.java
+++ b/src/com/xilinx/rapidwright/debug/ProbeRouter.java
@@ -35,9 +35,9 @@ import com.xilinx.rapidwright.design.Net;
 import com.xilinx.rapidwright.design.SitePinInst;
 import com.xilinx.rapidwright.design.blocks.PBlock;
 import com.xilinx.rapidwright.device.BELPin;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFHierCellInst;
 import com.xilinx.rapidwright.edif.EDIFHierPortInst;
-import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFPort;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
@@ -45,7 +45,6 @@ import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.router.Router;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.FileTools;
-import com.xilinx.rapidwright.util.MessageGenerator;
 
 public class ProbeRouter {
 
@@ -64,7 +63,6 @@ public class ProbeRouter {
 	 * that already exist in a design.  
 	 * @param d The existing placed and routed design with an ILA.
 	 * @param probeToTargetNets A map from probe names to desired net names (full hierarchical names).
-	 * @param pblock An optional pblock (area constraint) to contain routing within a certain area.
 	 */	
 	public static void updateProbeConnections(Design d, Map<String,String> probeToTargetNets){
 		updateProbeConnections(d, probeToTargetNets, null);
@@ -91,7 +89,7 @@ public class ProbeRouter {
 			
 			// Find the sink flop
 			String hierInstName = cellInstName.contains(EDIFTools.EDIF_HIER_SEP) ? cellInstName.substring(0, cellInstName.lastIndexOf('/')) : ""; 
-			EDIFHierPortInst startingPoint = new EDIFHierPortInst(hierInstName, portInst);
+			EDIFHierPortInst startingPoint = new EDIFHierPortInst(d.getNetlist().getHierCellInstFromName(hierInstName), portInst);
 			ArrayList<EDIFHierPortInst> sinks = EDIFTools.findSinks(startingPoint);
 			if(sinks.size() != 1) {
 				System.err.println("ERROR: Currently we only support a single flip flop "
@@ -114,8 +112,9 @@ public class ProbeRouter {
 			EDIFNet newNet = net.getParentCell().createNet(newPortName);
 			newNet.addPortInst(portInst);
 
-			EDIFCellInst parent = d.getNetlist().getCellInstFromHierName(parentCellInstName);
-			EDIFHierCellInst parentInst = new EDIFHierCellInst(parentCellInstName, parent);
+
+
+			EDIFHierCellInst parentInst = d.getNetlist().getHierCellInstFromName(parentCellInstName);
 			EDIFTools.connectDebugProbe(newNet, e.getValue(), newPortName, parentInst, d.getNetlist(), null);
 			
 			String parentNet = d.getNetlist().getParentNetName(e.getValue());

--- a/src/com/xilinx/rapidwright/design/Unisim.java
+++ b/src/com/xilinx/rapidwright/design/Unisim.java
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2020 Xilinx, Inc. 
+ * Copyright (c) 2021 Xilinx, Inc. 
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -24,12 +24,15 @@
  */
 package com.xilinx.rapidwright.design;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collection;
+
 import com.xilinx.rapidwright.device.Series;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFLibrary;
 
 /**
- * Generated on: Wed Dec 16 10:12:41 2020
+ * Generated on: Thu Jul 15 13:18:11 2021
  * by: com.xilinx.rapidwright.release.UnisimParser
  * 
  * Enumerates supported Unisim primitives that map to Xilinx devices.
@@ -1264,116 +1267,6 @@ public enum Unisim {
 	XPLL,
 	ZHOLD_DELAY,
 ;
-
-	private static Map<Unisim,Unisim[]> series7UnisimTransforms;
-
-	private static Map<Unisim,Unisim[]> ultraScaleUnisimTransforms;
-
-	static {
-		series7UnisimTransforms = new HashMap<Unisim, Unisim[]>();
-		series7UnisimTransforms.put(Unisim.BUFGP,new Unisim[]{Unisim.BUFG,Unisim.IBUF});
-		series7UnisimTransforms.put(Unisim.CFGLUT5,new Unisim[]{Unisim.SRLC32E});
-		series7UnisimTransforms.put(Unisim.FDCP,new Unisim[]{Unisim.FDCE,Unisim.FDPE,Unisim.LDCE,Unisim.LUT3});
-		series7UnisimTransforms.put(Unisim.FDCPE,new Unisim[]{Unisim.FDCE,Unisim.FDPE,Unisim.LDCE,Unisim.LUT3});
-		series7UnisimTransforms.put(Unisim.FDRS,new Unisim[]{Unisim.FDRE,Unisim.LUT2});
-		series7UnisimTransforms.put(Unisim.FDRSE,new Unisim[]{Unisim.FDRE,Unisim.LUT4});
-		series7UnisimTransforms.put(Unisim.FDRSE_1,new Unisim[]{Unisim.FDRE,Unisim.LUT4});
-		series7UnisimTransforms.put(Unisim.FDRS_1,new Unisim[]{Unisim.FDRE,Unisim.LUT2});
-		series7UnisimTransforms.put(Unisim.IBUF,new Unisim[]{Unisim.INBUF,Unisim.IBUFCTRL});
-		series7UnisimTransforms.put(Unisim.IBUFDS,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL});
-		series7UnisimTransforms.put(Unisim.IBUFDS_DIFF_OUT,new Unisim[]{Unisim.IBUFDS,Unisim.IBUFDS});
-		series7UnisimTransforms.put(Unisim.IBUFDS_DIFF_OUT_IBUFDISABLE,new Unisim[]{Unisim.IBUFDS_IBUFDISABLE_INT,Unisim.IBUFDS_IBUFDISABLE_INT});
-		series7UnisimTransforms.put(Unisim.IBUFDS_DIFF_OUT_INTERMDISABLE,new Unisim[]{Unisim.IBUFDS_INTERMDISABLE_INT,Unisim.IBUFDS_INTERMDISABLE_INT});
-		series7UnisimTransforms.put(Unisim.IBUFDS_IBUFDISABLE,new Unisim[]{Unisim.IBUFDS_IBUFDISABLE_INT,Unisim.IBUFDS_IBUFDISABLE_INT});
-		series7UnisimTransforms.put(Unisim.IBUFDS_IBUFDISABLE_INT,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL});
-		series7UnisimTransforms.put(Unisim.IBUFDS_INTERMDISABLE,new Unisim[]{Unisim.IBUFDS_INTERMDISABLE_INT,Unisim.IBUFDS_INTERMDISABLE_INT});
-		series7UnisimTransforms.put(Unisim.IBUF_IBUFDISABLE,new Unisim[]{Unisim.INBUF,Unisim.IBUFCTRL});
-		series7UnisimTransforms.put(Unisim.IBUF_INTERMDISABLE,new Unisim[]{Unisim.INBUF,Unisim.IBUFCTRL});
-		series7UnisimTransforms.put(Unisim.IOBUF,new Unisim[]{Unisim.IBUF,Unisim.OBUFT});
-		series7UnisimTransforms.put(Unisim.IOBUFDS,new Unisim[]{Unisim.IBUFDS,Unisim.OBUFTDS});
-		series7UnisimTransforms.put(Unisim.IOBUFDS_DCIEN,new Unisim[]{Unisim.IBUFDS_IBUFDISABLE,Unisim.OBUFTDS_DCIEN});
-		series7UnisimTransforms.put(Unisim.IOBUFDS_DIFF_OUT,new Unisim[]{Unisim.IBUFDS,Unisim.IBUFDS,Unisim.OBUFTDS});
-		series7UnisimTransforms.put(Unisim.IOBUFDS_DIFF_OUT_DCIEN,new Unisim[]{Unisim.IBUFDS_IBUFDISABLE_INT,Unisim.IBUFDS_IBUFDISABLE_INT,Unisim.OBUFTDS_DCIEN});
-		series7UnisimTransforms.put(Unisim.IOBUFDS_DIFF_OUT_INTERMDISABLE,new Unisim[]{Unisim.IBUFDS_INTERMDISABLE_INT,Unisim.IBUFDS_INTERMDISABLE_INT,Unisim.OBUFTDS});
-		series7UnisimTransforms.put(Unisim.IOBUFDS_INTERMDISABLE,new Unisim[]{Unisim.IBUFDS_INTERMDISABLE,Unisim.OBUFTDS});
-		series7UnisimTransforms.put(Unisim.IOBUF_DCIEN,new Unisim[]{Unisim.IBUF_IBUFDISABLE,Unisim.OBUFT_DCIEN});
-		series7UnisimTransforms.put(Unisim.IOBUF_INTERMDISABLE,new Unisim[]{Unisim.IBUF_INTERMDISABLE,Unisim.OBUFT});
-		series7UnisimTransforms.put(Unisim.LDCP,new Unisim[]{Unisim.LDCE,Unisim.LUT3,Unisim.LUT3});
-		series7UnisimTransforms.put(Unisim.LDCPE,new Unisim[]{Unisim.LDCE,Unisim.LUT3,Unisim.LUT4});
-		series7UnisimTransforms.put(Unisim.LUT6_2,new Unisim[]{Unisim.LUT6,Unisim.LUT5});
-		series7UnisimTransforms.put(Unisim.RAM128X1D,new Unisim[]{Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.MUXF7,Unisim.MUXF7});
-		series7UnisimTransforms.put(Unisim.RAM128X1S,new Unisim[]{Unisim.RAMS64E,Unisim.RAMS64E,Unisim.MUXF7});
-		series7UnisimTransforms.put(Unisim.RAM16X2S,new Unisim[]{Unisim.RAM32X1S,Unisim.RAM32X1S});
-		series7UnisimTransforms.put(Unisim.RAM16X4S,new Unisim[]{Unisim.RAM16X2S,Unisim.RAM16X2S});
-		series7UnisimTransforms.put(Unisim.RAM16X8S,new Unisim[]{Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S});
-		series7UnisimTransforms.put(Unisim.RAM256X1S,new Unisim[]{Unisim.RAMS64E,Unisim.RAMS64E,Unisim.RAMS64E,Unisim.RAMS64E,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF8});
-		series7UnisimTransforms.put(Unisim.RAM32M,new Unisim[]{Unisim.RAMS32,Unisim.RAMS32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32});
-		series7UnisimTransforms.put(Unisim.RAM32X1D,new Unisim[]{Unisim.RAMD32,Unisim.RAMD32});
-		series7UnisimTransforms.put(Unisim.RAM32X2S,new Unisim[]{Unisim.RAM32X1S,Unisim.RAM32X1S});
-		series7UnisimTransforms.put(Unisim.RAM32X4S,new Unisim[]{Unisim.RAM32X2S,Unisim.RAM32X2S});
-		series7UnisimTransforms.put(Unisim.RAM32X8S,new Unisim[]{Unisim.RAM32X4S,Unisim.RAM32X4S});
-		series7UnisimTransforms.put(Unisim.RAM64M,new Unisim[]{Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E});
-		series7UnisimTransforms.put(Unisim.RAM64X1D,new Unisim[]{Unisim.RAMD64E,Unisim.RAMD64E});
-		series7UnisimTransforms.put(Unisim.RAM64X2S,new Unisim[]{Unisim.RAM64X1S,Unisim.RAM64X1S});
-		series7UnisimTransforms.put(Unisim.ROM128X1,new Unisim[]{Unisim.LUT6,Unisim.LUT6,Unisim.MUXF7});
-		series7UnisimTransforms.put(Unisim.ROM256X1,new Unisim[]{Unisim.LUT6,Unisim.LUT6,Unisim.LUT6,Unisim.LUT6,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF8});
-		ultraScaleUnisimTransforms = new HashMap<Unisim, Unisim[]>();
-		ultraScaleUnisimTransforms.put(Unisim.BUFGP,new Unisim[]{Unisim.BUFG,Unisim.IBUF});
-		ultraScaleUnisimTransforms.put(Unisim.CFGLUT5,new Unisim[]{Unisim.SRLC32E});
-		ultraScaleUnisimTransforms.put(Unisim.DSP48E2,new Unisim[]{Unisim.DSP_ALU,Unisim.DSP_A_B_DATA,Unisim.DSP_C_DATA,Unisim.DSP_M_DATA,Unisim.DSP_MULTIPLIER,Unisim.DSP_OUTPUT,Unisim.DSP_PREADD,Unisim.DSP_PREADD_DATA});
-		ultraScaleUnisimTransforms.put(Unisim.FDCP,new Unisim[]{Unisim.FDCE,Unisim.FDPE,Unisim.LDCE,Unisim.LUT3});
-		ultraScaleUnisimTransforms.put(Unisim.FDCPE,new Unisim[]{Unisim.FDCE,Unisim.FDPE,Unisim.LDCE,Unisim.LUT3});
-		ultraScaleUnisimTransforms.put(Unisim.FDRS,new Unisim[]{Unisim.FDRE,Unisim.LUT2});
-		ultraScaleUnisimTransforms.put(Unisim.FDRSE,new Unisim[]{Unisim.FDRE,Unisim.LUT4});
-		ultraScaleUnisimTransforms.put(Unisim.FDRSE_1,new Unisim[]{Unisim.FDRE,Unisim.LUT4});
-		ultraScaleUnisimTransforms.put(Unisim.FDRS_1,new Unisim[]{Unisim.FDRE,Unisim.LUT2});
-		ultraScaleUnisimTransforms.put(Unisim.IBUF,new Unisim[]{Unisim.INBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFDS,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFDSE3,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFDS_DIFF_OUT,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFDS_DIFF_OUT_IBUFDISABLE,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFDS_DIFF_OUT_INTERMDISABLE,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFDS_IBUFDISABLE,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFDS_IBUFDISABLE_INT,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFDS_INTERMDISABLE,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUFE3,new Unisim[]{Unisim.INBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUF_IBUFDISABLE,new Unisim[]{Unisim.INBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IBUF_INTERMDISABLE,new Unisim[]{Unisim.INBUF,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUF,new Unisim[]{Unisim.INBUF,Unisim.OBUFT,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUFDS,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.OBUFTDS});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUFDSE3,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.OBUFTDS_DCIEN});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUFDS_DCIEN,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.OBUFTDS_DCIEN});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUFDS_DIFF_OUT,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.IBUFCTRL,Unisim.OBUFTDS});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUFDS_DIFF_OUT_DCIEN,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.IBUFCTRL,Unisim.OBUFTDS_DCIEN});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUFDS_DIFF_OUT_INTERMDISABLE,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.IBUFCTRL,Unisim.OBUFTDS});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUFDS_INTERMDISABLE,new Unisim[]{Unisim.DIFFINBUF,Unisim.IBUFCTRL,Unisim.OBUFTDS});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUFE3,new Unisim[]{Unisim.INBUF,Unisim.OBUFT_DCIEN,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUF_DCIEN,new Unisim[]{Unisim.INBUF,Unisim.OBUFT_DCIEN,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.IOBUF_INTERMDISABLE,new Unisim[]{Unisim.INBUF,Unisim.OBUFT,Unisim.IBUFCTRL});
-		ultraScaleUnisimTransforms.put(Unisim.LDCP,new Unisim[]{Unisim.LDCE,Unisim.LUT3,Unisim.LUT3});
-		ultraScaleUnisimTransforms.put(Unisim.LDCPE,new Unisim[]{Unisim.LDCE,Unisim.LUT3,Unisim.LUT4});
-		ultraScaleUnisimTransforms.put(Unisim.LUT6_2,new Unisim[]{Unisim.LUT6,Unisim.LUT5});
-		ultraScaleUnisimTransforms.put(Unisim.RAM128X1D,new Unisim[]{Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.MUXF7,Unisim.MUXF7});
-		ultraScaleUnisimTransforms.put(Unisim.RAM128X1S,new Unisim[]{Unisim.RAMS64E,Unisim.RAMS64E,Unisim.MUXF7});
-		ultraScaleUnisimTransforms.put(Unisim.RAM16X2S,new Unisim[]{Unisim.RAM32X1S,Unisim.RAM32X1S});
-		ultraScaleUnisimTransforms.put(Unisim.RAM16X4S,new Unisim[]{Unisim.RAM16X2S,Unisim.RAM16X2S});
-		ultraScaleUnisimTransforms.put(Unisim.RAM16X8S,new Unisim[]{Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S,Unisim.RAM32X1S});
-		ultraScaleUnisimTransforms.put(Unisim.RAM256X1D,new Unisim[]{Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF8,Unisim.MUXF8});
-		ultraScaleUnisimTransforms.put(Unisim.RAM256X1S,new Unisim[]{Unisim.RAMS64E,Unisim.RAMS64E,Unisim.RAMS64E,Unisim.RAMS64E,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF8});
-		ultraScaleUnisimTransforms.put(Unisim.RAM32M,new Unisim[]{Unisim.RAMS32,Unisim.RAMS32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32});
-		ultraScaleUnisimTransforms.put(Unisim.RAM32M16,new Unisim[]{Unisim.RAMS32,Unisim.RAMS32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32,Unisim.RAMD32});
-		ultraScaleUnisimTransforms.put(Unisim.RAM32X1D,new Unisim[]{Unisim.RAMD32,Unisim.RAMD32});
-		ultraScaleUnisimTransforms.put(Unisim.RAM32X2S,new Unisim[]{Unisim.RAM32X1S,Unisim.RAM32X1S});
-		ultraScaleUnisimTransforms.put(Unisim.RAM32X4S,new Unisim[]{Unisim.RAM32X2S,Unisim.RAM32X2S});
-		ultraScaleUnisimTransforms.put(Unisim.RAM32X8S,new Unisim[]{Unisim.RAM32X4S,Unisim.RAM32X4S});
-		ultraScaleUnisimTransforms.put(Unisim.RAM512X1S,new Unisim[]{Unisim.RAMS64E1,Unisim.RAMS64E1,Unisim.RAMS64E1,Unisim.RAMS64E1,Unisim.RAMS64E1,Unisim.RAMS64E1,Unisim.RAMS64E1,Unisim.RAMS64E1,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF8,Unisim.MUXF8,Unisim.MUXF9});
-		ultraScaleUnisimTransforms.put(Unisim.RAM64M,new Unisim[]{Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E});
-		ultraScaleUnisimTransforms.put(Unisim.RAM64M8,new Unisim[]{Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E,Unisim.RAMD64E});
-		ultraScaleUnisimTransforms.put(Unisim.RAM64X1D,new Unisim[]{Unisim.RAMD64E,Unisim.RAMD64E});
-		ultraScaleUnisimTransforms.put(Unisim.RAM64X2S,new Unisim[]{Unisim.RAM64X1S,Unisim.RAM64X1S});
-		ultraScaleUnisimTransforms.put(Unisim.ROM128X1,new Unisim[]{Unisim.LUT6,Unisim.LUT6,Unisim.MUXF7});
-		ultraScaleUnisimTransforms.put(Unisim.ROM256X1,new Unisim[]{Unisim.LUT6,Unisim.LUT6,Unisim.LUT6,Unisim.LUT6,Unisim.MUXF7,Unisim.MUXF7,Unisim.MUXF8});
-	}
 	
 	/**
 	 * Determines if on given series, if the unisim is transformed to
@@ -1382,8 +1275,8 @@ public enum Unisim {
 	 * @return True if unisim is transformed for the given architecture, false otherwise.
 	 */
 	public boolean hasTransform(Series s){
-		if(s == Series.Series7) return series7UnisimTransforms.containsKey(this);
-		return ultraScaleUnisimTransforms.containsKey(this);
+		final EDIFLibrary macroPrimitives = Design.getMacroPrimitives(s);
+		return macroPrimitives.containsCell(this.name());
 	}
 	
 	private static final Unisim[] EMPTY_ARRAY = {};
@@ -1396,8 +1289,17 @@ public enum Unisim {
 	 * this unisim or an empty array if no such transform is needed.
 	 */
 	public Unisim[] getTransform(Series s){
-		Map<Unisim,Unisim[]> map = s == Series.Series7 ? series7UnisimTransforms : ultraScaleUnisimTransforms;
-		Unisim[] value = map.get(this);
-		return value == null ? EMPTY_ARRAY : value;
+		final EDIFLibrary macroPrimitives = Design.getMacroPrimitives(s);
+	    final EDIFCell cell = macroPrimitives.getCell(this.name());
+
+	    final Collection<EDIFCellInst> children = cell.getCellInsts();
+	    Unisim[] result = new Unisim[children.size()];
+	    int i=0;
+	    for (EDIFCellInst child : children) {
+	        result[i] = valueOf(child.getCellType().getName());
+	        i++;
+	    }
+	    return result;
+
 	}
 }

--- a/src/com/xilinx/rapidwright/device/PartNameTools.java
+++ b/src/com/xilinx/rapidwright/device/PartNameTools.java
@@ -35,7 +35,7 @@ import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.util.FileTools;
 
 /**
- * Generated on: Wed Jun 02 21:00:46 2021
+ * Generated on: Fri Jul 02 17:02:23 2021
  * by: com.xilinx.rapidwright.release.PartNamePopulator
  * 
  * Class to hold utility APIs dealing with Parts and device names.
@@ -47,55 +47,56 @@ public class PartNameTools {
 	}
 	static {
 		partMap = new HashMap<String,Part>();
-		UnsafeInput his = FileTools.getUnsafeInputStream(FileTools.getRapidWrightResourceInputStream(FileTools.PART_DB_PATH));
+		try (UnsafeInput his = FileTools.getUnsafeInputStream(FileTools.getRapidWrightResourceInputStream(FileTools.PART_DB_PATH))) {
 		
-		int version = his.readInt();
-		if(version != FileTools.PART_DB_FILE_VERSION) {
-			throw new RuntimeException("ERROR: " + FileTools.PART_DB_PATH
-				+ " file version is incorrect.  Expecting version "
-				+ FileTools.PART_DB_FILE_VERSION + ", found " + version + ".");
-		}
-		String[] strings = FileTools.readStringArray(his);
-		int partCount = 0;
-		partCount = his.readInt();
-		for(int i=0; i < partCount; i++){
-			int[] part = FileTools.readIntArray(his);
-			Part tmpPart = new Part(
-				strings[part[0]],
-				FamilyType.valueOf(strings[part[1]].toUpperCase()),
-				strings[part[2]],
-				FamilyType.valueOf(strings[part[3]].toUpperCase()),
-				strings[part[4]],
-				strings[part[5]],
-				strings[part[6]],
-				strings[part[7]],
-				strings[part[8]],
-				strings[part[9]],
-				strings[part[10]],
-				strings[part[11]],
-				strings[part[12]],
-				strings[part[13]],
-				strings[part[14]],
-				strings[part[15]],
-				strings[part[16]],
-				Series.valueOf(strings[part[17]])
-				);
-			addToPartMap(strings[part[0]], tmpPart);
-			if(!(strings[part[8]].isEmpty())) {
-				addToPartMap(strings[part[4]]+"-"+strings[part[8]], tmpPart);
-				if(!partMap.containsKey(strings[part[4]])) {
+			int version = his.readInt();
+			if(version != FileTools.PART_DB_FILE_VERSION) {
+				throw new RuntimeException("ERROR: " + FileTools.PART_DB_PATH
+					+ " file version is incorrect.  Expecting version "
+					+ FileTools.PART_DB_FILE_VERSION + ", found " + version + ".");
+			}
+			String[] strings = FileTools.readStringArray(his);
+			int partCount = 0;
+			partCount = his.readInt();
+			for(int i=0; i < partCount; i++){
+				int[] part = FileTools.readIntArray(his);
+				Part tmpPart = new Part(
+					strings[part[0]],
+					FamilyType.valueOf(strings[part[1]].toUpperCase()),
+					strings[part[2]],
+					FamilyType.valueOf(strings[part[3]].toUpperCase()),
+					strings[part[4]],
+					strings[part[5]],
+					strings[part[6]],
+					strings[part[7]],
+					strings[part[8]],
+					strings[part[9]],
+					strings[part[10]],
+					strings[part[11]],
+					strings[part[12]],
+					strings[part[13]],
+					strings[part[14]],
+					strings[part[15]],
+					strings[part[16]],
+					Series.valueOf(strings[part[17]])
+					);
+				addToPartMap(strings[part[0]], tmpPart);
+				if(!(strings[part[8]].isEmpty())) {
+					addToPartMap(strings[part[4]]+"-"+strings[part[8]], tmpPart);
+					if(!partMap.containsKey(strings[part[4]])) {
+						addToPartMap(strings[part[4]], tmpPart);
+						addToPartMap(strings[part[4]]+strings[part[5]], tmpPart);
+						addToPartMap(strings[part[4]]+strings[part[5]]+strings[part[6]], tmpPart);
+						addToPartMap(strings[part[4]]+"-"+strings[part[5]], tmpPart);
+						addToPartMap(strings[part[4]]+"-"+strings[part[5]]+strings[part[6]], tmpPart);
+					}
+				} else {
 					addToPartMap(strings[part[4]], tmpPart);
 					addToPartMap(strings[part[4]]+strings[part[5]], tmpPart);
 					addToPartMap(strings[part[4]]+strings[part[5]]+strings[part[6]], tmpPart);
 					addToPartMap(strings[part[4]]+"-"+strings[part[5]], tmpPart);
 					addToPartMap(strings[part[4]]+"-"+strings[part[5]]+strings[part[6]], tmpPart);
 				}
-			} else {
-				addToPartMap(strings[part[4]], tmpPart);
-				addToPartMap(strings[part[4]]+strings[part[5]], tmpPart);
-				addToPartMap(strings[part[4]]+strings[part[5]]+strings[part[6]], tmpPart);
-				addToPartMap(strings[part[4]]+"-"+strings[part[5]], tmpPart);
-				addToPartMap(strings[part[4]]+"-"+strings[part[5]]+strings[part[6]], tmpPart);
 			}
 		}
 	}

--- a/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
@@ -1,115 +1,248 @@
 /*
- * 
- * Copyright (c) 2017 Xilinx, Inc. 
+ *
+ * Copyright (c) 2017 Xilinx, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
  *
- * This file is part of RapidWright. 
- * 
+ * This file is part of RapidWright.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
- */
-/**
- * 
+ *
  */
 package com.xilinx.rapidwright.edif;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Combines an {@link EDIFCellInst} with a full hierarchical
- * instance name to uniquely identify an instance in a netlist.
- * 
+ * An {@link EDIFCellInst} with its hierarchy, described by all the {@link EDIFCellInst}s that sit above it within
+ * the netlist.
+ *
+ * Instances of this class do not necessarily describe a complete hierarchy from the top level cell to a leaf instance.
+ * They may also be used to describe a partial hierarchy starting at an arbitrary point in the design.
+ *
+ * Instances of this class are immutable: Once created, it cannot be changed.
+ *
  * Created on: Oct 30, 2017
  */
 public class EDIFHierCellInst {
+    private final EDIFCellInst[] cellInsts;
 
-	private String hierarchicalInstName;
-	
-	private EDIFCellInst instance;
+    private EDIFHierCellInst(EDIFCellInst[] cellInsts, int newLength, EDIFCellInst relativeChild) {
+        if (newLength == 0) {
+            throw new IllegalStateException("Cannot have a hierCellInst without any names");
+        }
+        this.cellInsts = Arrays.copyOf(cellInsts, newLength);
+        if (relativeChild != null) {
+            this.cellInsts[this.cellInsts.length-1] = relativeChild;
+        }
+    }
 
-	/**
-	 * Constructor
-	 * @param hierarchicalInstanceName Full hierarchical name of the parent instance
-	 * @param instance The actual instance object
-	 */
-	public EDIFHierCellInst(String hierarchicalInstanceName, EDIFCellInst instance) {
-		super();
-		this.hierarchicalInstName = hierarchicalInstanceName;
-		this.instance = instance;
-	}
+    private static boolean isToplevelInst(EDIFCellInst eci) {
+        EDIFCell cellType = eci.getCellType();
+        EDIFLibrary library = cellType.getLibrary();
+        EDIFNetlist netlist = library.getNetlist();
+        EDIFCellInst topCellInst = null;
+        if(netlist != null) {
+            topCellInst = netlist.getTopCellInst();
+        }
+        if(topCellInst != null) {
+            return topCellInst==eci;
+        } else {
+            return false;
+        }
+    }
 
-	/**
-	 * @return the hierarchical name of this parent instance
-	 */
-	public String getHierarchicalInstName() {
-		return hierarchicalInstName;
-	}
+    /**
+     * Create an absolute EDIFHierCellInst.
+     * The first cellInst is required to be the top cell inst as returned by {@link EDIFNetlist#getTopCellInst()}
+     * @param cellInsts the hierarchy of cell insts
+     * @return a new instance
+     */
+    public static EDIFHierCellInst create(EDIFCellInst... cellInsts) {
+        if (cellInsts.length == 0) {
+            throw new RuntimeException("Cannot create empty EDIFHierCellInst");
+        }
+        if (!isToplevelInst(cellInsts[0])) {
+            throw new RuntimeException("Tried to create absolute EDIFHierCellInst, but is not rooted at top instance: "+ Arrays.toString(cellInsts));
+        }
+        return createRelative(cellInsts);
+    }
 
-	/**
-	 * @param hierarchicalInstanceName the hierarchical name of the parent instance
-	 */
-	public void setHierarchicalInstName(String hierarchicalInstanceName) {
-		this.hierarchicalInstName = hierarchicalInstanceName;
-	}
+    public static EDIFHierCellInst createTopInst(EDIFCellInst topCell) {
+        return new EDIFHierCellInst(new EDIFCellInst[]{topCell});
+    }
 
-	/**
-	 * @return the instance
-	 */
-	public EDIFCellInst getInst() {
-		return instance;
-	}
+    /**
+     * Create an EDIFHierCellInst. This may be absolute (first item is the top cell inst) or relative (starting at an arbitrary point in the hierarchy).
+     * @param cellInsts the hierarchy of cell insts
+     * @return a new top instance
+     */
+    public static EDIFHierCellInst createRelative(EDIFCellInst... cellInsts) {
+        return new EDIFHierCellInst(cellInsts);
+    }
 
-	/**
-	 * @param instance the instance to set
-	 */
-	public void setInst(EDIFCellInst instance) {
-		this.instance = instance;
-	}
-	
-	public String getFullHierarchicalInstName(){
-		if(isTopLevelInst()) return "";
-		if(hierarchicalInstName.isEmpty()) return instance.getName();
-		return hierarchicalInstName + EDIFTools.EDIF_HIER_SEP + instance.getName();
-	}
+    private boolean hasParent() {
+        return cellInsts.length > 1;
+    }
 
-	/**
-	 * Checks if this instance is the top level instance of the netlist.
-	 * @return True if this is the top instance, false otherwise.
-	 */
-	public boolean isTopLevelInst() {
-		EDIFCell cellType = instance.getCellType();
-		EDIFLibrary library = cellType.getLibrary();
-		EDIFNetlist netlist = library.getNetlist();
-		EDIFCellInst topCellInst = null;
-		if(netlist != null) {
-			topCellInst = netlist.getTopCellInst();
-		}
-		if(topCellInst != null) {
-			return topCellInst.equals(instance);
-		} else {
-			return false;
-		}
-	}
-	
-	public String toString(){
-		return getFullHierarchicalInstName();
-	}
-	
-	public EDIFCell getCellType(){
-		return instance.getCellType();
-	}
-	
-	public String getCellName(){
-		return instance.getCellName();
-	}
+    /**
+     * Create a new Instance.
+     * To guarantee Immutability, the provided array MUST NOT be changed.
+     * @param cellInsts the cells to use
+     */
+    private EDIFHierCellInst(EDIFCellInst[] cellInsts) {
+        if (cellInsts.length == 0) {
+            throw new RuntimeException("cannot have empty cell insts");
+        }
+        this.cellInsts = cellInsts;
+    }
+
+    public EDIFCellInst getInst() {
+        return cellInsts[cellInsts.length-1];
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EDIFHierCellInst that = (EDIFHierCellInst) o;
+        return Arrays.equals(cellInsts, that.cellInsts);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(cellInsts);
+    }
+
+    public EDIFHierCellInst getParent() {
+        if (cellInsts.length == 1) {
+            return null;
+        }
+        return new EDIFHierCellInst(cellInsts, cellInsts.length-1, null);
+    }
+
+    public EDIFHierCellInst getChild(EDIFCellInst relativeChild) {
+        return new EDIFHierCellInst(cellInsts, cellInsts.length+1, relativeChild);
+    }
+
+    public EDIFHierCellInst getSibling(EDIFCellInst relativeSibling) {
+        return new EDIFHierCellInst(cellInsts, cellInsts.length, relativeSibling);
+    }
+
+    public boolean isAbsolute() {
+        return isToplevelInst(cellInsts[0]);
+    }
+
+    public List<EDIFCellInst> getFullHierarchy() {
+        //We can't just return the internal array, as users could then change it.
+        //Return an unmodifiable list that uses the same backing array instead
+        return Collections.unmodifiableList(Arrays.asList(cellInsts));
+    }
+
+    public int getDepth() {
+        return cellInsts.length;
+    }
+
+    public boolean enterHierarchicalName(StringBuilder sb) {
+        int start = isAbsolute() ? 1 : 0;
+        for (int i = start; i < cellInsts.length; i++) {
+            if (i>start) {
+                sb.append(EDIFTools.EDIF_HIER_SEP);
+            }
+            sb.append(cellInsts[i].getName());
+        }
+        return start < cellInsts.length;
+    }
+
+    public String getFullHierarchicalInstName() {
+        StringBuilder sb = new StringBuilder();
+        enterHierarchicalName(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Checks if this instance is the top level instance of the netlist.
+     *
+     * @return True if this is the top instance, false otherwise.
+     */
+    public boolean isTopLevelInst() {
+        //Has multiple levels?
+        if (hasParent()) {
+            return false;
+        }
+        //HierCellInsts need not be absolute, so check the cell
+        return isToplevelInst(getInst());
+
+    }
+
+    public EDIFCell getCellType() {
+        return getInst().getCellType();
+    }
+
+    public String getCellName() {
+        return getInst().getCellName();
+    }
+
+    /**
+     * Get a direct child
+     * @param relativeChildName the name of the direct child
+     * @return the hierarchical child
+     */
+    public EDIFHierCellInst getChild(String relativeChildName) {
+        final EDIFCellInst cellInst = getCellType().getCellInst(relativeChildName);
+        if (cellInst == null) {
+            //throw new IllegalStateException(this + " does not have a child named "+relativeChildName);
+            return null;
+        }
+        return getChild(cellInst);
+    }
+
+    public EDIFHierNet getNet(String netName) {
+        final EDIFNet net = getInst().getCellType().getNet(netName);
+        if (net == null) {
+            return null;
+        }
+        return new EDIFHierNet(this, net);
+    }
+
+    /**
+     * Get a hierarchical port inst, viewed from external to this cell inst.
+     * @throws IllegalStateException if the port does not exist
+     */
+    public EDIFHierPortInst getPortInst(String portName) {
+        final EDIFPortInst port = getInst().getPortInst(portName);
+        if (port == null) {
+            return null;
+        }
+        return new EDIFHierPortInst(getParent(), port);
+    }
+
+    /**
+     * Add this instance's children to some collection
+     * @param collection the collection to add to
+     */
+    public void addChildren(Collection<EDIFHierCellInst> collection) {
+        for (EDIFCellInst cellInst : getInst().getCellType().getCellInsts()) {
+            collection.add(getChild(cellInst));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getFullHierarchicalInstName();
+    }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
@@ -25,6 +25,10 @@
  */
 package com.xilinx.rapidwright.edif;
 
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Combines an {@link EDIFNet} with a full hierarchical
  * instance name to uniquely identify a net in a netlist.
@@ -33,33 +37,26 @@ package com.xilinx.rapidwright.edif;
  */
 public class EDIFHierNet {
 
-	private String hierarchicalInstName;
-	
-	private EDIFNet net;
+	@NotNull
+	private final EDIFHierCellInst hierarchicalInst;
+	@NotNull
+	private final EDIFNet net;
 
 	/**
 	 * Constructor 
-	 * @param hierarchicalInstName Parent instance cell that contains this net
+	 * @param hierarchicalInst Parent instance cell that contains this net
 	 * @param net The actual net object
 	 */
-	public EDIFHierNet(String hierarchicalInstName, EDIFNet net) {
-		super();
-		this.hierarchicalInstName = hierarchicalInstName;
-		this.net = net;
+	public EDIFHierNet(@NotNull EDIFHierCellInst hierarchicalInst, @NotNull EDIFNet net) {
+		this.hierarchicalInst = Objects.requireNonNull(hierarchicalInst);
+		this.net = Objects.requireNonNull(net);
 	}
 
 	/**
 	 * @return the hierarchicalInstName
 	 */
 	public String getHierarchicalInstName() {
-		return hierarchicalInstName;
-	}
-
-	/**
-	 * @param hierarchicalInstName the hierarchicalInstName to set
-	 */
-	public void setHierarchicalInstName(String hierarchicalInstName) {
-		this.hierarchicalInstName = hierarchicalInstName;
+		return hierarchicalInst.getFullHierarchicalInstName();
 	}
 
 	/**
@@ -67,13 +64,6 @@ public class EDIFHierNet {
 	 */
 	public EDIFNet getNet() {
 		return net;
-	}
-
-	/**
-	 * @param net the net to set
-	 */
-	public void setNet(EDIFNet net) {
-		this.net = net;
 	}
 	
 	/**
@@ -83,17 +73,21 @@ public class EDIFHierNet {
 	 * @return Full hierarchical name of the instance attached to the port.
 	 */
 	public String getHierarchicalInstName(EDIFPortInst port){
-		if(this.hierarchicalInstName.isEmpty()){
-			return port.getCellInst().getName();
+		StringBuilder sb = new StringBuilder();
+		if (hierarchicalInst.enterHierarchicalName(sb)) {
+			sb.append(EDIFTools.EDIF_HIER_SEP);
 		}
-		return this.hierarchicalInstName + EDIFTools.EDIF_HIER_SEP + port.getCellInst().getName();
+		sb.append(port.getCellInst().getName());
+		return sb.toString();
 	}
 	
 	public String getHierarchicalNetName(){
-		if(this.hierarchicalInstName.length() == 0){
-			return net.getName();
+		StringBuilder sb = new StringBuilder();
+		if (hierarchicalInst.enterHierarchicalName(sb)) {
+			sb.append(EDIFTools.EDIF_HIER_SEP);
 		}
-		return this.hierarchicalInstName + EDIFTools.EDIF_HIER_SEP + net.getName();
+		sb.append(net.getName());
+		return sb.toString();
 	}
 
 	/**
@@ -101,8 +95,7 @@ public class EDIFHierNet {
 	 * @return The parent cell instance of this net.
 	 */
 	public EDIFCellInst getParentInst() {
-	    EDIFNetlist netlist = net.getParentCell().getLibrary().getNetlist();
-	    return netlist.getCellInstFromHierName(hierarchicalInstName);
+	    return hierarchicalInst.getInst();
 	}
 	
 	/* (non-Javadoc)
@@ -112,7 +105,8 @@ public class EDIFHierNet {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((hierarchicalInstName == null) ? 0 : hierarchicalInstName.hashCode());
+		//TODO does it make sense for hierarchicalInst or net to be null?
+		result = prime * result + ((hierarchicalInst == null) ? 0 : hierarchicalInst.hashCode());
 		result = prime * result + ((net == null) ? 0 : net.hashCode());
 		return result;
 	}
@@ -129,10 +123,10 @@ public class EDIFHierNet {
 		if (getClass() != obj.getClass())
 			return false;
 		EDIFHierNet other = (EDIFHierNet) obj;
-		if (hierarchicalInstName == null) {
-			if (other.hierarchicalInstName != null)
+		if (hierarchicalInst == null) {
+			if (other.hierarchicalInst != null)
 				return false;
-		} else if (!hierarchicalInstName.equals(other.hierarchicalInstName))
+		} else if (!hierarchicalInst.equals(other.hierarchicalInst))
 			return false;
 		if (net == null) {
 			if (other.net != null)
@@ -147,8 +141,11 @@ public class EDIFHierNet {
 	 */
 	@Override
 	public String toString() {
-		return "EDIFHierNet [hierarchicalInstName=" + hierarchicalInstName + ", net=" + net + "]";
+		return "EDIFHierNet [hierarchicalInstName=" + hierarchicalInst + ", net=" + net + "]";
 	}
-	
-	
+
+
+	public EDIFHierCellInst getHierarchicalInst() {
+		return hierarchicalInst;
+	}
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -51,7 +51,7 @@ import com.xilinx.rapidwright.util.MessageGenerator;
  * RapidWright, load it into Vivado first and then write it out from Vivado.
  * Created on: May 10, 2017
  */
-public class EDIFParser {
+public class EDIFParser implements AutoCloseable{
 
 	private Path fileName;
 	
@@ -785,5 +785,12 @@ public class EDIFParser {
 		p.stop().start("Write EDIF");
 		if(args.length > 1) n.exportEDIF(args[1]);
 		p.stop().printSummary();
+	}
+
+	@Override
+	public void close() throws IOException {
+		if(in!=null) {
+			in.close();
+		}
 	}
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -220,7 +220,6 @@ public class EDIFPortInst {
 	}
 
 	public EDIFNet getInternalNet(){
-		EDIFCellInst cellInst = getCellInst();
 		if(cellInst == null) return null;
 		return cellInst.getCellType().getInternalNet(this);
 	}

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -697,13 +697,11 @@ public class EDIFTools {
 	}
 
 	public static EDIFNetlist loadEDIFFile(Path fileName) {
-		EDIFParser p = null;
-		try {
-			p = new EDIFParser(fileName);
+		try (EDIFParser p = new EDIFParser(fileName)) {
+			return p.parseEDIFNetlist();
 		} catch (IOException e) {
 			throw new UncheckedIOException("ERROR: Couldn't read file : " + fileName, e);
 		}
-		return p.parseEDIFNetlist();
 	}
 
 	public static EDIFNetlist loadEDIFFile(String fileName){
@@ -755,12 +753,13 @@ public class EDIFTools {
 					+ "be passed to resulting DCP load script.");
 			}
 		}
-		if(EDIFTools.EDIF_DEBUG && FileTools.isFileNewer(FileTools.appendExtension(edifFileName , ".dat"), edifFileName)){
-			edif = FileTools.readObjectFromKryoFile(edifFileName + ".dat", EDIFNetlist.class);
+		Path kryoFile = FileTools.appendExtension(edifFileName , ".dat");
+		if(EDIFTools.EDIF_DEBUG && FileTools.isFileNewer(kryoFile, edifFileName)){
+			edif = FileTools.readObjectFromKryoFile(kryoFile, EDIFNetlist.class);
 		}else{
 			edif = loadEDIFFile(edifFileName);
-			if(!(new File(edifFileName + ".dat").exists()) || FileTools.isFileNewer(edifFileName, FileTools.appendExtension(edifFileName , ".dat")) ){
-				if(EDIFTools.EDIF_DEBUG) FileTools.writeObjectToKryoFile(edifFileName + ".dat", edif);			
+			if(!Files.exists(kryoFile) || FileTools.isFileNewer(edifFileName, kryoFile)){
+				if(EDIFTools.EDIF_DEBUG) FileTools.writeObjectToKryoFile(kryoFile, edif);
 			}
 		}
 		if(edifDirectoryName != null) {

--- a/src/com/xilinx/rapidwright/examples/PolynomialGenerator.java
+++ b/src/com/xilinx/rapidwright/examples/PolynomialGenerator.java
@@ -50,7 +50,6 @@ import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.router.Router;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
-import com.xilinx.rapidwright.util.MessageGenerator;
 import com.xilinx.rapidwright.util.StringTools;
 
 public class PolynomialGenerator {
@@ -385,7 +384,7 @@ public class PolynomialGenerator {
 		t.stop().start("Final Route");
 		
 		
-		Map<String,String> parentNetMap = n.getParentNetMap();
+		Map<String,String> parentNetMap = n.getParentNetMapNames();
 		for(Net net : new ArrayList<>(d.getNets())){
 			if(net.getPins().size() > 0 && net.getSource() == null){
 				if(net.isStaticNet()) continue;

--- a/src/com/xilinx/rapidwright/examples/PrintEDIFInstances.java
+++ b/src/com/xilinx/rapidwright/examples/PrintEDIFInstances.java
@@ -33,7 +33,6 @@ import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFHierCellInst;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFTools;
-import com.xilinx.rapidwright.util.MessageGenerator;
 
 /**
  * This example enumerates all cell instances in an EDIF netlist
@@ -48,15 +47,14 @@ public class PrintEDIFInstances {
 			PrintWriter pw = new PrintWriter(fileName);
 			pw.println("DESIGN NAME: " + ee.getName());
 			Queue<EDIFHierCellInst> queue = new LinkedList<EDIFHierCellInst>();
-			queue.add(new EDIFHierCellInst("", ee.getTopCellInst()));
+			queue.add(ee.getTopHierCellInst());
 			while(!queue.isEmpty()){
 				EDIFHierCellInst p = queue.poll();
 				EDIFCellInst i = p.getInst();
-				String path = p.getHierarchicalInstName();
-				String curr = path + "/" + i.getName();
+				String curr = p.getFullHierarchicalInstName();
 				pw.println(curr + " (" + i.getCellType() + ") from library " + i.getCellType().getLibrary());
 				for(EDIFCellInst i2 : i.getCellType().getCellInsts()){
-					queue.add(new EDIFHierCellInst(curr, i2));
+					queue.add(p.getChild(i2));
 				}
 			}
 			

--- a/src/com/xilinx/rapidwright/examples/SLRCrosserGenerator.java
+++ b/src/com/xilinx/rapidwright/examples/SLRCrosserGenerator.java
@@ -274,14 +274,14 @@ public class SLRCrosserGenerator {
 			int lagunaStartX = start.getInstanceX();
 			int lagunaStartY = start.getInstanceY();
 			for(int i=0; i < width; i++){
-				EDIFNet net = d.getNetlist().getNetFromHierName(busName + "[" + i + "]");
+				EDIFHierNet net = d.getNetlist().getHierNetFromName(busName + "[" + i + "]");
 				int x = ((i / 12) % 2) + lagunaStartX;
 				int y = lagunaStartY + ((i/(LAGUNA_FLOPS_PER_SITE*LAGUNA_SITES_PER_TILE))*2) 
 									 + ((i/LAGUNA_FLOPS_PER_SITE % 2) == 1 ? 1 : 0);
 
 				Site txSite = d.getDevice().getSite("LAGUNA_X" + x + "Y" + y);
 				String txElementName = "TX_REG" + (i % LAGUNA_FLOPS_PER_SITE);
-				placeAndRouteLagunaFlopPair(d, new EDIFHierNet("", net), txSite, txElementName);
+				placeAndRouteLagunaFlopPair(d, net, txSite, txElementName);
 			}
 		}
 		

--- a/src/com/xilinx/rapidwright/router/Router.java
+++ b/src/com/xilinx/rapidwright/router/Router.java
@@ -750,7 +750,7 @@ public class Router extends AbstractRouter {
 	/**
 	 * Looks backwards from an input pin depth number of hops to see if there
 	 * exists at least one free path.
-	 * @param p Input pin to check routability
+	 * @param rn Input pin to check routability
 	 * @param depth Number of PIP hops to check
 	 * @return True if there exists at least one path depth PIP hops free, false otherwise.
 	 */
@@ -1921,7 +1921,7 @@ public class Router extends AbstractRouter {
 		Design d = getDesign();
 		EDIFNetlist n = d.getNetlist();
 		d.getNetlist().resetParentNetMap();
-		Map<String,String> parentNetMap = getDesign().getNetlist().getParentNetMap();
+		Map<String,String> parentNetMap = getDesign().getNetlist().getParentNetMapNames();
 		
 		// Build a reverse net (Parent Net -> Net Aliases)
 		Map<String,HashSet<String>> reverseNetMap = new HashMap<>();

--- a/src/com/xilinx/rapidwright/router/SATRouter.java
+++ b/src/com/xilinx/rapidwright/router/SATRouter.java
@@ -35,6 +35,7 @@ import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.SitePin;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.Wire;
+import com.xilinx.rapidwright.edif.EDIFHierNet;
 import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.util.FileTools;
@@ -164,11 +165,12 @@ public class SATRouter {
 	
 	public void updateSitePinInsts(){
 		EDIFNetlist n = design.getNetlist();
-		Map<String,ArrayList<EDIFHierPortInst>> physNetPinMap = n.getPhysicalNetPinMap();
-		nextNet: for(Entry<String,ArrayList<EDIFHierPortInst>> netPins : physNetPinMap.entrySet()){
-			Net net = design.getNet(netPins.getKey());
+		Map<EDIFHierNet,List<EDIFHierPortInst>> physNetPinMap = n.getPhysicalNetPinMap();
+		nextNet: for(Entry<EDIFHierNet,List<EDIFHierPortInst>> netPins : physNetPinMap.entrySet()){
+
+			Net net = n.getPhysicalNetFromPin(netPins.getValue().iterator().next(), design);
 			if(net == null){
-				net = design.createNet(netPins.getKey());
+				net = design.createNet(netPins.getKey().getHierarchicalNetName());
 			}
 			EDIFHierPortInst output = null;
 			Site outputSite = null;
@@ -265,7 +267,7 @@ public class SATRouter {
 	 * for the SAT solver. 
 	 */
 	private void populateNetsToRoute(){
-		Map<String,String> parentNetMap = design.getNetlist().getParentNetMap();
+		Map<String,String> parentNetMap = design.getNetlist().getParentNetMapNames();
 		for(SiteInst i : design.getSiteInsts()){
 			for(Entry<String,Net> e : i.getNetSiteWireMap().entrySet()){
 				Net n = e.getValue();

--- a/src/com/xilinx/rapidwright/timing/TimingGraph.java
+++ b/src/com/xilinx/rapidwright/timing/TimingGraph.java
@@ -20,6 +20,19 @@
 
 package com.xilinx.rapidwright.timing;
 
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
@@ -34,26 +47,12 @@ import com.xilinx.rapidwright.edif.EDIFHierCellInst;
 import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
-
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.shortestpath.AllDirectedPaths;
 import org.jgrapht.alg.shortestpath.BellmanFordShortestPath;
 import org.jgrapht.alg.shortestpath.KShortestSimplePaths;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 import org.jgrapht.graph.GraphWalk;
-
-import java.io.FileNotFoundException;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Queue;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.Collection;
 
 
 /**
@@ -130,7 +129,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
         determineLogicDelaysFromEDIFCellInsts();
         set = new ArrayList<>();
         Queue<EDIFHierCellInst> q = new LinkedList<>();
-        q.add(new EDIFHierCellInst("", top));
+        q.add(design.getNetlist().getTopHierCellInst());
         while (!q.isEmpty()) {
             EDIFHierCellInst i = q.poll();
             for (EDIFCellInst child : i.getInst().getCellType().getCellInsts()) {
@@ -138,7 +137,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                 if (!i.isTopLevelInst()) {
                     fullName = i.getFullHierarchicalInstName();// + EDIFTools.EDIF_HIER_SEP + child.getName();
                 }
-                EDIFHierCellInst newCell = new EDIFHierCellInst(fullName, child);
+                EDIFHierCellInst newCell = i.getChild(child);
                 if (newCell.getInst().getCellType().isPrimitive()) {
                     set.add(newCell);
                 } else {
@@ -1077,7 +1076,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
             return -1;
         }
         List<EDIFHierPortInst> hports = null;
-        hports = design.getNetlist().getPhysicalPins(netName);
+        hports = design.getNetlist().getPhysicalPins(n);
 
         if (hports == null) {
             return 0;

--- a/src/com/xilinx/rapidwright/util/Installer.java
+++ b/src/com/xilinx/rapidwright/util/Installer.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -229,8 +230,8 @@ public class Installer {
 		Path root = FileSystems.getDefault().getPath(dir);
 		List<String> javaSrcs = null;
 		
-		try{
-			javaSrcs = Files.walk(root)
+		try (final Stream<Path> walk = Files.walk(root)){
+			javaSrcs = walk
 			        .filter(foundPath -> foundPath.toString().endsWith(".java"))
 			        .map(javaPath -> javaPath.toAbsolutePath().toString())
 			        .collect(Collectors.toList());			

--- a/test/com/xilinx/rapidwright/checker/CheckOpenFiles.java
+++ b/test/com/xilinx/rapidwright/checker/CheckOpenFiles.java
@@ -1,0 +1,14 @@
+package com.xilinx.rapidwright.checker;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(CheckOpenFilesExtension.class)
+public @interface CheckOpenFiles {
+}

--- a/test/com/xilinx/rapidwright/checker/CheckOpenFilesExtension.java
+++ b/test/com/xilinx/rapidwright/checker/CheckOpenFilesExtension.java
@@ -1,0 +1,93 @@
+package com.xilinx.rapidwright.checker;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Check that a testcase does leak open files
+ *
+ * Only works on Linux. On other OSes it cannot detect errors and will fail silently.
+ */
+public class CheckOpenFilesExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+    private String getOwnPid() {
+        final RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
+        String name = runtimeBean.getName();
+        int atPosition = name.indexOf("@");
+        if (atPosition<=1) {
+            return name;
+        }
+        return name.substring(0,atPosition);
+    }
+    private List<String> getOpenFiles() {
+        final Path fdList = Paths.get("/proc/" + getOwnPid() + "/fd");
+        if (!Files.exists(fdList)) {
+            //We are probably not on Linux, fail silently
+            return Collections.emptyList();
+        }
+        try (final Stream<Path> list = Files.list(fdList)) {
+            return list.map(p -> {
+                try {
+                    final Path linkTarget = Files.readSymbolicLink(p);
+                    return linkTarget.toString();
+                } catch (IOException e) {
+                    return p.toString();
+                }
+            })
+                    .filter(this::checkIgnore)
+                    .sorted()
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean checkIgnore(String path) {
+        //Ignore Random Device
+        if (path.equals("/dev/random") || path.equals("/dev/urandom")) {
+            return false;
+        }
+        //Socket for debugging should be ignored
+        if (path.startsWith("socket:")) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create("com", "xilinx", "rapidwright", "checker");
+    private static final String OPEN_FILES = "openFiles";
+
+    @Override
+    public void afterTestExecution(ExtensionContext extensionContext) {
+        final List<String> afterList = getOpenFiles();
+        List<String> beforeList = extensionContext.getStore(NAMESPACE).get(OPEN_FILES, List.class);
+
+
+        if (!beforeList.equals(afterList)) {
+            final Stream<String> newlyOpened = afterList.stream().filter(s -> !beforeList.contains(s)).map(s -> "Newly opened: " + s);
+            final Stream<String> closed = beforeList.stream().filter(s -> !afterList.contains(s)).map(s -> "Closed: " + s);
+
+            final String res = Stream.concat(newlyOpened, closed)
+                    .collect(Collectors.joining("\n","List of open Files changed: \n", ""));
+            Assertions.fail(res);
+        }
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext extensionContext) {
+        extensionContext.getStore(NAMESPACE).put(OPEN_FILES, getOpenFiles());
+    }
+}

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -18,17 +18,18 @@ import org.junit.jupiter.api.io.TempDir;
  * so we just try to catch obvious issues.
  */
 public class TestDesign {
+    public static final String DEVICE = "xc7a12t";
 
-    private static final String SITE = "SLICE_X42Y42";
+    private static final String SITE = "SLICE_X20Y42";
 
     private Design createSampleDesign() {
         final EDIFNetlist netlist = TestEDIF.createEmptyNetlist();
         final Design design = new Design(netlist);
 
         final Cell myCell = design.createCell("myCell", Unisim.FDRE);
-        System.out.println("myCell.getBEL() = " + myCell.getBEL());
+
         final Site site = design.getDevice().getSite(SITE);
-        final SiteInst siteInst = design.createSiteInst(site);
+        design.createSiteInst(site);
         final BEL bel = site.getBEL("AFF");
         Assertions.assertNotNull(bel);
         design.placeCell(myCell, site, bel);
@@ -40,7 +41,7 @@ public class TestDesign {
     @CheckOpenFiles
     public void checkDcpRoundtrip(@TempDir Path tempDir) throws IOException {
         //Keep a reference to the device to avoid it being garbage collected during testcase execution
-        Device device = Device.getDevice(TestRelocation.DEVICE_ULTRASCALE);
+        Device device = Device.getDevice(DEVICE);
 
         //Use separate files for writing/reading so we can identify identify leaking file handles by filename
         final Path filenameWrite = tempDir.resolve("testWrite.dcp");
@@ -50,7 +51,7 @@ public class TestDesign {
         Files.copy(filenameWrite, filenameRead);
 
         Design design = Design.readCheckpoint(filenameRead);
-        TestEDIF.verifyNetlist(design.getNetlist());
+        TestEDIF.verifyNetlist(design.getNetlist(), "myCell");
 
         final Cell cell = design.getCell("myCell");
         Assertions.assertNotNull(cell);

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -1,0 +1,56 @@
+package com.xilinx.rapidwright.design;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.xilinx.rapidwright.checker.CheckOpenFiles;
+import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test that we can write a DCP file and read it back in. We currently don't have a way to check designs for equality,
+ * so we just try to catch obvious issues.
+ */
+public class TestDesign {
+
+    private static final String SITE = "SLICE_X42Y42";
+
+    private Design createSampleDesign() {
+        final EDIFNetlist netlist = TestEDIF.createEmptyNetlist();
+        final Design design = new Design(netlist);
+
+        final Cell myCell = design.createCell("myCell", Unisim.FDRE);
+        System.out.println("myCell.getBEL() = " + myCell.getBEL());
+        final Site site = design.getDevice().getSite(SITE);
+        final SiteInst siteInst = design.createSiteInst(site);
+        final BEL bel = site.getBEL("AFF");
+        Assertions.assertNotNull(bel);
+        design.placeCell(myCell, site, bel);
+
+        return design;
+    }
+
+    @Test
+    @CheckOpenFiles
+    public void checkDcpRoundtrip(@TempDir Path tempDir) throws IOException {
+        //Use separate files for writing/reading so we can identify identify leaking file handles by filename
+        final Path filenameWrite = tempDir.resolve("testWrite.dcp");
+        final Path filenameRead = tempDir.resolve("testRead.dcp");
+
+        createSampleDesign().writeCheckpoint(filenameWrite);
+        Files.copy(filenameWrite, filenameRead);
+
+        Design design = Design.readCheckpoint(filenameRead);
+        TestEDIF.verifyNetlist(design.getNetlist());
+
+        final Cell cell = design.getCell("myCell");
+        Assertions.assertNotNull(cell);
+        Assertions.assertEquals(SITE, cell.getSiteInst().getSite().getName());
+
+    }
+}

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 
 import com.xilinx.rapidwright.checker.CheckOpenFiles;
 import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import org.junit.jupiter.api.Assertions;
@@ -38,6 +39,9 @@ public class TestDesign {
     @Test
     @CheckOpenFiles
     public void checkDcpRoundtrip(@TempDir Path tempDir) throws IOException {
+        //Keep a reference to the device to avoid it being garbage collected during testcase execution
+        Device device = Device.getDevice(TestRelocation.DEVICE_ULTRASCALE);
+
         //Use separate files for writing/reading so we can identify identify leaking file handles by filename
         final Path filenameWrite = tempDir.resolve("testWrite.dcp");
         final Path filenameRead = tempDir.resolve("testRead.dcp");

--- a/test/com/xilinx/rapidwright/design/TestEDIF.java
+++ b/test/com/xilinx/rapidwright/design/TestEDIF.java
@@ -9,10 +9,7 @@ import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFDesign;
 import com.xilinx.rapidwright.edif.EDIFLibrary;
-import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
-import com.xilinx.rapidwright.edif.EDIFPort;
-import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,7 +28,7 @@ public class TestEDIF {
         final EDIFCell topCell = new EDIFCell(workLibrary, "myTestCell");
         netlist.getDesign().setTopCell(topCell);
 
-        EDIFTools.ensureCorrectPartInEDIF(netlist, TestRelocation.DEVICE_ULTRASCALE);
+        EDIFTools.ensureCorrectPartInEDIF(netlist, TestDesign.DEVICE);
 
         return netlist;
     }
@@ -51,11 +48,11 @@ public class TestEDIF {
 
         final EDIFNetlist netlist = EDIFTools.readEdifFile(filenameRead);
 
-        verifyNetlist(netlist);
+        verifyNetlist(netlist, "inst");
 
     }
 
-    public static void verifyNetlist(EDIFNetlist netlist) {
+    public static void verifyNetlist(EDIFNetlist netlist, String expectedName) {
         final EDIFLibrary workLibrary = netlist.getWorkLibrary();
         Assertions.assertNotNull(workLibrary);
 
@@ -65,6 +62,6 @@ public class TestEDIF {
 
         Assertions.assertEquals(cell.getCellInsts().size(),1);
         final EDIFCellInst inst = cell.getCellInsts().iterator().next();
-        Assertions.assertEquals("inst", inst.getName());
+        Assertions.assertEquals(expectedName, inst.getName());
     }
 }

--- a/test/com/xilinx/rapidwright/design/TestEDIF.java
+++ b/test/com/xilinx/rapidwright/design/TestEDIF.java
@@ -1,0 +1,70 @@
+package com.xilinx.rapidwright.design;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.xilinx.rapidwright.checker.CheckOpenFiles;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFDesign;
+import com.xilinx.rapidwright.edif.EDIFLibrary;
+import com.xilinx.rapidwright.edif.EDIFNet;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPort;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test that we can write an EDIF file and read it back in. We currently don't have a way to check designs for equality,
+ * so we just try to catch obvious issues.
+ */
+public class TestEDIF {
+
+    public static EDIFNetlist createEmptyNetlist() {
+        EDIFNetlist netlist = new EDIFNetlist("test");
+        netlist.setDesign(new EDIFDesign("test"));
+        final EDIFLibrary workLibrary = netlist.getWorkLibrary();
+        final EDIFCell topCell = new EDIFCell(workLibrary, "myTestCell");
+        netlist.getDesign().setTopCell(topCell);
+
+        EDIFTools.ensureCorrectPartInEDIF(netlist, TestRelocation.DEVICE_ULTRASCALE);
+
+        return netlist;
+    }
+
+    @Test
+    @CheckOpenFiles
+    public void checkEdifRoundtrip(@TempDir Path tempDir) throws IOException {
+        //Use separate files for writing/reading so we can identify identify leaking file handles by filename
+        final Path filenameWrite = tempDir.resolve("testWrite.edf");
+        final Path filenameRead = tempDir.resolve("testRead.edf");
+
+        final EDIFNetlist original = createEmptyNetlist();
+
+        EDIFCellInst inst = Design.createUnisimInst(original.getTopCell(), "inst", Unisim.FDRE);
+        original.exportEDIF(filenameWrite);
+        Files.copy(filenameWrite, filenameRead);
+
+        final EDIFNetlist netlist = EDIFTools.readEdifFile(filenameRead);
+
+        verifyNetlist(netlist);
+
+    }
+
+    public static void verifyNetlist(EDIFNetlist netlist) {
+        final EDIFLibrary workLibrary = netlist.getWorkLibrary();
+        Assertions.assertNotNull(workLibrary);
+
+        final EDIFCell cell = workLibrary.getCell("myTestCell");
+        Assertions.assertNotNull(cell);
+        Assertions.assertEquals(cell, netlist.getTopCell());
+
+        Assertions.assertEquals(cell.getCellInsts().size(),1);
+        final EDIFCellInst inst = cell.getCellInsts().iterator().next();
+        Assertions.assertEquals("inst", inst.getName());
+    }
+}

--- a/test/com/xilinx/rapidwright/design/TestEDIF.java
+++ b/test/com/xilinx/rapidwright/design/TestEDIF.java
@@ -1,15 +1,22 @@
 package com.xilinx.rapidwright.design;
 
 import java.io.IOException;
+import java.lang.ref.SoftReference;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.xilinx.rapidwright.checker.CheckOpenFiles;
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFDesign;
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
 import com.xilinx.rapidwright.edif.EDIFLibrary;
+import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPort;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -60,8 +67,90 @@ public class TestEDIF {
         Assertions.assertNotNull(cell);
         Assertions.assertEquals(cell, netlist.getTopCell());
 
-        Assertions.assertEquals(cell.getCellInsts().size(),1);
+        Assertions.assertEquals(cell.getCellInsts().size(), 1);
         final EDIFCellInst inst = cell.getCellInsts().iterator().next();
         Assertions.assertEquals(expectedName, inst.getName());
+    }
+
+    private void connectToParent(EDIFCellInst cellInst, String portName, String innerPrefix) {
+        EDIFCell parent = cellInst.getParentCell();
+        final EDIFNet net = parent.createNet("net/"+portName);
+        final EDIFPortInst innerPortInst = net.createPortInst(innerPrefix+portName, cellInst);
+        final EDIFPort port = parent.createPort("port/"+portName, innerPortInst.getDirection(), 1);
+        net.createPortInst(port);
+    }
+
+    private void addFDREConnections(EDIFCellInst cellInst, String innerPrefix) {
+        connectToParent(cellInst, "D", innerPrefix);
+        connectToParent(cellInst, "C", innerPrefix);
+        connectToParent(cellInst, "Q", innerPrefix);
+    }
+
+    @Test
+    public void testParentNetMap() {
+        EDIFNetlist netlist = createWrappedRegisterDesign();
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("net/D", "net/D");
+        expected.put("net/C", "net/C");
+        expected.put("net/Q", "inter/mediate/net/Q");
+        expected.put("inter/mediate/net/D", "net/D");
+        expected.put("inter/mediate/net/C", "net/C");
+        expected.put("inter/mediate/net/Q", "inter/mediate/net/Q");
+
+        final Map<String, String> actual = netlist.getParentNetMapNames();
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testHierGetters() {
+        final EDIFNetlist netlist = createWrappedRegisterDesign();
+
+        final EDIFHierCellInst topHierCellInst = netlist.getTopHierCellInst();
+        final EDIFHierCellInst intermediate = topHierCellInst.getChild("inter/mediate");
+        final EDIFHierCellInst reg = intermediate.getChild("inst/asdf");
+
+        //Check cell insts
+        Assertions.assertEquals(topHierCellInst, netlist.getHierCellInstFromName(""));
+        Assertions.assertEquals(intermediate, netlist.getHierCellInstFromName("inter/mediate"));
+        Assertions.assertEquals(reg, netlist.getHierCellInstFromName("inter/mediate/inst/asdf"));
+
+        //Check nets
+        Assertions.assertEquals(topHierCellInst.getNet("net/D"), netlist.getHierNetFromName("net/D"));
+        Assertions.assertEquals(topHierCellInst.getNet("net/C"), netlist.getHierNetFromName("net/C"));
+        Assertions.assertEquals(topHierCellInst.getNet("net/Q"), netlist.getHierNetFromName("net/Q"));
+        Assertions.assertEquals(intermediate.getNet("net/D"), netlist.getHierNetFromName("inter/mediate/net/D"));
+        Assertions.assertEquals(intermediate.getNet("net/C"), netlist.getHierNetFromName("inter/mediate/net/C"));
+        Assertions.assertEquals(intermediate.getNet("net/Q"), netlist.getHierNetFromName("inter/mediate/net/Q"));
+
+        //Check Ports
+        Assertions.assertEquals(intermediate.getPortInst("port/D"), netlist.getHierPortInstFromName("inter/mediate/port/D"));
+        Assertions.assertEquals(intermediate.getPortInst("port/C"), netlist.getHierPortInstFromName("inter/mediate/port/C"));
+        Assertions.assertEquals(intermediate.getPortInst("port/Q"), netlist.getHierPortInstFromName("inter/mediate/port/Q"));
+        Assertions.assertEquals(reg.getPortInst("D"), netlist.getHierPortInstFromName("inter/mediate/inst/asdf/D"));
+        Assertions.assertEquals(reg.getPortInst("C"), netlist.getHierPortInstFromName("inter/mediate/inst/asdf/C"));
+        Assertions.assertEquals(reg.getPortInst("Q"), netlist.getHierPortInstFromName("inter/mediate/inst/asdf/Q"));
+    }
+
+
+
+    SoftReference<EDIFNetlist> wrappedRegisterDesign = null;
+    private EDIFNetlist createWrappedRegisterDesign() {
+        //Make a hard reference before checking to avoid race condition!
+        EDIFNetlist netlist = wrappedRegisterDesign != null ? wrappedRegisterDesign.get() : null;
+        if (netlist == null) {
+            netlist = createEmptyNetlist();
+
+            final EDIFCell topCell = netlist.getTopCell();
+            final EDIFCell intermediate = new EDIFCell(netlist.getWorkLibrary(), "intermediate");
+
+            EDIFCellInst fdreInst = Design.createUnisimInst(intermediate, "inst/asdf", Unisim.FDRE);
+            final EDIFCellInst intermediateInst = intermediate.createCellInst("inter/mediate", topCell);
+
+            addFDREConnections(fdreInst, "");
+            addFDREConnections(intermediateInst, "port/");
+            wrappedRegisterDesign = new SoftReference<>(netlist);
+        }
+        return netlist;
     }
 }

--- a/test/com/xilinx/rapidwright/design/TestRelocation.java
+++ b/test/com/xilinx/rapidwright/design/TestRelocation.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class TestRelocation {
 
 
-    public static final String DEVICE_VERSAL = "xcvc1902";
-    public static final String DEVICE_ULTRASCALE = "xcvu3p";
+    private static final String DEVICE_VERSAL = "xcvc1902";
+    private static final String DEVICE_ULTRASCALE = "xcvu3p";
 
     private void testRelocateTile(Device device, String templateStr, String newAnchorStr, String oldAnchorStr, String expectedResultStr) {
         Tile template = device.getTile(templateStr);


### PR DESCRIPTION
Previously, `EDIFHierCellInst` stored all hierarchy as a single String. When we accessed hierarchy info, we had to re-parse the string every time. This PR replaces the internal representation of `EDIFHierCellInst` with an Array of `EDIFCellInst`.

This provides a speedup for `EDIFNetlist.getParentNetMap` while simultaneously decreasing memory usage. It also fixes #188.

This PR is dependent on #198. Github's view for this PR will include all of #198's diff until that one is merged. As #198 currently fails testing, this one does as well.