### PR TITLE
Switch to Python 3.6 because of CI failures

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -43,5 +43,9 @@
 	<classpathentry kind="lib" path="jars/junit-platform-commons-1.7.1.jar"/>
 	<classpathentry kind="lib" path="jars/junit-platform-engine-1.7.1.jar"/>
 	<classpathentry kind="lib" path="jars/opentest4j-1.2.0.jar"/>
+	<classpathentry kind="lib" path="jars/commons-cli-1.2.jar"/>
+	<classpathentry kind="lib" path="jars/commons-io-2.11.0.jar"/>
+	<classpathentry kind="lib" path="jars/jzlib-1.1.3.jar"/>
+	<classpathentry kind="lib" path="jars/jeromq-0.5.2.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - name: Setup Python 3.5
+      - name: Setup Python 3.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.5
+          python-version: 3.6
 
       - name: Cache Jars & Data
         id: cache-rapidwright


### PR DESCRIPTION
Signed-off-by: Chris Lavin <clavin@xilinx.com>