### PR TITLE
Refactor gradle to facilitate other gradle parents

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   RAPIDWRIGHT_VERSION: v2021.2.0-beta
+  RAPIDWRIGHT_PATH: ${{ github.workspace }}
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   RAPIDWRIGHT_VERSION: v2021.2.0-beta
-  RAPIDWRIGHT_PATH: ${{ github.workspace }}
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -17,20 +17,6 @@ def get_rapidwright_version_line = file('.github/workflows/build.yml').filterLin
 def rapidwright_version = sw.toString().replace("RAPIDWRIGHT_VERSION: v", "").replace("-beta", "").trim()
 
 dependencies {
-    api 'com.esotericsoftware:kryo:5.2.1'
-    api 'org.jgrapht:jgrapht-core:1.3.0'
-    api 'org.capnproto:runtime:0.1.13'
-    api 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    api 'org.python:jython-standalone:2.7.2'
-    api 'com.google.protobuf:protobuf-java:3.11.4'
-    api 'org.jetbrains:annotations:20.1.0'
-    api 'org.zeromq:jeromq:0.5.2'
-    api 'commons-cli:commons-cli:1.2'
-    api 'org.json:json:20160810'
-    api 'com.jcraft:jzlib:1.1.3'
-    api 'commons-io:commons-io:2.11.0'
-    api 'com.xilinx.rapidwright:qtjambi-'+os+':4.5.2_01'
-    api 'com.xilinx.rapidwright:jupyter-kernel-jsr223:1.0.0'
     api 'com.xilinx.rapidwright:rapidwright-api-lib:' + rapidwright_version
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,12 @@
-import java.util.stream.Collectors
-
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'application'
-    id 'java-library'
     id 'signing'
 }
 
+apply from: 'common.gradle'
 
 mainClassName = "com.xilinx.rapidwright.MainEntrypoint"
