### PR TITLE
CI to use JDK11 (but still target 8) to be compat with capnproto jar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           submodules: recursive
       - uses: gradle/wrapper-validation-action@v1.0.4
-      - name: Setup JDK 1.8
+      - name: Setup JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 1.11
 
 
       - name: Cache Jars & Data


### PR DESCRIPTION
Necessary for #253.