### PR TITLE
add classes to dump site insts, edif or physical netlists as dot graphs

### DIFF
--- a/src/com/xilinx/rapidwright/debug/DotEdifDumper.java
+++ b/src/com/xilinx/rapidwright/debug/DotEdifDumper.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.xilinx.rapidwright.debug;
 
 import com.xilinx.rapidwright.edif.EDIFCell;

--- a/src/com/xilinx/rapidwright/debug/DotEdifDumper.java
+++ b/src/com/xilinx/rapidwright/debug/DotEdifDumper.java
@@ -1,0 +1,142 @@
+package com.xilinx.rapidwright.debug;
+
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFNet;
+import com.xilinx.rapidwright.edif.EDIFPort;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
+import com.xilinx.rapidwright.util.Pair;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Dump an EDIF cell's contents to a Graphviz Dot Graph
+ */
+public class DotEdifDumper extends DotGraphDumper<EDIFCellInst, EDIFPortInst, Pair<EDIFPort, Integer>, EDIFNet, EDIFCell> {
+    public DotEdifDumper() {
+        super(true);
+    }
+
+    public DotEdifDumper(boolean makeNetNode) {
+        super(makeNetNode);
+    }
+
+    @Override
+    protected Stream<EDIFCellInst> getInstances(EDIFCell top) {
+        return top.getCellInsts().stream();
+    }
+
+    @Override
+    protected Stream<EDIFPortInst> getPorts(EDIFCellInst edifCellInst) {
+        return edifCellInst.getPortInsts().stream();
+    }
+
+    @Override
+    protected Stream<Pair<EDIFPort,Integer>> getPortTemplates(EDIFCellInst edifCellInst) {
+        return edifCellInst.getCellType().getPorts().stream().flatMap(p-> {
+            if (p.isBus()) {
+                return Arrays.stream(p.getBitBlastedIndicies()).mapToObj(i -> new Pair<>(p, i));
+            }
+            return Stream.of(new Pair<>(p, 0));
+        });
+    }
+
+    @Override
+    protected Stream<EDIFNet> getNets(EDIFCell top) {
+        return top.getNets().stream();
+    }
+
+    @Override
+    protected Stream<EDIFPortInst> getNetPorts(EDIFNet edifNet) {
+        return edifNet.getPortInsts().stream();
+    }
+
+    @Override
+    protected boolean isOutputPort(EDIFPortInst edifPortInst) {
+        return edifPortInst.isOutput() ^ (edifPortInst.getCellInst() == null);
+    }
+
+    @Override
+    protected boolean isOutputPortTemplate(Pair<EDIFPort,Integer> port) {
+        return port.getFirst().isOutput();
+    }
+
+    @Override
+    protected String getInstanceName(EDIFCellInst edifCellInst) {
+        return edifCellInst.getName()+" ("+edifCellInst.getCellType()+")";
+    }
+
+    @Override
+    protected String getPortName(EDIFPortInst edifPortInst) {
+        return edifPortInst.getName();
+    }
+
+    @Override
+    protected String getPortTemplateName(Pair<EDIFPort,Integer> port) {
+        if (port.getFirst().getWidth()==1) {
+            return port.getFirst().getName();
+        }
+        return port.getFirst().getBusName()+"["+port.getSecond()+"]";
+    }
+
+    @Override
+    protected Stream<EDIFPortInst> getRootPorts(EDIFCell top) {
+        return top.getNets().stream().flatMap(n->n.getPortInsts().stream())
+                .filter(p->p.getCellInst() == null).distinct();
+    }
+
+    @Override
+    protected String getNetName(EDIFNet edifNet) {
+        return edifNet.getName();
+    }
+
+    @Override
+    protected Map<?, ?> getInstanceProperties(EDIFCellInst edifCellInst, EDIFCell top) {
+        return edifCellInst.getProperties();
+    }
+
+
+    /**
+     * Dump an edif cell to a file while filtering the cellInsts that are shown
+     * @param to the target file
+     * @param cell the cell to dump
+     * @param filter A function that filters the instances that are shown
+     */
+    public static void dump(Path to, EDIFCell cell, BiPredicate<EDIFCellInst, EDIFCell> filter) {
+        new DotEdifDumper().doDump(cell, to, filter);
+    }
+
+    /**
+     * Dump an edif cell to a file while filtering the cellInsts that are shown
+     * @param to the target file
+     * @param cell the cell to dump
+     * @param filter A function that filters the instances that are shown
+     */
+    public static void dump(Path to, EDIFCell cell, Predicate<EDIFCellInst> filter) {
+        dump(to, cell, (i, d)->filter.test(i));
+    }
+
+    /**
+     * Dump an edif cell to a file
+     * @param to the target file
+     * @param cell the cell to dump
+     */
+    public static void dump(Path to, EDIFCell cell) {
+        dump(to, cell, (BiPredicate<EDIFCellInst, EDIFCell>) null);
+    }
+
+    @Override
+    protected EDIFCellInst getPortInstance(EDIFPortInst port) {
+        return port.getCellInst();
+    }
+
+    @Override
+    protected EDIFNet getPortNet(EDIFPortInst p) {
+        return p.getNet();
+    }
+}

