### PR TITLE
Introduce relocatable rectangle of tiles

### DIFF
--- a/src/com/xilinx/rapidwright/design/Port.java
+++ b/src/com/xilinx/rapidwright/design/Port.java
@@ -338,14 +338,13 @@ public class Port implements Serializable, Cloneable{
 		boundingBox = null;
 	}
 
-	TileRectangle boundingBox = null;
-	public TileRectangle getBoundingBox() {
+	RelocatableTileRectangle boundingBox = null;
+	public RelocatableTileRectangle getBoundingBox() {
 		if (boundingBox == null) {
-			TileRectangle.MutableRectangle mut = new TileRectangle.MutableRectangle();
+			boundingBox = new RelocatableTileRectangle();
 			for (SitePinInst sitePinInst : getSitePinInsts()) {
-				mut.extendTo(sitePinInst.getTile());
+				boundingBox.extendTo(sitePinInst.getTile());
 			}
-			boundingBox = mut.toImmutable().orElseThrow(()->new IllegalStateException("Cannot get Bounding Box of Port without Pins"));
 		}
 		return boundingBox;
 	}

--- a/src/com/xilinx/rapidwright/design/RelocatableTileRectangle.java
+++ b/src/com/xilinx/rapidwright/design/RelocatableTileRectangle.java
@@ -1,0 +1,250 @@
+package com.xilinx.rapidwright.design;
+
+import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.device.Tile;
+
+import java.util.Objects;
+import java.util.stream.Collector;
+
+/**
+ * A {@link TileRectangle} that is relocatable.
+ * <p>
+ * As padding tiles may be inserted when relocating Rectangles, we do not store coordinates of tiles but rather the
+ * tiles themselves. For every border (top/bottom/left/right) we save one example tile. When Relocation is not needed,
+ * use {@link SimpleTileRectangle} instead
+ */
+public class RelocatableTileRectangle extends TileRectangle {
+
+    private Tile minColumn;
+    private Tile maxColumn;
+    private Tile minRow;
+    private Tile maxRow;
+    private boolean empty = true;
+
+
+    public RelocatableTileRectangle(Tile tile) {
+        this.minColumn = tile;
+        this.maxColumn = tile;
+        this.minRow = tile;
+        this.maxRow = tile;
+        empty = false;
+    }
+
+    public RelocatableTileRectangle(Tile minColumn, Tile maxColumn, Tile minRow, Tile maxRow) {
+        this.minColumn = Objects.requireNonNull(minColumn);
+        this.maxColumn = Objects.requireNonNull(maxColumn);
+        this.minRow = Objects.requireNonNull(minRow);
+        this.maxRow = Objects.requireNonNull(maxRow);
+        empty = false;
+    }
+
+    public RelocatableTileRectangle() {
+    }
+
+    /**
+     * Collect a Stream&lt;Tile&gt; to a TileRectangle
+     *
+     * @return A Collector
+     */
+    public static Collector<Tile, ?, RelocatableTileRectangle> collector() {
+        return TileRectangle.collector(RelocatableTileRectangle::new, RelocatableTileRectangle::extendTo);
+    }
+
+    public static RelocatableTileRectangle of(Tile... tiles) {
+        final RelocatableTileRectangle result = new RelocatableTileRectangle();
+        for (Tile tile : tiles) {
+            result.extendTo(tile);
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RelocatableTileRectangle{" +
+                "minColumn=" + minColumn +
+                ", maxColumn=" + maxColumn +
+                ", minRow=" + minRow +
+                ", maxRow=" + maxRow +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RelocatableTileRectangle that = (RelocatableTileRectangle) o;
+        return minColumn.getColumn() == that.minColumn.getColumn()
+                && maxColumn.getColumn() == that.maxColumn.getColumn()
+                && minRow.getRow() == that.minRow.getRow()
+                && maxRow.getRow() == that.maxRow.getRow();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minColumn.getColumn(), maxColumn.getColumn(), minRow.getRow(), maxRow.getRow());
+    }
+
+    private Tile[][] minColumnArr;
+    private Tile[][] maxColumnArr;
+    private Tile[][] minRowArr;
+    private Tile[][] maxRowArr;
+
+
+    private String failedReloc(Tile template, Tile newAnchor, Tile originalAnchor, Tile[][] arr) {
+        //We try to find the name the new tile would have
+        int tileXOffset = template.getTileXCoordinate() - originalAnchor.getTileXCoordinate();
+        int tileYOffset = template.getTileYCoordinate() - originalAnchor.getTileYCoordinate();
+        int newTileX = newAnchor.getTileXCoordinate() + tileXOffset;
+        int newTileY = newAnchor.getTileYCoordinate() + tileYOffset;
+
+        String newName = template.getNameRoot()+"_X"+newTileX+"Y"+newTileY;
+
+
+        return "Failed to find corresponding tile \""+newName+"\" for "+template+" when relocating from "+originalAnchor+" to "+newAnchor+". Rect: "+ this;
+    }
+
+    public RelocatableTileRectangle getCorresponding(Tile newAnchor, Tile originalAnchor) {
+        if (minColumnArr == null) {
+            minColumnArr = newAnchor.getDevice().getTilesByNameRoot(minColumn.getNameRoot());
+            maxColumnArr = newAnchor.getDevice().getTilesByNameRoot(maxColumn.getNameRoot());
+            minRowArr = newAnchor.getDevice().getTilesByNameRoot(minRow.getNameRoot());
+            maxRowArr = newAnchor.getDevice().getTilesByNameRoot(maxRow.getNameRoot());
+        }
+
+        return new RelocatableTileRectangle(
+                Objects.requireNonNull(Module.getCorrespondingTile(minColumn, newAnchor, originalAnchor, minColumnArr), ()->failedReloc(minColumn, newAnchor, originalAnchor, minColumnArr)),
+                Objects.requireNonNull(Module.getCorrespondingTile(maxColumn, newAnchor, originalAnchor, maxColumnArr), ()->failedReloc(maxColumn, newAnchor, originalAnchor, maxColumnArr)),
+                Objects.requireNonNull(Module.getCorrespondingTile(minRow, newAnchor, originalAnchor, minRowArr), ()->failedReloc(minRow, newAnchor, originalAnchor, minRowArr)),
+                Objects.requireNonNull(Module.getCorrespondingTile(maxRow, newAnchor, originalAnchor, maxRowArr), ()->failedReloc(maxRow, newAnchor, originalAnchor, maxRowArr))
+        );
+    }
+
+
+    private void extendToRect(Tile otherMinX, Tile otherMaxX, Tile otherMinY, Tile otherMaxY) {
+        minColumnArr = null;
+        maxColumnArr = null;
+        minRowArr = null;
+        maxRowArr = null;
+        if (empty) {
+            minColumn = otherMinX;
+            maxColumn = otherMaxX;
+            minRow = otherMinY;
+            maxRow = otherMaxY;
+            empty = false;
+            return;
+        }
+
+        if (otherMinX.getColumn() < minColumn.getColumn()) {
+            minColumn = otherMinX;
+        }
+        if (otherMaxX.getColumn() > maxColumn.getColumn()) {
+            maxColumn = otherMaxX;
+        }
+        if (otherMinY.getRow() < minRow.getRow()) {
+            minRow = otherMinY;
+        }
+        if (otherMaxY.getRow() > maxRow.getRow()) {
+            maxRow = otherMaxY;
+        }
+    }
+
+    /**
+     * Extend the Rectangle so that the specified Tile is inside
+     *
+     * @param tile The tile to include
+     */
+    public void extendTo(Tile tile) {
+        extendToRect(tile, tile, tile, tile);
+    }
+
+    /**
+     * Extend the Rectangle so that the specified Rectangle is inside
+     *
+     * @param rect The Rectangle to include
+     */
+    public void extendTo(RelocatableTileRectangle rect) {
+        if (rect.empty) {
+            return;
+        }
+        extendToRect(rect.minColumn, rect.maxColumn, rect.minRow, rect.maxRow);
+    }
+
+
+    /**
+     * Extend the Rectangle so that a shifted tile is inside. The Tile is assumed to be located relative to some anchor.
+     * The anchor is shifted from {@code templateAnchor} to {@code currentAnchor}. This location relative to the new
+     * anchor is then included in the Rectangle.
+     *
+     * @param tile           tile to include after shifting
+     * @param currentAnchor  target anchor
+     * @param templateAnchor source anchor
+     */
+    public void extendToCorresponding(Tile tile, Site currentAnchor, SiteInst templateAnchor) {
+        Tile corresponding = Module.getCorrespondingTile(tile, currentAnchor.getTile(), templateAnchor.getTile());
+        extendToRect(
+                corresponding,
+                corresponding,
+                corresponding,
+                corresponding
+        );
+    }
+
+    /**
+     * Extend the Rectangle so that a shifted rectangle is inside. The Rectangle is assumed to be located relative to some anchor.
+     * The anchor is shifted from {@code templateAnchor} to {@code currentAnchor}. This location relative to the new
+     * anchor is then included in the Rectangle.
+     *
+     * @param rect           Rectangle to include after shifting
+     * @param currentAnchor  target anchor
+     * @param templateAnchor source anchor
+     */
+    @Override
+    public void extendToCorresponding(RelocatableTileRectangle rect, Site currentAnchor, SiteInst templateAnchor) {
+        extendToRect(
+                Objects.requireNonNull(Module.getCorrespondingTile(rect.minColumn, currentAnchor.getTile(), templateAnchor.getTile())),
+                Objects.requireNonNull(Module.getCorrespondingTile(rect.maxColumn, currentAnchor.getTile(), templateAnchor.getTile())),
+                Objects.requireNonNull(Module.getCorrespondingTile(rect.minRow, currentAnchor.getTile(), templateAnchor.getTile())),
+                Objects.requireNonNull(Module.getCorrespondingTile(rect.maxRow, currentAnchor.getTile(), templateAnchor.getTile()))
+        );
+    }
+
+    @Override
+    public int getMinRow() {
+        return minRow.getRow();
+    }
+
+    @Override
+    public int getMaxRow() {
+        return maxRow.getRow();
+    }
+
+    @Override
+    public int getMinColumn() {
+        return minColumn.getColumn();
+    }
+
+    @Override
+    public int getMaxColumn() {
+        return maxColumn.getColumn();
+    }
+
+    public boolean isEmpty() {
+        return empty;
+    }
+
+    public Tile getMinColumnTile() {
+        return minColumn;
+    }
+
+    public Tile getMaxColumnTile() {
+        return maxColumn;
+    }
+
+    public Tile getMinRowTile() {
+        return minRow;
+    }
+
+    public Tile getMaxRowTile() {
+        return maxRow;
+    }
+}

--- a/src/com/xilinx/rapidwright/design/SimpleTileRectangle.java
+++ b/src/com/xilinx/rapidwright/design/SimpleTileRectangle.java
@@ -1,0 +1,146 @@
+package com.xilinx.rapidwright.design;
+
+import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.device.Tile;
+
+import java.util.Objects;
+import java.util.stream.Collector;
+
+/**
+ * A {@link TileRectangle} that uses Row/Column indices for storage. Fast, but not relocatable.
+ */
+public class SimpleTileRectangle extends TileRectangle {
+    private int minColumn;
+    private int maxColumn;
+    private int minRow;
+    private int maxRow;
+    private boolean empty = true;
+
+    public SimpleTileRectangle() {
+    }
+
+    public SimpleTileRectangle(int minColumn, int maxColumn, int minRow, int maxRow) {
+        this.minColumn = minColumn;
+        this.maxColumn = maxColumn;
+        this.minRow = minRow;
+        this.maxRow = maxRow;
+        this.empty = false;
+    }
+
+    public SimpleTileRectangle(SimpleTileRectangle rect) {
+        this.minColumn = rect.minColumn;
+        this.maxColumn = rect.maxColumn;
+        this.minRow = rect.minRow;
+        this.maxRow = rect.maxRow;
+        this.empty = rect.empty;
+    }
+
+    public static Collector<Tile, ?, SimpleTileRectangle> collector() {
+        return TileRectangle.collector(SimpleTileRectangle::new, SimpleTileRectangle::extendTo);
+    }
+
+
+    private void extendToRect(int otherMinColumn, int otherMaxColumn, int otherMinRow, int otherMaxRow) {
+        if (empty) {
+            minColumn = otherMinColumn;
+            maxColumn = otherMaxColumn;
+            minRow = otherMinRow;
+            maxRow = otherMaxRow;
+            empty = false;
+            return;
+        }
+
+        if (otherMinColumn < minColumn) {
+            minColumn = otherMinColumn;
+        }
+        if (otherMaxColumn > maxColumn) {
+            maxColumn = otherMaxColumn;
+        }
+        if (otherMinRow < minRow) {
+            minRow = otherMinRow;
+        }
+        if (otherMaxRow > maxRow) {
+            maxRow = otherMaxRow;
+        }
+    }
+
+    /**
+     * Extend the Rectangle so that the specified Tile is inside
+     * @param tile The tile to include
+     */
+    @Override
+    public void extendTo(Tile tile) {
+        extendToRect(tile.getColumn(), tile.getColumn(), tile.getRow(), tile.getRow());
+    }
+
+    /**
+     * Extend the Rectangle so that the specified Rectangle is inside
+     * @param rect The Rectangle to include
+     */
+    @Override
+    public void extendTo(RelocatableTileRectangle rect) {
+        extendTo((TileRectangle) rect);
+    }
+
+    /**
+     * Extend the Rectangle so that the specified Rectangle is inside
+     * @param rect The Rectangle to include
+     */
+    public void extendTo(TileRectangle rect) {
+        if (rect.isEmpty()) {
+            return;
+        }
+        extendToRect(rect.getMinColumn(), rect.getMaxColumn(), rect.getMinRow(), rect.getMaxRow());
+    }
+
+    /**
+     * Extend the Rectangle so that a shifted rectangle is inside. The Rectangle is assumed to be located relative to some anchor.
+     * The anchor is shifted from {@code templateAnchor} to {@code currentAnchor}. This location relative to the new
+     * anchor is then included in the Rectangle.
+     * @param rect Rectangle to include after shifting
+     * @param currentAnchor target anchor
+     * @param templateAnchor source anchor
+     */
+    public void extendToCorresponding(RelocatableTileRectangle rect, Site currentAnchor, SiteInst templateAnchor) {
+        extendToRect(
+                Objects.requireNonNull(Module.getCorrespondingTile(rect.getMinColumnTile(), currentAnchor.getTile(), templateAnchor.getTile())).getColumn(),
+                Objects.requireNonNull(Module.getCorrespondingTile(rect.getMaxColumnTile(), currentAnchor.getTile(), templateAnchor.getTile())).getColumn(),
+                Objects.requireNonNull(Module.getCorrespondingTile(rect.getMinRowTile(), currentAnchor.getTile(), templateAnchor.getTile())).getRow(),
+                Objects.requireNonNull(Module.getCorrespondingTile(rect.getMaxRowTile(), currentAnchor.getTile(), templateAnchor.getTile())).getRow()
+        );
+    }
+
+    @Override
+    public int getMinColumn() {
+        return minColumn;
+    }
+
+    @Override
+    public int getMaxColumn() {
+        return maxColumn;
+    }
+
+    @Override
+    public int getMinRow() {
+        return minRow;
+    }
+
+    @Override
+    public int getMaxRow() {
+        return maxRow;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return empty;
+    }
+
+
+    public static SimpleTileRectangle of(Tile... tiles) {
+        final SimpleTileRectangle result = new SimpleTileRectangle();
+        for (Tile tile : tiles) {
+            result.extendTo(tile);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
The class TileRectangle I introduced in #166 was not relocatable. This PR adds the class `RelocatableTileRectangle` which stores references to the actual tiles and can therefore be relocated across the fabric.

This new class is slightly slower than the old one. If you don't need relocatability, the old one should still be used. Therefore, I kept it under the name `SimpleTileRectangle`.