### PR TITLE
Fix #117 by setCellType doing what updateCellType did

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1833,9 +1833,9 @@ public class DesignTools {
 			destNetlist.migrateCellAndSubCells(cellInst.getCellType());
 			EDIFHierCellInst bbInst = destNetlist.getHierCellInstFromName(e.getValue());
 			bbInst.getInst().setCellTypeRaw(cellInst.getCellType());
-            for(EDIFPortInst portInst : bbInst.getInst().getPortInsts()) {
-            	portInst.getPort().setParentCell(cellInst.getCellType());
-            }
+			for(EDIFPortInst portInst : bbInst.getInst().getPortInsts()) {
+				portInst.getPort().setParentCell(cellInst.getCellType());
+			}
 			instsWithSeparator.add(e.getKey() + EDIFTools.EDIF_HIER_SEP);
 		}
 		destNetlist.resetParentNetMap();

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1832,10 +1832,7 @@ public class DesignTools {
 			EDIFHierCellInst cellInst = src.getNetlist().getHierCellInstFromName(e.getKey());
 			destNetlist.migrateCellAndSubCells(cellInst.getCellType());
 			EDIFHierCellInst bbInst = destNetlist.getHierCellInstFromName(e.getValue());
-			bbInst.getInst().setCellTypeRaw(cellInst.getCellType());
-			for(EDIFPortInst portInst : bbInst.getInst().getPortInsts()) {
-				portInst.getPort().setParentCell(cellInst.getCellType());
-			}
+			bbInst.getInst().setCellType(cellInst.getCellType());
 			instsWithSeparator.add(e.getKey() + EDIFTools.EDIF_HIER_SEP);
 		}
 		destNetlist.resetParentNetMap();

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -835,7 +835,7 @@ public class DesignTools {
 		}
 		inst.getCellType().getLibrary().removeCell(inst.getCellType());
 		netlist.migrateCellAndSubCells(cell.getTopEDIFCell(), true);
-		inst.updateCellType(cell.getTopEDIFCell());
+		inst.setCellType(cell.getTopEDIFCell());
 		netlist.removeUnusedCellsFromAllWorkLibraries();
 		
 		// Add placement information
@@ -1832,7 +1832,7 @@ public class DesignTools {
 			EDIFHierCellInst cellInst = src.getNetlist().getHierCellInstFromName(e.getKey());
 			destNetlist.migrateCellAndSubCells(cellInst.getCellType());
 			EDIFHierCellInst bbInst = destNetlist.getHierCellInstFromName(e.getValue());
-			bbInst.getInst().setCellType(cellInst.getCellType());
+			bbInst.getInst().setCellTypeRaw(cellInst.getCellType());
             for(EDIFPortInst portInst : bbInst.getInst().getPortInsts()) {
             	portInst.getPort().setParentCell(cellInst.getCellType());
             }

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -199,15 +199,20 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
     }
 
     /**
+     * Forcibly modify the cell being instantiated without updating portInsts
      * @param cellType the cellType to set
      */