-
-def os = System.getProperty("os.name").toLowerCase().contains("windows") ?
-                                       "win64-msvc2005x64" : "linux64-gcc"
-def sw = new StringWriter()
-def get_rapidwright_version_line = new File('.github/workflows/build.yml').filterLine(sw) { 
-    line -> line.contains('RAPIDWRIGHT_VERSION:') 
-}
-def rapidwright_version = sw.toString().replace("RAPIDWRIGHT_VERSION: v", "").replace("-beta", "").trim()
-
-
-configurations.implementation.canBeResolved = true
-configurations.testImplementation.canBeResolved = true
-configurations.api.canBeResolved = true
 
 sourceSets {
   main {
@@ -38,9 +22,13 @@ sourceSets {
   }
 }
 
-repositories {
-    mavenCentral()
+def os = System.getProperty("os.name").toLowerCase().contains("windows") ?
+                                       "win64-msvc2005x64" : "linux64-gcc"
+def sw = new StringWriter()
+def get_rapidwright_version_line = file('.github/workflows/build.yml').filterLine(sw) { 
+    line -> line.contains('RAPIDWRIGHT_VERSION:') 
 }
+def rapidwright_version = sw.toString().replace("RAPIDWRIGHT_VERSION: v", "").replace("-beta", "").trim()
 
 dependencies {
     api 'com.esotericsoftware:kryo:5.2.1'
@@ -58,29 +46,7 @@ dependencies {
     api 'com.xilinx.rapidwright:qtjambi-'+os+':4.5.2_01'
     api 'com.xilinx.rapidwright:jupyter-kernel-jsr223:1.0.0'
     api 'com.xilinx.rapidwright:rapidwright-api-lib:' + rapidwright_version
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'
 }
-
-//Kryo needs to access sun.nio.ch.DirectBuffer. This is forbidden by default in Java 16 and up. Check if we need to add a jvm arg.
-if (org.gradle.api.JavaVersion.current().isJava10Compatible()) {
-	applicationDefaultJvmArgs = ["--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"]
-}
-
-tasks.withType(Test) {
-  maxHeapSize = "5G"
-  //Propagate JVM settings to test JVM
-  jvmArgs applicationDefaultJvmArgs
-  environment 'RAPIDWRIGHT_PATH',file('.')
-  //We need to rerun tests when the data files change
-  if (file('data').exists()) {
-    inputs.dir file('data')
-  }
-}
-
-sourceCompatibility = 8
-targetCompatibility = 8
 
 task copyJars(type: Copy) {
     from configurations.implementation
@@ -123,6 +89,7 @@ task javadocJar(type: Jar) {
     from javadoc
     archiveClassifier = rapidwright_version + "-javadoc"
 }
+
 task standaloneJar (type: Jar) {
     duplicatesStrategy = DuplicatesStrategy.WARN
     manifest {
@@ -132,6 +99,7 @@ task standaloneJar (type: Jar) {
     from { configurations.implementation.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
+
 artifacts {
     archives javadocJar
     archives sourceJar
@@ -188,77 +156,5 @@ signing {
     }
     sign configurations.archives
     sign publishing.publications.mavenJava
-}
-
-task testJava(type:Test) {
-  group = "verification"
-  description = "Runs the Java unit tests."
-
-  useJUnitPlatform()
-}
-
-task testPython(type:Test) {
-  group = "verification"
-  description = "Runs the Python unit tests."
-  doFirst {
-    // Necessary because gradle will try and match against Java tests
-    filter.setFailOnNoMatchingTests(false)
-  }
-  doLast {
-    exec {
-      environment 'CLASSPATH', sourceSets.main.runtimeClasspath.getAsPath()
-      executable = 'python3'
-      args = ['-m', 'pytest', '--junitxml', "$buildDir/test-results/testPython/testPython.xml", '--rootdir', 'python/test']
-      // Enable verbose flag which prints out a pass/fail for every test
-      args += ['-v']
-      // Prevent python/tests/... with the same namespace as in Java from clobbering
-      args += ['--import-mode=importlib']
-      // Workaround from https://github.com/jpype-project/jpype/issues/842#issuecomment-847027355
-      args += ['-p', 'no:faulthandler']
-      if (!filter.commandLineIncludePatterns.isEmpty()) {
-        args += ['--pyargs'] + filter.commandLineIncludePatterns.stream().map((p) -> 'python.test.' + p).collect(Collectors.toList())
-      }
-    }
-  }
-}
-
-test {
-  dependsOn testJava
-  dependsOn testPython
-}
-
-gradle.taskGraph.whenReady {
-  if (!project.test.filter.commandLineIncludePatterns.isEmpty()) {
-    throw new InvalidUserDataException("'test' task does not support filters (i.e. '--tests' option); please apply filters directly to 'testJava'/'testPython' tasks instead.")
-  }
-}
-
-task updateSubmodules(type:Exec) {
-  group = "build setup"
-  description = "Update Git submodules"
-  executable = 'git'
-  args = ['submodule', 'update', '--init', '--recursive']
-}
-
-task initSubmodules {
-  group = "build setup"
-  description = "Init Git submodules (first time only)"
-  if (!file("test/RapidWrightDCP/.git").exists()) {
-    dependsOn updateSubmodules
-  }
-}
-
-task remindSubmodules {
-  onlyIf {
-    testJava.state.failure != null || testPython.state.failure != null
-  }
-  doLast {
-    logger.warn('Failed tests detected. Some tests depend on DCPs from the git submodule at test/RapidWrightDCP, consider checking its status and updating with \'gradlew updateSubmodules\'')
-  }
-}
-
-tasks.withType(Test) {
-  dependsOn initSubmodules
-  finalizedBy remindSubmodules
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,6 @@ apply from: 'common.gradle'
 
 mainClassName = "com.xilinx.rapidwright.MainEntrypoint"
 
-def os = System.getProperty("os.name").toLowerCase().contains("windows") ?
-                                       "win64-msvc2005x64" : "linux64-gcc"
 def sw = new StringWriter()
 def get_rapidwright_version_line = file('.github/workflows/build.yml').filterLine(sw) { 
     line -> line.contains('RAPIDWRIGHT_VERSION:') 
@@ -31,13 +29,6 @@ sourceSets {
     java {
       srcDirs = ['test']
     }
-  }
-}
-
-tasks.withType(Test) {
-  //We need to rerun tests when the data files change
-  if (file('data').exists()) {
-    inputs.dir file('data')
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,20 +8,6 @@ apply from: 'common.gradle'
 
 mainClassName = "com.xilinx.rapidwright.MainEntrypoint"
 
-sourceSets {
-  main {
-    java.destinationDirectory.fileValue(file('bin'))
-    java {
-      srcDirs = ['src']
-    }
-  }
-  test {
-    java {
-      srcDirs = ['test']
-    }
-  }
-}
-
 def os = System.getProperty("os.name").toLowerCase().contains("windows") ?
                                        "win64-msvc2005x64" : "linux64-gcc"
 def sw = new StringWriter()
@@ -46,6 +32,28 @@ dependencies {
     api 'com.xilinx.rapidwright:qtjambi-'+os+':4.5.2_01'
     api 'com.xilinx.rapidwright:jupyter-kernel-jsr223:1.0.0'
     api 'com.xilinx.rapidwright:rapidwright-api-lib:' + rapidwright_version
+}
+
+sourceSets {
+  main {
+    java.destinationDirectory.fileValue(file('bin'))
+    java {
+      srcDirs = ['src']
+    }
+  }
+  test {
+    java {
+      srcDirs = ['test']
+    }
+  }
+}
+
+tasks.withType(Test) {
+  environment 'RAPIDWRIGHT_PATH',file('.')
+  //We need to rerun tests when the data files change
+  if (file('data').exists()) {
+    inputs.dir file('data')
+  }
 }
 
 task copyJars(type: Copy) {
@@ -156,5 +164,39 @@ signing {
     }
     sign configurations.archives
     sign publishing.publications.mavenJava
+}
+
+task testPython(type:Test) {
+  group = "verification"
+  description = "Runs the Python unit tests."
+  doFirst {
+    // Necessary because gradle will try and match against Java tests
+    filter.setFailOnNoMatchingTests(false)
+  }
+  doLast {
+    exec {
+      if (project.gradle.parent == null) {
+        environment 'CLASSPATH', sourceSets.main.runtimeClasspath.getAsPath()
+        executable = 'python3'
+        args = ['-m', 'pytest', '--junitxml', '$buildDir/test-results/testPython/testPython.xml']
+        args += ['--rootdir', 'python/test']
+        // Enable verbose flag which prints out a pass/fail for every test
+        args += ['-v']
+        // Prevent python/tests/... with the same namespace as in Java from clobbering
+        args += ['--import-mode=importlib']
+        // Workaround from https://github.com/jpype-project/jpype/issues/842#issuecomment-847027355
+        args += ['-p', 'no:faulthandler']
+        if (!filter.commandLineIncludePatterns.isEmpty()) {
+          args += ['--pyargs'] + filter.commandLineIncludePatterns.stream().map((p) -> 'python.test.' + p).collect(Collectors.toList())
+        }
+      } else {
+        logger.warn("'testPython' cannot be run within a composite build yet. Ignoring.")
+      }
+    }
+  }
+}
+
+test {
+  dependsOn testPython
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'signing'
 }
 
+if (System.getenv('RAPIDWRIGHT_PATH') == null) {
+  throw new GradleException('RAPIDWRIGHT_PATH environment variable not set')
+}
+
 apply from: 'common.gradle'
 
 mainClassName = "com.xilinx.rapidwright.MainEntrypoint"
@@ -35,7 +39,6 @@ sourceSets {
 }
 
 tasks.withType(Test) {
-  environment 'RAPIDWRIGHT_PATH',file('.')
   //We need to rerun tests when the data files change
   if (file('data').exists()) {
     inputs.dir file('data')

--- a/build.gradle
+++ b/build.gradle
@@ -151,22 +151,17 @@ task testPython(type:Test) {
   }
   doLast {
     exec {
-      if (project.gradle.parent == null) {
-        environment 'CLASSPATH', sourceSets.main.runtimeClasspath.getAsPath()
-        executable = 'python3'
-        args = ['-m', 'pytest', '--junitxml', '$buildDir/test-results/testPython/testPython.xml']
-        args += ['--rootdir', 'python/test']
-        // Enable verbose flag which prints out a pass/fail for every test
-        args += ['-v']
-        // Prevent python/tests/... with the same namespace as in Java from clobbering
-        args += ['--import-mode=importlib']
-        // Workaround from https://github.com/jpype-project/jpype/issues/842#issuecomment-847027355
-        args += ['-p', 'no:faulthandler']
-        if (!filter.commandLineIncludePatterns.isEmpty()) {
-          args += ['--pyargs'] + filter.commandLineIncludePatterns.stream().map((p) -> 'python.test.' + p).collect(Collectors.toList())
-        }
-      } else {
-        logger.warn("'testPython' cannot be run within a composite build yet. Ignoring.")
+      environment 'CLASSPATH', sourceSets.main.runtimeClasspath.getAsPath()
+      executable = 'python3'
+      args = ['-m', 'pytest', '--junitxml', '$buildDir/test-results/testPython/testPython.xml', '--rootdir', 'python/test']
+      // Enable verbose flag which prints out a pass/fail for every test
+      args += ['-v']
+      // Prevent python/tests/... with the same namespace as in Java from clobbering
+      args += ['--import-mode=importlib']
+      // Workaround from https://github.com/jpype-project/jpype/issues/842#issuecomment-847027355
+      args += ['-p', 'no:faulthandler']
+      if (!filter.commandLineIncludePatterns.isEmpty()) {
+        args += ['--pyargs'] + filter.commandLineIncludePatterns.stream().map((p) -> 'python.test.' + p).collect(Collectors.toList())
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'signing'
 }
 
-if (System.getenv('RAPIDWRIGHT_PATH') == null) {
-  throw new GradleException('RAPIDWRIGHT_PATH environment variable not set')
-}
-
 apply from: 'common.gradle'
 
 mainClassName = "com.xilinx.rapidwright.MainEntrypoint"

--- a/common.gradle
+++ b/common.gradle
@@ -4,11 +4,35 @@ apply plugin: 'java-library'
 sourceCompatibility = 8
 targetCompatibility = 8
 
+def rapidwrightDir = System.getenv("RAPIDWRIGHT_PATH")
+
 repositories {
     mavenCentral()
 }
 
+def os = System.getProperty("os.name").toLowerCase().contains("windows") ?
+                                       "win64-msvc2005x64" : "linux64-gcc"
+def sw = new StringWriter()
+def get_rapidwright_version_line = new File(rapidwrightDir + '/.github/workflows/build.yml').filterLine(sw) { 
+    line -> line.contains('RAPIDWRIGHT_VERSION:') 
+}
+def rapidwright_version = sw.toString().replace("RAPIDWRIGHT_VERSION: v", "").replace("-beta", "").trim()
+
 dependencies {
+  api 'com.esotericsoftware:kryo:5.2.1'
+  api 'org.jgrapht:jgrapht-core:1.3.0'
+  api 'org.capnproto:runtime:0.1.13'
+  api 'net.sf.jopt-simple:jopt-simple:5.0.4'
+  api 'org.python:jython-standalone:2.7.2'
+  api 'com.google.protobuf:protobuf-java:3.11.4'
+  api 'org.jetbrains:annotations:20.1.0'
+  api 'org.zeromq:jeromq:0.5.2'
+  api 'commons-cli:commons-cli:1.2'
+  api 'org.json:json:20160810'
+  api 'com.jcraft:jzlib:1.1.3'
+  api 'commons-io:commons-io:2.11.0'
+  api 'com.xilinx.rapidwright:qtjambi-'+os+':4.5.2_01'
+  api 'com.xilinx.rapidwright:jupyter-kernel-jsr223:1.0.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'

--- a/common.gradle
+++ b/common.gradle
@@ -29,11 +29,6 @@ tasks.withType(Test) {
   maxHeapSize = "5G"
   //Propagate JVM settings to test JVM
   jvmArgs applicationDefaultJvmArgs
-  environment 'RAPIDWRIGHT_PATH',file('.')
-  //We need to rerun tests when the data files change
-  if (file('data').exists()) {
-    inputs.dir file('data')
-  }
 }
 
 task testJava(type:Test) {
@@ -43,34 +38,8 @@ task testJava(type:Test) {
   useJUnitPlatform()
 }
 
-task testPython(type:Test) {
-  group = "verification"
-  description = "Runs the Python unit tests."
-  doFirst {
-    // Necessary because gradle will try and match against Java tests
-    filter.setFailOnNoMatchingTests(false)
-  }
-  doLast {
-    exec {
-      environment 'CLASSPATH', sourceSets.main.runtimeClasspath.getAsPath()
-      executable = 'python3'
-      args = ['-m', 'pytest', '--junitxml', "$buildDir/test-results/testPython/testPython.xml", '--rootdir', 'python/test']
-      // Enable verbose flag which prints out a pass/fail for every test
-      args += ['-v']
-      // Prevent python/tests/... with the same namespace as in Java from clobbering
-      args += ['--import-mode=importlib']
-      // Workaround from https://github.com/jpype-project/jpype/issues/842#issuecomment-847027355
-      args += ['-p', 'no:faulthandler']
-      if (!filter.commandLineIncludePatterns.isEmpty()) {
-        args += ['--pyargs'] + filter.commandLineIncludePatterns.stream().map((p) -> 'python.test.' + p).collect(Collectors.toList())
-      }
-    }
-  }
-}
-
 test {
   dependsOn testJava
-  dependsOn testPython
 }
 
 gradle.taskGraph.whenReady {
@@ -96,7 +65,7 @@ task initSubmodules {
 
 task remindSubmodules {
   onlyIf {
-    testJava.state.failure != null || testPython.state.failure != null
+    testJava.state.failure != null || (project.tasks.findByName('testPython') && testPython.state.failure != null)
   }
   doLast {
     logger.warn('Failed tests detected. Some tests depend on DCPs from the git submodule at test/RapidWrightDCP, consider checking its status and updating with \'gradlew updateSubmodules\'')

--- a/common.gradle
+++ b/common.gradle
@@ -4,7 +4,7 @@ apply plugin: 'java-library'
 sourceCompatibility = 8
 targetCompatibility = 8
 
-def rapidwrightDir = System.getenv("RAPIDWRIGHT_PATH")
+def rapidwrightDir = System.getenv("RAPIDWRIGHT_PATH") ? System.getenv("RAPIDWRIGHT_PATH") : file('.').toString()
 
 repositories {
     if (project.hasProperty('useMavenLocal') && useMavenLocal == "True") {

--- a/common.gradle
+++ b/common.gradle
@@ -4,7 +4,7 @@ apply plugin: 'java-library'
 sourceCompatibility = 8
 targetCompatibility = 8
 
-def rapidwrightDir = System.getenv("RAPIDWRIGHT_PATH") ? System.getenv("RAPIDWRIGHT_PATH") : file('.').toString()
+def rapidwrightDir = System.getenv("RAPIDWRIGHT_PATH") ?: file('.').toString()
 
 repositories {
     if (project.hasProperty('useMavenLocal') && useMavenLocal == "True") {

--- a/common.gradle
+++ b/common.gradle
@@ -1,0 +1,110 @@
+apply plugin: 'application'
+apply plugin: 'java-library'
+
+sourceCompatibility = 8
+targetCompatibility = 8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'
+}
+
+import java.util.stream.Collectors
+
+//Kryo needs to access sun.nio.ch.DirectBuffer. This is forbidden by default in Java 16 and up. Check if we need to add a jvm arg.
+if (org.gradle.api.JavaVersion.current().isJava10Compatible()) {
+	applicationDefaultJvmArgs = ["--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"]
+}
+
+configurations.implementation.canBeResolved = true
+configurations.testImplementation.canBeResolved = true
+configurations.api.canBeResolved = true
+
+tasks.withType(Test) {
+  maxHeapSize = "5G"
+  //Propagate JVM settings to test JVM
+  jvmArgs applicationDefaultJvmArgs
+  environment 'RAPIDWRIGHT_PATH',file('.')
+  //We need to rerun tests when the data files change
+  if (file('data').exists()) {
+    inputs.dir file('data')
+  }
+}
+
+task testJava(type:Test) {
+  group = "verification"
+  description = "Runs the Java unit tests."
+
+  useJUnitPlatform()
+}
+
+task testPython(type:Test) {
+  group = "verification"
+  description = "Runs the Python unit tests."
+  doFirst {
+    // Necessary because gradle will try and match against Java tests
+    filter.setFailOnNoMatchingTests(false)
+  }
+  doLast {
+    exec {
+      environment 'CLASSPATH', sourceSets.main.runtimeClasspath.getAsPath()
+      executable = 'python3'
+      args = ['-m', 'pytest', '--junitxml', "$buildDir/test-results/testPython/testPython.xml", '--rootdir', 'python/test']
+      // Enable verbose flag which prints out a pass/fail for every test
+      args += ['-v']
+      // Prevent python/tests/... with the same namespace as in Java from clobbering
+      args += ['--import-mode=importlib']
+      // Workaround from https://github.com/jpype-project/jpype/issues/842#issuecomment-847027355
+      args += ['-p', 'no:faulthandler']
+      if (!filter.commandLineIncludePatterns.isEmpty()) {
+        args += ['--pyargs'] + filter.commandLineIncludePatterns.stream().map((p) -> 'python.test.' + p).collect(Collectors.toList())
+      }
+    }
+  }
+}
+
+test {
+  dependsOn testJava
+  dependsOn testPython
+}
+
+gradle.taskGraph.whenReady {
+  if (!project.test.filter.commandLineIncludePatterns.isEmpty()) {
+    throw new InvalidUserDataException("'test' task does not support filters (i.e. '--tests' option); please apply filters directly to 'testJava'/'testPython' tasks instead.")
+  }
+}
+
+task updateSubmodules(type:Exec) {
+  group = "build setup"
+  description = "Update Git submodules"
+  executable = 'git'
+  args = ['submodule', 'update', '--init', '--recursive']
+}
+
+task initSubmodules {
+  group = "build setup"
+  description = "Init Git submodules (first time only)"
+  if (!file("test/RapidWrightDCP/.git").exists()) {
+    dependsOn updateSubmodules
+  }
+}
+
+task remindSubmodules {
+  onlyIf {
+    testJava.state.failure != null || testPython.state.failure != null
+  }
+  doLast {
+    logger.warn('Failed tests detected. Some tests depend on DCPs from the git submodule at test/RapidWrightDCP, consider checking its status and updating with \'gradlew updateSubmodules\'')
+  }
+}
+
+tasks.withType(Test) {
+  dependsOn initSubmodules
+  finalizedBy remindSubmodules
+}
+

--- a/common.gradle
+++ b/common.gradle
@@ -14,13 +14,8 @@ repositories {
     mavenCentral()
 }
 
-def os = System.getProperty("os.name").toLowerCase().contains("windows") ?
+ext.os = System.getProperty("os.name").toLowerCase().contains("windows") ?
                                        "win64-msvc2005x64" : "linux64-gcc"
-def sw = new StringWriter()
-def get_rapidwright_version_line = new File(rapidwrightDir + '/.github/workflows/build.yml').filterLine(sw) { 
-    line -> line.contains('RAPIDWRIGHT_VERSION:') 
-}
-def rapidwright_version = sw.toString().replace("RAPIDWRIGHT_VERSION: v", "").replace("-beta", "").trim()
 
 dependencies {
   api 'com.esotericsoftware:kryo:5.2.1'
@@ -57,6 +52,10 @@ tasks.withType(Test) {
   maxHeapSize = "5G"
   //Propagate JVM settings to test JVM
   jvmArgs applicationDefaultJvmArgs
+  //We need to rerun tests when the data files change
+  if (file(rapidwrightDir + '/data').exists()) {
+    inputs.dir file(rapidwrightDir + '/data')
+  }
 }
 
 task testJava(type:Test) {

--- a/common.gradle
+++ b/common.gradle
@@ -7,6 +7,10 @@ targetCompatibility = 8
 def rapidwrightDir = System.getenv("RAPIDWRIGHT_PATH")
 
 repositories {
+    if (project.hasProperty('useMavenLocal') && useMavenLocal == "True") {
+       project.logger.lifecycle('Using Maven Local Repository')
+       mavenLocal()
+    }
     mavenCentral()
 }
 


### PR DESCRIPTION
Mainly, moving the dependency and testing stuff into `common.gradle` which is included back.