### PR TITLE
Fix #117 by merging {set,update}CellType into new set overload

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -835,7 +835,7 @@ public class DesignTools {
 		}
 		inst.getCellType().getLibrary().removeCell(inst.getCellType());
 		netlist.migrateCellAndSubCells(cell.getTopEDIFCell(), true);
-		inst.updateCellType(cell.getTopEDIFCell());
+		inst.setCellType(cell.getTopEDIFCell(), true);
 		netlist.removeUnusedCellsFromAllWorkLibraries();
 		
 		// Add placement information
@@ -1146,7 +1146,7 @@ public class DesignTools {
 		for(EDIFPort port : futureBlackBox.getCellType().getPorts()){
 			blackBox.addPort(port);
 		}
-		futureBlackBox.setCellType(blackBox);
+		futureBlackBox.setCellType(blackBox, false);
 		futureBlackBox.addProperty(EDIFCellInst.BLACK_BOX_PROP, true);
 		
 		t.stop().printSummary();
@@ -1832,7 +1832,7 @@ public class DesignTools {
 			EDIFHierCellInst cellInst = src.getNetlist().getHierCellInstFromName(e.getKey());
 			destNetlist.migrateCellAndSubCells(cellInst.getCellType());
 			EDIFHierCellInst bbInst = destNetlist.getHierCellInstFromName(e.getValue());
-			bbInst.getInst().setCellType(cellInst.getCellType());
+			bbInst.getInst().setCellType(cellInst.getCellType(), false);
             for(EDIFPortInst portInst : bbInst.getInst().getPortInsts()) {
             	portInst.getPort().setParentCell(cellInst.getCellType());
             }

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -138,7 +138,7 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
 	public EDIFCellInst addNewCellInstUniqueName(String suggestedName, EDIFCell reference){
 		EDIFCellInst i = new EDIFCellInst();
 		i.setName(suggestedName);
-		i.setCellType(reference);
+		i.setCellType(reference, false);
 		return addCellInstUniqueName(i);
 	}
 	

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -59,7 +59,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
     
     public EDIFCellInst(String name, EDIFCell cellType, EDIFCell parentCell){
         super(name);
-        setCellType(cellType);
+        setCellType(cellType, false);
         if(parentCell != null) parentCell.addCellInst(this);
         viewref = cellType != null ? cellType.getEDIFView() : DEFAULT_VIEWREF;
     }
@@ -185,13 +185,36 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
     }
 
     /**
-     * @param cellType the cellType to set
+     * Modify the cell being instantiated
+     * @param cellType the new cell type to be instantiated
+     * @param updatePortInsts update port references on portInst objects
+     */
+    public void setCellType(EDIFCell cellType, boolean updatePortInsts) {
+        this.cellType = cellType;
+        this.viewref = cellType != null ? cellType.getEDIFView() : null;
+        if (updatePortInsts) {
+            for (EDIFPortInst portInst : getPortInsts()) {
+                EDIFPort origPort = portInst.getPort();
+                EDIFPort port = cellType.getPort(origPort.getBusName());
+                if (port == null || port.getWidth() != origPort.getWidth()) {
+                    port = cellType.getPort(origPort.getName());
+                }
+                portInst.setPort(port);
+            }
+        }
+    }
+
+    /**
+     * @deprecated
      */
     public void setCellType(EDIFCell cellType) {
         this.cellType = cellType;
         this.viewref = cellType != null ? cellType.getEDIFView() : null;
     }
-    
+
+    /**
+     * @deprecated
+     */
     public void updateCellType(EDIFCell cellType) {
         setCellType(cellType);
         for(EDIFPortInst portInst : getPortInsts()) {

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -446,7 +446,7 @@ public class EDIFNetlist extends EDIFName {
 		if(existingCell == null){
 			destLib.addCell(cell);
 			for(EDIFCellInst inst : cell.getCellInsts()){
-				inst.updateCellType(migrateCellAndSubCellsWorker(inst.getCellType()));
+				inst.setCellType(migrateCellAndSubCellsWorker(inst.getCellType()), true);
 				//The view might have changed
 				inst.getViewref().setName(inst.getCellType().getView());
 			}
@@ -521,7 +521,7 @@ public class EDIFNetlist extends EDIFName {
 					instCellType.updateEDIFRename();
 					i++;
 				}
-				inst.setCellType(instCellType); // updating the celltype, which could be changed due to adding suffix
+				inst.setCellType(instCellType, false); // updating the celltype, which could be changed due to adding suffix
 				destLibSub.addCell(instCellType);
 				cells.add(instCellType);
 			}
@@ -1617,11 +1617,7 @@ public class EDIFNetlist extends EDIFName {
 						if (newCell == null) {
 							throw new RuntimeException("failed to find cell macro "+cellName+", we are in "+lib.getName());
 						}
-						inst.setCellType(newCell);
-						for(EDIFPortInst portInst : inst.getPortInsts()) {
-							String portName = portInst.getPort().getBusName();
-							portInst.setPort(newCell.getPort(portName));
-						}
+						inst.setCellType(newCell, true);
 					}
 				}
 			}

--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -701,10 +701,10 @@ public class EDIFParser implements AutoCloseable{
 			expect(LEFT_PAREN, getNextToken());
 			expect(LIBRARYREF, getNextToken());
 			String libraryref = getNextToken();
-			inst.setCellType(getRefEDIFCell(cellref, libraryref));
+			inst.setCellType(getRefEDIFCell(cellref, libraryref), false);
 			expect(RIGHT_PAREN, getNextToken());
 		} else {
-			inst.setCellType(getRefEDIFCell(cellref, currentLibraryName));
+			inst.setCellType(getRefEDIFCell(cellref, currentLibraryName), false);
 		}
 
 		expect(RIGHT_PAREN,getNextToken());

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1176,7 +1176,7 @@ public class EDIFTools {
 			EDIFCell origCell = cellInst.getCellType();
 			EDIFCell newCell = new EDIFCell(origCell.getLibrary(), origCell, origCell.getName() 
 					+ "_RW" + unique++);
-			cellInst.getInst().updateCellType(newCell);
+			cellInst.getInst().setCellType(newCell, true);
 			
 			// Update any physical cell references
 			for(EDIFCellInst inst : newCell.getCellInsts()) {

--- a/src/com/xilinx/rapidwright/examples/PicoBlazeArray.java
+++ b/src/com/xilinx/rapidwright/examples/PicoBlazeArray.java
@@ -152,7 +152,7 @@ public class PicoBlazeArray {
 					T mi = createInstance(design, makeName(x,y), impl, picoBlazeImpls);
 
 					instances.put(mi.getName(), mi);
-					mi.getCellInst().setCellType(impl.getNetlist().getTopCell());
+					mi.getCellInst().setCellType(impl.getNetlist().getTopCell(), false);
 
 					placeInArray(mi, bram, impl);
 

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -309,7 +309,7 @@ public class DeviceResourcesWriter {
                 EDIFCell macroCell = macros.getCell(instCell.getName());
                 if(macroCell != null && !unsupportedMacros.contains(macroCell)) {
                     // remap cell definition to macro library
-                    inst.updateCellType(macroCell);
+                    inst.setCellType(macroCell, true);
                 }
             }
         }

--- a/src/com/xilinx/rapidwright/ipi/BlockStitcher.java
+++ b/src/com/xilinx/rapidwright/ipi/BlockStitcher.java
@@ -586,7 +586,7 @@ public class BlockStitcher {
 			if(inst == null) throw new RuntimeException("ERROR: Couldn't update EDIF cell instance.");
 			EDIFCell cellType = work.getCell(e.getValue().getName() + "_" + e.getValue().getName());
 			if(cellType == null) throw new RuntimeException("ERROR: Couldn't update EDIF cell type " + e.getValue().getName());
-			inst.setCellType(cellType);
+			inst.setCellType(cellType, false);
 		}
 		
 		for(EDIFCell c : stitched.getNetlist().getLibrary("IP_Integrator_Lib").getCells()){

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -80,7 +80,7 @@ public class TestDesign {
         netlist.migrateCellAndSubCells(module.getNetlist().getTopCell());
 
         ModuleInst mi = design.createModuleInst("inst", module);
-        mi.getCellInst().setCellType(module.getNetlist().getTopCell());
+        mi.getCellInst().setCellType(module.getNetlist().getTopCell(), false);
         mi.placeOnOriginalAnchor();
         String oldAnchor = mi.getAnchor().toString();
 


### PR DESCRIPTION
I agree with #117 that having two `EDIFCellInst` methods that are synonyms of each other is not particularly useful. 

This is the first of two proposed fixes, and is the safer option:

`EDIFCellInst.updateCellType(EDIFCell)`
`EDIFCellInst.setCellType(EDIFCell)`

now merged into:

``EDIFCellInst.setCellType(EDIFCell, boolean)`

The boolean determines whether to perform the original `updateCellType` functionality (which updates the port references on the portInsts) or whether to just do the original `setCellType`.

All references to the former two methods have been changed to the new overload, and those former methods marked as being `@deprecated`. This should be a non-functional change.