### PR TITLE
gitmodules: fix URL to RapidWrightDCP to avoid permission issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "RapidWrightDCP"]
 	path = RapidWrightDCP
-	url = git@github.com:eddieh-xlnx/RapidWrightDCP
+	url = https://github.com/eddieh-xlnx/RapidWrightDCP.git


### PR DESCRIPTION
This changes the submodule SSH-formatted URL into the HTTPS format to avoid lack of permission error generated while initializing the submodule.