### PR TITLE
Bumping version of jupyter_kernel for JeroMQ update to 0.5.2

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -31,7 +31,7 @@ dependencies {
   api 'com.jcraft:jzlib:1.1.3'
   api 'commons-io:commons-io:2.11.0'
   api 'com.xilinx.rapidwright:qtjambi-'+os+':4.5.2_01'
-  api 'com.xilinx.rapidwright:jupyter-kernel-jsr223:1.0.0'
+  api 'com.xilinx.rapidwright:jupyter-kernel-jsr223:1.0.1'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'


### PR DESCRIPTION
Signed-off-by: Chris Lavin <clavin@xilinx.com>