--- a/src/com/xilinx/rapidwright/debug/DotGraphDumper.java
+++ b/src/com/xilinx/rapidwright/debug/DotGraphDumper.java
@@ -1,0 +1,338 @@
+package com.xilinx.rapidwright.debug;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PrimitiveIterator;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public abstract class DotGraphDumper<InstanceT, PortT, PortTemplateT, NetT, DesignT> {
+    private final boolean makeNetNode;
+
+    protected DotGraphDumper(boolean makeNetNode) {
+        this.makeNetNode = makeNetNode;
+    }
+
+    /**
+     * Extend an existing filter to also output instances that connect to the ones that are shown
+     * @param initialFilter the filter to extend
+     * @return the extended filter
+     */
+    public BiPredicate<InstanceT, DesignT> extendFilterToConnected(BiPredicate<InstanceT, DesignT> initialFilter) {
+        Objects.requireNonNull(initialFilter);
+        return (i,design) -> {
+            if (initialFilter.test(i, design)) {
+                return true;
+            }
+
+            Stream<PortT> ports = i != null ? getPorts(i) : getRootPorts(design);
+
+            return ports
+                    .map(this::getPortNet)
+                    .flatMap(this::getNetPorts)
+                    .map(this::getPortInstance)
+                    .anyMatch(conn->initialFilter.test(conn, design));
+        };
+    }
+
+    /**
+     * Extend an existing filter to also output instances that connect to the ones that are shown
+     * @param initialFilter the filter to extend
+     * @return the extended filter
+     */
+    public BiPredicate<InstanceT, DesignT> extendFilterToConnected(Predicate<InstanceT> initialFilter) {
+        return extendFilterToConnected((i,d)->initialFilter.test(i));
+    }
+
+    protected abstract NetT getPortNet(PortT p);
+
+    protected abstract Stream<InstanceT> getInstances(DesignT design);
+    protected abstract Stream<PortT> getPorts(InstanceT instance);
+    protected abstract Stream<PortTemplateT> getPortTemplates(InstanceT instance);
+    protected abstract Stream<NetT> getNets(DesignT design);
+    protected abstract Stream<PortT> getNetPorts(NetT net);
+    protected abstract boolean isOutputPort(PortT port);
+    protected abstract boolean isOutputPortTemplate(PortTemplateT port);
+    protected abstract String getInstanceName(InstanceT instance);
+    protected abstract String getPortName(PortT port);
+    protected abstract String getPortTemplateName(PortTemplateT port);
+    protected abstract Stream<PortT> getRootPorts(DesignT design);
+    protected abstract String getNetName(NetT net);
+    protected abstract Map<?, ?> getInstanceProperties(InstanceT instance, DesignT design);
+    protected abstract InstanceT getPortInstance(PortT port);
+
+    private String escapeText(String s) {
+        return s.replaceAll("([\\\\\"<>])", "\\\\$1");
+    }
+    private String escapeHtml(String s) {
+        return s.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    }
+
+
+    private String formatPorts(List<PortT> ports, List<PortTemplateT> missingPorts, Map<PortT, String> portIds) {
+        Stream<String> actualPorts = ports.stream().map(p -> "<td border=\"1\" port=\"" + portIds.get(p) + "\">" + escapeHtml(getPortName(p)) + "</td>");
+        Stream<String> missingPortStream = missingPorts.stream().map(p -> "<td border=\"1\" bgcolor=\"gray\">" + escapeHtml("MISSING " + getPortTemplateName(p)) + "</td>");
+
+        String res = Stream.concat(actualPorts, missingPortStream)
+                .collect(Collectors.joining("\n"));
+        if (res.isEmpty()) {
+            return "<tr><td border=\"1\">&nbsp;</td></tr>";
+        }
+        return "<tr><td><table cellspacing=\"0\" cellpadding=\"0\" border=\"0\"><tr>\n"+res+"\n</tr></table></td></tr>";
+    }
+
+    private String replaceChars(String name) {
+        return name.replaceAll("[^0-9a-zA-Z_]","");
+    }
+    private Map<PortT, String> dumpInstance(PrintWriter pw, java.util.PrimitiveIterator.OfInt ids, InstanceT inst, DesignT design) {
+        String id = "inst_" +replaceChars(getInstanceName(inst))+"_"+ ids.next();
+
+
+        Map<Boolean, List<PortT>> partitioned = getPorts(inst)
+                .sorted(Comparator.comparing(this::getPortName))
+                .collect(Collectors.partitioningBy(this::isOutputPort));
+        List<PortT> inputs = partitioned.get(false);
+        List<PortT> outputs = partitioned.get(true);
+
+        Set<String> portNames = Stream.concat(inputs.stream(), outputs.stream())
+                .map(this::getPortName)
+                .collect(Collectors.toSet());
+
+        Map<Boolean, List<PortTemplateT>> partitionedTemplates = getPortTemplates(inst)
+                .sorted(Comparator.comparing(this::getPortTemplateName))
+                .filter(p -> !portNames.contains(getPortTemplateName(p)))
+                .collect(Collectors.partitioningBy(this::isOutputPortTemplate));
+
+        List<PortTemplateT> missingInputs = partitionedTemplates.get(false);
+        List<PortTemplateT> missingOutputs = partitionedTemplates.get(true);
+
+        Iterator<String> portIdIter = IntStream.iterate(0, i -> i + 1).mapToObj(Integer::toString).iterator();
+        Map<PortT, String> portIds = Stream.concat(inputs.stream(), outputs.stream())
+                .collect(Collectors.toMap(Function.identity(), p -> portIdIter.next()));
+
+
+        Stream<String> head = Stream.of(
+                formatPorts(inputs, missingInputs, portIds),
+                "<tr><td border=\"1\"><b>"+escapeHtml(getInstanceName(inst))+"</b></td></tr>"
+        );
+        Stream<String> props;
+        Map<?,?> propMap = getInstanceProperties(inst, design);
+        if (propMap == null) {
+            props = Stream.empty();
+        } else {
+            props = propMap
+                    .entrySet()
+                    .stream()
+                    .map(e -> "<tr><td border=\"1\">"+escapeHtml(e.getKey() + " -&gt; " + e.getValue())+"</td></tr>")
+                    .sorted();
+        }
+        Stream<String> tail = Stream.of(
+                formatPorts(outputs, missingOutputs, portIds)
+        );
+
+        String label = Stream.of(
+                head,
+                props,
+                tail
+        )
+                .flatMap(s->s)
+                .collect(Collectors.joining("\n","<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\">\n","\n</table>"));
+
+        pw.println(id+"[label=<\n"+label+">, shape=none];");
+
+
+        return portIds.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e->id+":"+e.getValue()));
+    }
+
+    private Map<PortT,String> dumpRootPins(PrintWriter pw, DesignT design, BiPredicate<InstanceT, DesignT> filter) {
+
+        Iterator<String> portIdIter = IntStream.iterate(0, i -> i + 1).mapToObj(i -> "rootPort" + i).iterator();
+        Map<PortT, String> portIds = getRootPorts(design)
+                .collect(Collectors.toMap(Function.identity(), p -> portIdIter.next()));
+
+
+        //Don't check filter if there are no root ports, filter may not expect that check
+        if (portIds.isEmpty() || !filter.test(null, design)) {
+            return new HashMap<>();
+        }
+
+
+        portIds.forEach((p,id)-> pw.println(id+"[label=\"ROOT PIN "+escapeText(getPortName(p))+"\"];"));
+        return portIds;
+    }
+
+    private Map<PortT, String> dumpCells(DesignT design, PrintWriter pw, BiPredicate<InstanceT, DesignT> filter) {
+        PrimitiveIterator.OfInt ids = IntStream.iterate(0, i -> i + 1).iterator();
+        Stream<InstanceT> instances = getInstances(design)
+                .filter(i->filter.test(i, design));
+        return instances
+                .map(inst -> dumpInstance(pw, ids, inst, design))
+                .reduce(dumpRootPins(pw, design, filter), (m, n) -> {m.putAll(n); return m;});
+    }
+
+    private List<PortT> getNetSources(NetT net) {
+        List<PortT> sources = getNetPorts(net).filter(this::isOutputPort).collect(Collectors.toList());
+        if (sources.size() > 1) {
+            System.err.println("multiple sources for "+net+": "+sources);
+        }
+        if (sources.isEmpty()) {
+            System.err.println("no source for "+net);
+        }
+        return sources;
+    }
+
+    private boolean netHasFilteredPorts(NetT net, DesignT design, BiPredicate<InstanceT, DesignT> filter) {
+        return filter!= null && !getNetPorts(net).map(this::getPortInstance).allMatch(i->filter.test(i, design));
+    }
+
+    private void dumpConnections(DesignT design, Map<PortT, String> portIds, PrintWriter pw, BiPredicate<InstanceT, DesignT> filter) {
+
+        Stream<NetT> nets = getNets(design)
+                .filter(n->getNetPorts(n).anyMatch(port->filter.test(getPortInstance(port), design)));
+
+        Iterator<String> netIdIter = IntStream.iterate(0, i -> i + 1).mapToObj(i -> "net" + i).iterator();
+        if (makeNetNode) {
+            dumpConnectionsNetNode(design, portIds, pw, filter, nets, netIdIter);
+        } else {
+            dumpConnectionsDirect(design, portIds, pw, filter, nets, netIdIter);
+        }
+
+    }
+
+    private void dumpConnectionsDirect(DesignT design, Map<PortT, String> portIds, PrintWriter pw, BiPredicate<InstanceT, DesignT> filter, Stream<NetT> nets, Iterator<String> netIdIter) {
+        nets
+                .forEach(net -> {
+                    List<String> sourceIDs = new ArrayList<>();
+                    List<String> sinkIDs = new ArrayList<>();
+
+                    int filteredOutSources = 0;
+                    int filteredOutSinks = 0;
+
+                    for (PortT port : (Iterable<PortT>) getNetPorts(net)::iterator) {
+                        boolean isSource = isOutputPort(port);
+                        boolean isShown = filter.test(getPortInstance(port), design);
+
+                        if (!isShown) {
+                            if (isSource) {
+                                filteredOutSources++;
+                            } else {
+                                filteredOutSinks++;
+                            }
+                        } else {
+                            String id = portIds.get(port);
+                            if (id == null) {
+                                id = netIdIter.next();
+                                pw.println(id + "[label=\"unknown port of " + escapeText(getNetName(net)) + "\"];");
+
+
+                                System.err.println("no id for port " + port + " in net " + net);
+                            }
+                            if (isSource) {
+                                sourceIDs.add(id);
+                            } else {
+                                sinkIDs.add(id);
+                            }
+                        }
+                    }
+
+
+                    if (sinkIDs.size() > 1 && sourceIDs.isEmpty() && filteredOutSources > 0) {
+                        //There are multiple sinks, but all sources are hidden. Let's add a source node
+                        String id = netIdIter.next();
+                        pw.println(id + "[label=\"hidden Source of " + escapeText(getNetName(net)) + "\"];");
+                        sourceIDs.add(id);
+                    }
+
+                    if (sourceIDs.size() > 1 && sinkIDs.isEmpty() && filteredOutSinks > 0) {
+                        //There are multiple sources, but all sinks are hidden. Let's add a sink node
+                        String id = netIdIter.next();
+                        pw.println(id + "[label=\"hidden Sink of " + escapeText(getNetName(net)) + "\", style=\"dashed\"];");
+                        sinkIDs.add(id);
+                    }
+
+                    for (String sourceID : sourceIDs) {
+                        for (String sinkID : sinkIDs) {
+                            pw.println(sourceID + " -> " + sinkID + ";");
+                        }
+                    }
+
+                });
+    }
+
+    private void dumpConnectionsNetNode(DesignT design, Map<PortT, String> portIds, PrintWriter pw, BiPredicate<InstanceT, DesignT> filter, Stream<NetT> nets, Iterator<String> netIdIter) {
+        nets
+                .forEach(net -> {
+                    String nid = netIdIter.next();
+                    boolean hasFilteredPorts = netHasFilteredPorts(net, design, filter);
+                    String filterSuffix = hasFilteredPorts ? ", style=\"dashed\"" : "";
+                    pw.println(nid+"[label=\"NET "+escapeText(getNetName(net))+"\""+filterSuffix+"];");
+
+                    getNetPorts(net)
+                            .filter(p-> filter.test(getPortInstance(p), design))
+                            .forEach(port -> {
+                        String pid = portIds.get(port);
+                        if (pid == null) {
+                            System.err.println("no id for port "+port+" in "+net);
+                        } else {
+                            if (isOutputPort(port)) {
+                                pw.println(pid + " -> " + nid);
+                            } else {
+                                pw.println(nid + " -> " + pid);
+                            }
+                        }
+                    });
+
+                });
+    }
+
+    /**
+     * Dump the design to a PrintWriter. Optionally filter the instances shown
+     * @param design the design to dump
+     * @param pw the PrintWriter to output to
+     * @param filter A function that filters the instances that are shown. Pass null to show everything
+     */
+    public void doDump(DesignT design, PrintWriter pw, BiPredicate<InstanceT, DesignT> filter) {
+
+        if (filter == null) {
+            filter = (i,d) -> true;
+        }
+
+        pw.println("digraph G {");
+
+        Map<PortT, String> portIds = dumpCells(design, pw, filter);
+
+        dumpConnections(design, portIds, pw, filter);
+
+        pw.println("}");
+    }
+
+    /**
+     * Dump the design to a file. Optionally filter the instances shown
+     * @param design the design to dump
+     * @param output the target file
+     * @param filter A function that filters the instances that are shown. Pass null to show everything
+     */
+    public void doDump(DesignT design, Path output, BiPredicate<InstanceT, DesignT> filter) {
+        try(PrintWriter pw = new PrintWriter(Files.newBufferedWriter(output))) {
+            doDump(design, pw, filter);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}
+

--- a/src/com/xilinx/rapidwright/debug/DotGraphDumper.java
+++ b/src/com/xilinx/rapidwright/debug/DotGraphDumper.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2021 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.xilinx.rapidwright.debug;
 
 import java.io.IOException;

--- a/src/com/xilinx/rapidwright/debug/DotPhysicalDumper.java
+++ b/src/com/xilinx/rapidwright/debug/DotPhysicalDumper.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2021 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.xilinx.rapidwright.debug;
 
 import com.xilinx.rapidwright.design.Design;

--- a/src/com/xilinx/rapidwright/debug/DotPhysicalDumper.java
+++ b/src/com/xilinx/rapidwright/debug/DotPhysicalDumper.java
@@ -1,0 +1,134 @@
+package com.xilinx.rapidwright.debug;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.design.SitePinInst;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Dump a Design's physical representation to a Graphviz Dot Graph
+ */
+public class DotPhysicalDumper extends DotGraphDumper<SiteInst, SitePinInst, Void, Net, Design> {
+
+    public DotPhysicalDumper() {
+        super(true);
+    }
+
+    public DotPhysicalDumper(boolean makeNetNode) {
+        super(makeNetNode);
+    }
+
+    @Override
+    protected Stream<SiteInst> getInstances(Design design) {
+        return design.getSiteInsts().stream();
+    }
+
+    @Override
+    protected Stream<SitePinInst> getPorts(SiteInst siteInst) {
+        return siteInst.getSitePinInsts().stream();
+    }
+
+    @Override
+    protected Stream<Void> getPortTemplates(SiteInst siteInst) {
+        return Stream.empty();
+    }
+
+    @Override
+    protected Stream<Net> getNets(Design design) {
+        return design.getNets().stream().filter(n->n.getPins().size()>0);
+    }
+
+    @Override
+    protected Stream<SitePinInst> getNetPorts(Net net) {
+        return net.getPins().stream();
+    }
+
+    @Override
+    protected boolean isOutputPort(SitePinInst sitePinInst) {
+        return sitePinInst.isOutPin();
+    }
+
+    @Override
+    protected boolean isOutputPortTemplate(Void port) {
+        throw new IllegalStateException("Does not have templates");
+    }
+
+    @Override
+    protected String getInstanceName(SiteInst si) {
+        return si.getName();
+    }
+
+    @Override
+    protected String getPortName(SitePinInst sitePinInst) {
+        return sitePinInst.getName();
+    }
+
+    @Override
+    protected String getPortTemplateName(Void port) {
+        throw new IllegalStateException("Does not have templates");
+    }
+
+    @Override
+    protected Stream<SitePinInst> getRootPorts(Design design) {
+        return Stream.empty();
+    }
+
+    @Override
+    protected String getNetName(Net net) {
+        return net.getName();
+    }
+
+    @Override
+    protected Map<?, ?> getInstanceProperties(SiteInst siteInst, Design design) {
+        return siteInst.getCells().stream().distinct().collect(Collectors.toMap(Function.identity(), x->""));
+    }
+
+
+
+    /**
+     * Dump a physical netlist to a file while filtering the SiteInsts that are shown
+     * @param to the target file
+     * @param design the design to dump
+     * @param filter A function that filters the instances that are shown
+     */
+    public static void dump(Path to, Design design, BiPredicate<SiteInst, Design> filter) {
+        new DotPhysicalDumper().doDump(design, to, filter);
+    }
+
+    /**
+     * Dump a physical netlist to a file while filtering the SiteInsts that are shown
+     * @param to the target file
+     * @param design the design to dump
+     * @param filter A function that filters the instances that are shown
+     */
+    public static void dump(Path to, Design design,Predicate<SiteInst> filter) {
+        dump(to, design, (i, d)->filter.test(i));
+    }
+
+    /**
+     * Dump a physical netlist to a file
+     * @param to the target file
+     * @param design the design to dump
+     */
+    public static void dump(Path to, Design design) {
+        dump(to, design, (BiPredicate<SiteInst, Design>) null);
+    }
+
+    @Override
+    protected SiteInst getPortInstance(SitePinInst port) {
+        return port.getSiteInst();
+    }
+
+    @Override
+    protected Net getPortNet(SitePinInst p) {
+        return p.getNet();
+    }
+}

--- a/src/com/xilinx/rapidwright/debug/DotSiteDumper.java
+++ b/src/com/xilinx/rapidwright/debug/DotSiteDumper.java
@@ -1,0 +1,210 @@
+package com.xilinx.rapidwright.debug;
+
+import com.xilinx.rapidwright.design.Cell;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.BELPin;
+import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.util.Pair;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Dump BELs and connections from a single Site or SiteInst to a Graphviz Dot Graph
+ */
+public class DotSiteDumper extends DotGraphDumper<BEL, BELPin, BELPin, List<BELPin>, SiteInst>{
+
+    private static class SiteNets {
+        private final List<List<BELPin>> nets;
+        private final Map<BELPin, List<BELPin>> pinToNet;
+
+        private SiteNets(List<List<BELPin>> nets, Map<BELPin, List<BELPin>> pinToNet) {
+            this.nets = nets;
+            this.pinToNet = pinToNet;
+        }
+
+        private static Stream<List<BELPin>> toConnections(BELPin pin) {
+            if (!pin.isOutput()) {
+                return Stream.empty();
+            }
+            final List<BELPin> net = Stream.concat(Stream.of(pin), pin.getSiteConns().stream()).collect(Collectors.toList());
+            return Stream.of(net);
+        }
+
+        public static SiteNets computeSiteNets(Site site) {
+            final List<List<BELPin>> nets = Arrays.stream(site.getBELs())
+                    .flatMap(b -> Arrays.stream(b.getPins()))
+                    .flatMap(SiteNets::toConnections)
+                    .filter(n -> n.size() > 1)
+                    .collect(Collectors.toList());
+
+            final Map<BELPin, List<BELPin>> pinToNet = nets.stream()
+                    .flatMap(net -> net.stream().map(pin -> new Pair<>(pin, net)))
+                    .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond));
+            return new SiteNets(nets, pinToNet);
+        }
+    }
+
+    public DotSiteDumper() {
+        super(false);
+    }
+
+    public DotSiteDumper(boolean makeNetNode) {
+        super(makeNetNode);
+    }
+
+    private final Map<Site, SiteNets> netCache = new HashMap<>();
+
+
+    private SiteNets getSiteInfo(Site site) {
+        return netCache.computeIfAbsent(site, SiteNets::computeSiteNets);
+    }
+
+    @Override
+    protected Stream<BEL> getInstances(SiteInst design) {
+        return Arrays.stream(design.getBELs());
+    }
+
+    @Override
+    protected Stream<BELPin> getPorts(BEL instance) {
+        return Arrays.stream(instance.getPins());
+    }
+
+    @Override
+    protected Stream<BELPin> getPortTemplates(BEL instance) {
+        return Arrays.stream(instance.getPins());
+    }
+
+    @Override
+    protected Stream<List<BELPin>> getNets(SiteInst design) {
+        return getSiteInfo(design.getSite()).nets.stream();
+    }
+
+    @Override
+    protected Stream<BELPin> getNetPorts(List<BELPin> net) {
+        return net.stream();
+    }
+
+    @Override
+    protected boolean isOutputPort(BELPin port) {
+        return port.isOutput();
+    }
+
+    @Override
+    protected boolean isOutputPortTemplate(BELPin port) {
+        return port.isOutput();
+    }
+
+    @Override
+    protected String getInstanceName(BEL instance) {
+        return instance.getName();
+    }
+
+    @Override
+    protected String getPortName(BELPin port) {
+        return port.getName();
+    }
+
+    @Override
+    protected String getPortTemplateName(BELPin port) {
+        return port.getName();
+    }
+
+    @Override
+    protected Stream<BELPin> getRootPorts(SiteInst design) {
+        return Stream.empty();
+    }
+
+    @Override
+    protected String getNetName(List<BELPin> net) {
+        return net.get(0).getSiteWireName();
+    }
+
+    @Override
+    protected Map<?, ?> getInstanceProperties(BEL instance, SiteInst design) {
+        final Cell cell = design.getCell(instance);
+        if (cell == null) {
+            return null;
+        }
+        return cell.getProperties();
+    }
+
+    private static SiteInst makeDummySiteInst(Site site) {
+        SiteInst dummy = new SiteInst("", site.getSiteTypeEnum());
+        dummy.place(site);
+        return dummy;
+    }
+
+
+    /**
+     * Dump a SiteInst to a file while filtering the cellInsts that are shown
+     * @param to the target file
+     * @param siteInst the siteInst to dump
+     * @param filter A function that filters the bels that are shown
+     */
+    public static void dump(Path to, SiteInst siteInst, BiPredicate<BEL, SiteInst> filter) {
+        new DotSiteDumper().doDump(siteInst, to, filter);
+    }
+    /**
+     * Dump a SiteInst to a file while filtering the cellInsts that are shown
+     * @param to the target file
+     * @param siteInst the siteInst to dump
+     * @param filter A function that filters the bels that are shown
+     */
+    public static void dump(Path to, SiteInst siteInst, Predicate<BEL> filter) {
+        dump(to, siteInst, (bel, si) -> filter.test(bel));
+    }
+    /**
+     * Dump a SiteInst to a file
+     * @param to the target file
+     * @param siteInst the siteInst to dump
+     */
+    public static void dump(Path to, SiteInst siteInst) {
+        dump(to, siteInst, (BiPredicate<BEL, SiteInst>) null);
+    }
+
+    /**
+     * Dump a Site to a file while filtering the cellInsts that are shown
+     * @param to the target file
+     * @param site the Site to dump
+     * @param filter A function that filters the bels that are shown
+     */
+    public static void dump(Path to, Site site, BiPredicate<BEL, SiteInst> filter) {
+        new DotSiteDumper().doDump(makeDummySiteInst(site), to, filter);
+    }
+    /**
+     * Dump a Site to a file while filtering the cellInsts that are shown
+     * @param to the target file
+     * @param site the Site to dump
+     * @param filter A function that filters the bels that are shown
+     */
+    public static void dump(Path to, Site site, Predicate<BEL> filter) {
+        dump(to, site, (bel, si) -> filter.test(bel));
+    }
+    /**
+     * Dump a Site to a file
+     * @param to the target file
+     * @param site the Site to dump
+     */
+    public static void dump(Path to, Site site) {
+        dump(to, site, (BiPredicate<BEL, SiteInst>) null);
+    }
+
+    @Override
+    protected BEL getPortInstance(BELPin port) {
+        return port.getBEL();
+    }
+
+    @Override
+    protected List<BELPin> getPortNet(BELPin p) {
+        return p.getSiteConns();
+    }
+}

--- a/src/com/xilinx/rapidwright/debug/DotSiteDumper.java
+++ b/src/com/xilinx/rapidwright/debug/DotSiteDumper.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2021 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.xilinx.rapidwright.debug;
 
 import com.xilinx.rapidwright.design.Cell;


### PR DESCRIPTION
This adds classes to dump our different representations of designs as Graphviz Dot graphs. Their output has already been very useful to me in diagnosing problems. There are classes to dump these representations:

* EDIF Cells
* Physical Netlists
* SiteInsts

Instances can be filtered to limit the generated graphs to the area of interest.