-    public void setCellType(EDIFCell cellType) {
+    public void setCellTypeRaw(EDIFCell cellType) {
         this.cellType = cellType;
         this.viewref = cellType != null ? cellType.getEDIFView() : null;
     }
-    
-    public void updateCellType(EDIFCell cellType) {
-        setCellType(cellType);
+
+    /**
+     * Modify the cell being instantiated and update port refs on portInsts
+     * @param cellType the cellType to set
+     */
+    public void setCellType(EDIFCell cellType) {
+        setCellTypeRaw(cellType);
         for(EDIFPortInst portInst : getPortInsts()) {
             EDIFPort origPort = portInst.getPort();
             EDIFPort port = cellType.getPort(origPort.getBusName());
@@ -216,6 +221,13 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
             }
             portInst.setPort(port);
         }
+    }
+
+    /**
+     * @deprecated
+     */
+    public void updateCellType(EDIFCell cellType) {
+        setCellType(cellType);
     }
 	
 	public boolean isBlackBox(){

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -447,7 +447,7 @@ public class EDIFNetlist extends EDIFName {
 		if(existingCell == null){
 			destLib.addCell(cell);
 			for(EDIFCellInst inst : cell.getCellInsts()){
-				inst.updateCellType(migrateCellAndSubCellsWorker(inst.getCellType()));
+				inst.setCellType(migrateCellAndSubCellsWorker(inst.getCellType()));
 				//The view might have changed
 				inst.getViewref().setName(inst.getCellType().getView());
 			}
@@ -1619,10 +1619,6 @@ public class EDIFNetlist extends EDIFName {
 							throw new RuntimeException("failed to find cell macro "+cellName+", we are in "+lib.getName());
 						}
 						inst.setCellType(newCell);
-						for(EDIFPortInst portInst : inst.getPortInsts()) {
-							String portName = portInst.getPort().getBusName();
-							portInst.setPort(newCell.getPort(portName));
-						}
 					}
 				}
 			}

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1171,7 +1171,7 @@ public class EDIFTools {
 			EDIFCell origCell = cellInst.getCellType();
 			EDIFCell newCell = new EDIFCell(origCell.getLibrary(), origCell, origCell.getName() 
 					+ "_RW" + unique++);
-			cellInst.getInst().updateCellType(newCell);
+			cellInst.getInst().setCellType(newCell);
 			
 			// Update any physical cell references
 			for(EDIFCellInst inst : newCell.getCellInsts()) {

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -1,6 +1,5 @@
 package com.xilinx.rapidwright.interchange;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,7 +17,6 @@ import java.util.Queue;
 
 import org.capnproto.MessageBuilder;
 import org.capnproto.PrimitiveList;
-import org.capnproto.SerializePacked;
 import org.capnproto.StructList;
 import org.capnproto.Text;
 import org.capnproto.TextList;
@@ -28,7 +26,6 @@ import org.capnproto.Void;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.DesignTools;
 import com.xilinx.rapidwright.design.SiteInst;
-import com.xilinx.rapidwright.design.SitePinInst;
 import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.design.VivadoPropType;
 import com.xilinx.rapidwright.design.VivadoProp;
@@ -45,7 +42,6 @@ import com.xilinx.rapidwright.device.IOStandard;
 import com.xilinx.rapidwright.device.PackagePin;
 import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.PIPType;
-import com.xilinx.rapidwright.device.PIPWires;
 import com.xilinx.rapidwright.device.PseudoPIPHelper;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.SitePIP;
@@ -55,15 +51,9 @@ import com.xilinx.rapidwright.device.TileTypeEnum;
 import com.xilinx.rapidwright.device.Wire;
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
-import com.xilinx.rapidwright.edif.EDIFDesign;
 import com.xilinx.rapidwright.edif.EDIFLibrary;
-import com.xilinx.rapidwright.edif.EDIFName;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
-import com.xilinx.rapidwright.edif.EDIFPort;
-import com.xilinx.rapidwright.edif.EDIFPortInst;
-import com.xilinx.rapidwright.edif.EDIFPropertyValue;
 import com.xilinx.rapidwright.edif.EDIFTools;
-import com.xilinx.rapidwright.interchange.EnumerateCellBelMapping;
 import com.xilinx.rapidwright.interchange.DeviceResources.Device.BELCategory;
 import com.xilinx.rapidwright.interchange.DeviceResources.Device.BELInverter;
 import com.xilinx.rapidwright.interchange.DeviceResources.Device.CellInversion;
@@ -85,7 +75,6 @@ import com.xilinx.rapidwright.interchange.DeviceResources.Device.ParameterMapRul
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist;
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist.Direction;
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist.PropertyMap;
-import com.xilinx.rapidwright.interchange.WireType;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.Pair;
 
@@ -309,7 +298,7 @@ public class DeviceResourcesWriter {
                 EDIFCell macroCell = macros.getCell(instCell.getName());
                 if(macroCell != null && !unsupportedMacros.contains(macroCell)) {
                     // remap cell definition to macro library
-                    inst.updateCellType(macroCell);
+                    inst.setCellType(macroCell);
                 }
             }
         }

--- a/test/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/com/xilinx/rapidwright/design/TestDesign.java
@@ -11,7 +11,6 @@ import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
-import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.util.ParallelismTools;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
I agree with #117 that having two `EDIFCellInst` methods that are synonyms of each other is not particularly useful. 

This is the second of two proposed fixes, and is the riskier option.

`EDIFCellInst.setCellType(EDIFCell)` renamed to `setCellTypeRaw(EDIFCell)` (latter is not used, but kept around just in case it is useful in the future)
`EDIFCellInst.updateCellType(EDIFCell)` renamed to `setCellType(EDIFCell)`

with `updateCellType()` marked as `@deprecated` while still calling the new `setCellType`.

~The reasoning here is that one should never update the cell type without updating the port references of its portInsts. The only exception I'm not terribly confident about is:~
https://github.com/Xilinx/RapidWright/blob/7177e016ad6c1beefb1778d5a80aab7a468f4b3f/src/com/xilinx/rapidwright/design/DesignTools.java#L1820-L1835
~which does some portInst parent cell juggling too, and is currently the only reason for `setCellTypeRaw` existing.~ (see resolved discussion)