### PR TITLE
Test secondary source pins created correctly

### DIFF
--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import com.xilinx.rapidwright.support.CheckOpenFiles;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Site;
@@ -86,5 +87,21 @@ public class TestDesign {
         design = Design.readCheckpoint(filenameRead);
         mi = design.getModuleInst("inst");
         Assertions.assertEquals(oldAnchor, mi.getAnchor().toString());
+    }
+
+    @Test
+    @CheckOpenFiles
+    public void testDcpSecondarySourcePins() {
+        final String inputPath = RapidWrightDCP.getString("ramb18.dcp");
+        Design design = Design.readCheckpoint(inputPath);
+
+        for (int i = 0; i < 18; i++) {
+            Net net = design.getNet("r/U0/inst_blk_mem_gen/gnbram.gnativebmg.native_blk_mem_gen/valid.cstr/ramloop[0].ram.r/prim_noinit.ram/douta[" + i + "]");
+            SitePinInst spi = net.getSource();
+            if (i == 8 || i == 17)
+                Assertions.assertEquals("DOPADOP" + i/9, spi.getName());
+            else
+                Assertions.assertEquals("DOADO" + (i - i/9), spi.getName());
+        }
     }
 }


### PR DESCRIPTION
On Series 7, secondary site types (e.g. RAMB18) can have differently named pins than primary site types (e.g. FIFO18) and thus `Design.readCheckpoint` should be mindful of that. RapidWright currently handles this correctly for sink pins, but not for source pins.

This issue (at least for RAM/FIFO sites) does not appear to be an issue on UltraScale+.

Test for this here, fix expected to appear in an upcoming release.