### PR TITLE
Adding convenience methods to EDIFPort to get internal nets

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -27,6 +27,8 @@ package com.xilinx.rapidwright.edif;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Represents a port on an {@link EDIFCell} within an EDIF netlist.
@@ -167,6 +169,54 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
 		int rightBracket = getName().lastIndexOf(']');
 		int colon = getName().lastIndexOf(':');
 		return Integer.parseInt(getName().substring(colon+1, rightBracket));
+	}
+	
+	/**
+	 * Gets the list of internal nets connected to this port, indexed in the same way as the port.
+	 * A single bit port will only have one entry in the list, for example. 
+	 * @return The list of internal nets connected to this port.  If one or more bits is not 
+	 * connected (such as in a primitive cell), a null entry will be present at the corresponding 
+	 * index.
+	 */
+	public List<EDIFNet> getInternalNets(){
+	    List<EDIFNet> nets = new ArrayList<>(width);
+	    for(int i=0; i < width; i++) {
+	        nets.add(getInternalNet(i));
+	    }
+	    return nets;
+	}
+	
+	/**
+	 * Gets the internal net connected to this port at specified index of the port,
+	 * connected to the inside of the cell.  
+	 * @param index Index of port (0 if it is a single bit) 
+	 * @return The internal net connect to this port or null if not connect (such as a primitive).
+	 */
+	public EDIFNet getInternalNet(int index) {
+	    return parentCell.getInternalNet(getPortInstNameFromPort(index));
+	}
+	
+	/**
+	 * If the port is only one bit wide or the user only needs the 0th indexed net, this is
+	 * a convenience method to getting the internal net (inside the cell) connected to this port.  
+	 * @return The internal net connected to this port (single bit or 0th index only), 
+	 * or null if not connected (such as a primitive).
+	 */
+	public EDIFNet getInternalNet() {
+	    return getInternalNet(0);
+	}
+	
+	/**
+	 * Gets the PortInst name from this port and the specified index
+	 * @param index The index to get from the port 
+	 * @return The name of the PortInst for the specified index
+	 */
+	public String getPortInstNameFromPort(int index) {
+	    if(!isBus()) return getBusName();
+	    if(isLittleEndian()){
+	        index = (getWidth()-1) - index;
+	    }
+	    return getBusName() + "[" + index + "]";     
 	}
 	
 	public void exportEDIF(Writer wr, String indent) throws IOException{

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -111,12 +111,7 @@ public class EDIFPortInst {
 	}
 	
 	protected String getPortInstNameFromPort(){
-		if(!port.isBus()) return port.getBusName();
-		int idx = index;
-		if(port.isLittleEndian()){
-			idx = (port.getWidth()-1) - idx;
-		}
-		return port.getBusName() + "[" + idx + "]";
+		return port.getPortInstNameFromPort(index);
 	}
 	
 	public String getName(){

--- a/test/com/xilinx/rapidwright/edif/TestEDIFPort.java
+++ b/test/com/xilinx/rapidwright/edif/TestEDIFPort.java
@@ -1,0 +1,46 @@
+package com.xilinx.rapidwright.edif;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestEDIFPort {
+
+    @Test    
+    public void testEDIFPortInternalNets() {
+        Design design = Design.readCheckpoint(RapidWrightDCP.getPath("picoblaze_ooc_X10Y235.dcp"));
+        
+        for(EDIFLibrary lib : design.getNetlist().getLibraries()) {
+            for(EDIFCell cell : lib.getCells()) {
+                boolean isLeaf = cell.isLeafCellOrBlackBox();
+                Map<String,EDIFNet> internalNetMap = cell.getInternalNetMap();
+                for(EDIFPort port : cell.getPorts()) {
+                   if(port.isBus()) {
+                       List<EDIFNet> nets = port.getInternalNets();                      
+                       for(int i=0; i < port.getWidth(); i ++) {
+                           EDIFNet net = nets.get(i);
+                           Assertions.assertEquals(port.getInternalNet(i), nets.get(i));
+                           String portInstName = port.getPortInstNameFromPort(i);
+                           Assertions.assertEquals(internalNetMap.get(portInstName), net);
+                           if(isLeaf) {
+                               Assertions.assertNull(net);
+                           }
+                       }
+                   }else {
+                       EDIFNet net = port.getInternalNet();
+                       String portInstName = port.getPortInstNameFromPort(0);
+                       Assertions.assertEquals(internalNetMap.get(portInstName), net);
+                       if(isLeaf) {
+                           Assertions.assertNull(net);
+                       }
+                   }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Chris Lavin <clavin@xilinx.com>