### PR TITLE
Test >4GB EDIFs are writeCheckpoint-able (needs >=14GB)

### DIFF
--- a/src/com/xilinx/rapidwright/tests/CodePerfTracker.java
+++ b/src/com/xilinx/rapidwright/tests/CodePerfTracker.java
@@ -187,10 +187,18 @@ public class CodePerfTracker {
 
 	private void print(String segmentName, Long runtime, Long memUsage, boolean nested){
 		if(isUsingGCCallsToTrackMemory()){
-			System.out.printf("%"+maxSegmentNameSize+"s: %"+maxRuntimeSize+".3fs %"+maxUsageSize+".3fMBs\n", 
-				segmentName,
-				(runtime)/1000000000.0,
-				(memUsage)/(1024.0*1024.0));
+			if (nested) {
+				System.out.printf("%"+maxSegmentNameSize+"s: %"+maxRuntimeSize+"s %" + maxUsageSize + "s      (%" + maxRuntimeSize + ".3fs)\n",
+						segmentName,
+						"",
+						"",
+						(runtime)/1000000000.0);
+			} else {
+				System.out.printf("%"+maxSegmentNameSize+"s: %"+maxRuntimeSize+".3fs %"+maxUsageSize+".3fMBs\n",
+						segmentName,
+						(runtime)/1000000000.0,
+						(memUsage)/(1024.0*1024.0));
+			}
 		} else {
 			if (nested) {
 				System.out.printf("%" + maxSegmentNameSize + "s: %" + maxRuntimeSize + "s  (%" + maxRuntimeSize + ".3fs)\n",

--- a/src/com/xilinx/rapidwright/util/CountingOutputStream.java
+++ b/src/com/xilinx/rapidwright/util/CountingOutputStream.java
@@ -38,8 +38,20 @@ public class CountingOutputStream extends FilterOutputStream {
 
     @Override
     public void write(int b) throws IOException {
-        super.write(b);
+        out.write(b);
         bytesWritten++;
+    }
+
+    @Override
+    public void write(byte b[]) throws IOException {
+        out.write(b);
+        bytesWritten += b.length;
+    }
+
+    @Override
+    public void write(byte b[], int off, int len) throws IOException {
+        out.write(b, off, len);
+        bytesWritten += len;
     }
 
     public long getBytesWritten() {

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -200,7 +200,7 @@ public class TestDesign {
         } finally {
             ParallelismTools.setParallel(false);
         }
-
+    }
     @Test
     @CheckOpenFiles
     public void testBug349(@TempDir Path tempDir) throws IOException {

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -169,7 +169,7 @@ public class TestDesign {
     @Test
     @CheckOpenFiles
     public void testDcpEdifBiggerThan4GB(@TempDir Path tempDir) {
-        long maxMemoryNeeded = 1024L*1024L*1024L*16L;
+        long maxMemoryNeeded = 1024L*1024L*1024L*14L;
         Assumptions.assumeTrue(Runtime.getRuntime().maxMemory() >= maxMemoryNeeded);
 
         final String edifName = "testDcpEdifBiggerThan4GB";

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -173,8 +173,8 @@ public class TestDesign {
 
     @Test
     @CheckOpenFiles
-    public void testEdifBiggerThan4GB(@TempDir Path tempDir) {
-        long maxMemoryNeeded = 1024L*1024L*1024L*20L;
+    public void testDcpEdifBiggerThan4GB(@TempDir Path tempDir) {
+        long maxMemoryNeeded = 1024L*1024L*1024L*16L;
         Assumptions.assumeTrue(Runtime.getRuntime().maxMemory() >= maxMemoryNeeded);
 
         final String edifName = "testEdifBiggerThan4GB";
@@ -194,10 +194,10 @@ public class TestDesign {
 
     @Test
     @CheckOpenFiles
-    public void testEdifBiggerThan4GBParallel(@TempDir Path tempDir) {
+    public void testDcpEdifBiggerThan4GBParallel(@TempDir Path tempDir) {
         try {
             ParallelismTools.setParallel(true);
-            testEdifBiggerThan4GB(tempDir);
+            testDcpEdifBiggerThan4GB(tempDir);
         } finally {
             ParallelismTools.setParallel(false);
         }

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -201,6 +201,7 @@ public class TestDesign {
             ParallelismTools.setParallel(false);
         }
     }
+    
     @Test
     @CheckOpenFiles
     public void testBug349(@TempDir Path tempDir) throws IOException {


### PR DESCRIPTION
Also optimize `CountingOutputStream` by overriding the array variants of `write`.