### PR TITLE
gradle: add group and description to update_jars task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 }
 
 abstract class UpdateJarsTask extends DefaultTask {
+    UpdateJarsTask() {
+        group = "build setup"
+        description = "Download Jar Dependencies"
+    }
     @TaskAction
     def updateJars() {
     	def f = new File('rapidwright-installer.jar')


### PR DESCRIPTION
This makes the update_jars task visible in Gradle's task list (can be viewed by running `./gradlew tasks`).