### PR TITLE
Switching to SHA instead of tags for non-GitHub authored Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: gradle/wrapper-validation-action@v1.0.4
+      - uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
 
       - name: Setup JDK 1.11
         uses: actions/setup-java@v2

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -33,7 +33,7 @@ jobs:
           done
 
       - name: Publish
-        uses: EnricoMi/publish-unit-test-result-action@v1.18
+        uses: EnricoMi/publish-unit-test-result-action@c6ffacdf2fce00e8222e3a373b87ec805a04bc46
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           files: "artifacts/**/*.xml"


### PR DESCRIPTION
Signed-off-by: Chris Lavin <clavin@xilinx.com>