### PR TITLE
Test routethru PIPs do not appear as sink pins

### DIFF
--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -9,6 +9,7 @@ import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -86,5 +87,17 @@ public class TestDesign {
         design = Design.readCheckpoint(filenameRead);
         mi = design.getModuleInst("inst");
         Assertions.assertEquals(oldAnchor, mi.getAnchor().toString());
+    }
+
+    @Test
+    @CheckOpenFiles
+    public void testRouteThruPIPsSitePinInsts() {
+        final String inputPath = RapidWrightDCP.getString("routethru_pip.dcp");
+        Design design = Design.readCheckpoint(inputPath);
+
+        Net net = design.getNet("CO3_OBUF");
+        for (SitePinInst spi : net.getSinkPins()) {
+            Assertions.assertTrue(spi.getSite().isInputPin(spi.getName()));
+        }
     }
 }


### PR DESCRIPTION
It appears that on Series 7 (but not UltraScale+) Vivado chooses to emit a route that has COUT as the driver, and then uses a COUT -> DMUX route thru PIP in order to exit onto the general fabric.

In this case, RapidWright incorrectly recognizes the DMUX as a sink pin. Test for this here, fix expected to appear in an upcoming release.