### PR TITLE
make: update jars: link from var to prevent API call limit 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ JARFILES = $(shell find `pwd`/jars -name '*.jar' | egrep -v 'javadoc|win64' | tr
 SOURCES := $(shell find ./src -name '*.java'  )
 CLASSES := $(shell find ./src -name '*.java' | grep -v package-info.java | sed 's=^./src=./bin=' | sed 's/.java$$/.class/')
 
+JARS_LINK ?= $(shell curl -s https://api.github.com/repos/Xilinx/RapidWright/releases/latest | grep "browser_download_url.*_jars.zip" | cut -d : -f 2,3 | tr -d \")
+
 .PHONY: compile update_jars
 compile: $(CLASSES)
 $(CLASSES): $(SOURCES) $(JARFILES)
@@ -17,7 +19,7 @@ $(CLASSES): $(SOURCES) $(JARFILES)
 
 update_jars:
 	rm -rf jars
-	curl -s https://api.github.com/repos/Xilinx/RapidWright/releases/latest | grep "browser_download_url.*_jars.zip" | cut -d : -f 2,3 | tr -d \" | wget -qi -
+	echo $(JARS_LINK) | wget -qi -
 	unzip rapidwright_jars.zip
 	rm jars/qtjambi-win64-msvc2005x64-4.5.2_01.jar rapidwright_jars.zip
 	make -C . compile


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

There is a limit of calls to the GH API to get the jars' link. This results in failures while running a CI system that spawns several jobs that do require updating the jars.

This can be overcome by providing the link externally, which can be generated once for all the jobs that do require it, thus preventing reaching the API call limit.