### PR TITLE
Fix #238, replaces EDIFHierNet.toString() with hierarchical net name …

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1157,7 +1157,7 @@ public class EDIFNetlist extends EDIFName {
 	 * @return The physical/parent net name or null if none could be found.
 	 */
 	public String getParentNetName(String netAlias){
-		return getParentNetMap().get(getHierNetFromName(netAlias)).toString();
+		return getParentNetMap().get(getHierNetFromName(netAlias)).getHierarchicalNetName();
 	}
 	/**
 	 * Gets the canonical net for this net name.  This corresponds to the driving net


### PR DESCRIPTION
…representation.

Signed-off-by: Chris Lavin <clavin@xilinx.com>