### PR TITLE
Gradle improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ sourceSets {
 
 test {
     useJUnitPlatform()
+    maxHeapSize = "5G"
 }
 
 tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,16 @@ sourceSets {
   }
 }
 
+//Kryo needs to access sun.nio.ch.DirectBuffer. This is forbidden by default in Java 16 and up. Check if we need to add a jvm arg.
+if (org.gradle.api.JavaVersion.current().isJava10Compatible()) {
+	applicationDefaultJvmArgs = ["--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"]
+}
+
 test {
     useJUnitPlatform()
     maxHeapSize = "5G"
+    //Propagate JVM settings to test JVM
+    jvmArgs applicationDefaultJvmArgs
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
* Increase Heap Limit in Unit tests from 512MB to 5GB. This should fix the failure on master.
* For newer Java Versions, apply the workaround identified by @gatecat in #190 to `run`, `install` and `test` tasks.