### PR TITLE
Binary EDIF Format 

### DIFF
--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
@@ -1,0 +1,224 @@
+package com.xilinx.rapidwright.edif;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.xilinx.rapidwright.util.FileTools;
+
+/**
+ * A Reader for the RapidWright Binary EDIF Format
+ *  
+ * Provides a binary alternative to textual EDIF that is ~10-15X smaller and loads 5-10X faster.
+ * This is intended as a cached version of text-based EDIF as it cannot be read by Vivado.  One
+ * additional tradeoff is that it takes about 2.5-3X longer to write than text-based EDIF.
+ */
+public class BinaryEDIFReader {
+    
+    /**
+     * Reads an EDIFName object from kryo-based input stream.
+     * @param o The object to populate
+     * @param is Kryo-based input stream
+     * @param strings Indexed string lookup
+     * @return True if this object has a non-zero property map, false if none
+     * @see BinaryEDIFWriter#writeEDIFName(EDIFName, Output, Map, boolean)
+     */
+    private static boolean readEDIFName(EDIFName o, Input is, String[] strings) {
+        int nameIdx = is.readInt();
+        if((nameIdx & BinaryEDIFWriter.EDIF_NAME_FLAG) == BinaryEDIFWriter.EDIF_NAME_FLAG) {
+            o.setEDIFRename(strings[nameIdx & ~BinaryEDIFWriter.EDIF_NAME_FLAG]);
+            nameIdx = is.readInt();
+        }
+        o.setName(strings[nameIdx & ~BinaryEDIFWriter.EDIF_PROP_FLAG]);
+        return (nameIdx & BinaryEDIFWriter.EDIF_PROP_FLAG) == BinaryEDIFWriter.EDIF_PROP_FLAG;
+    }
+
+    /**
+     * Reads the common attributes of an EDIFPropertyObject (EDIFName and property map)
+     * @param o The object to read
+     * @param is The Kryo-based input stream
+     * @param strings Indexed string lookup
+     * @see BinaryEDIFWriter#writeEDIFObject(EDIFPropertyObject, Output, Map<String,Integer>)
+     */
+    static void readEDIFObject(EDIFPropertyObject o, Input is, String[] strings) {
+        if(readEDIFName(o, is, strings)) {
+            int numProps = is.readShortUnsigned();
+            for(int i=0; i < numProps; i++) {
+                EDIFName key = new EDIFName();
+                if(readEDIFName(key, is, strings)) {
+                    throw new RuntimeException("ERROR: Corrupted file while reading " + o.getName());
+                }
+                int typeAndStringIdx = is.readInt();
+                EDIFValueType type = EDIFValueType.values()[typeAndStringIdx >>> BinaryEDIFWriter.EDIF_PROP_TYPE_BIT];
+                String value = strings[BinaryEDIFWriter.EDIF_PROP_VALUE_MASK & typeAndStringIdx];
+                o.addProperty(key, new EDIFPropertyValue(value, type));
+            }
+        }
+    }
+
+    /**
+     * Reads an EDIFDesign object
+     * @param is The Kryo-based input stream 
+     * @param strings Indexed string lookup
+     * @param netlist The current netlist being populated
+     * @return A new EDIFDesign object, populated with data from the input stream
+     * @see BinaryEDIFWriter#writeEDIFDesign(EDIFDesign, Output, Map)
+     */
+    static EDIFDesign readEDIFDesign(Input is, String[] strings, EDIFNetlist netlist) {
+        EDIFDesign design = new EDIFDesign();
+        readEDIFObject(design, is, strings);
+        design.setTopCell(BinaryEDIFReader.readEDIFCellRef(is, strings, netlist, null));
+        netlist.setDesign(design);
+        return design;
+    }
+
+    /**
+     * Reads the reference for an EDIFCell
+     * @param is A Kryo-based input stream
+     * @param strings Indexed string lookup
+     * @param netlist The current netlist being populated
+     * @param parentCellLib The current parent cell's library, or null if this is for EDIFDesign
+     * @return The existing EDIFCell contained in the specified library of the netlist.
+     * @see BinaryEDIFWriter#writeEDIFCellRef(EDIFCell, Output, Map, EDIFLibrary)
+     */
+    static EDIFCell readEDIFCellRef(Input is, String[] strings, EDIFNetlist netlist, 
+                                            EDIFLibrary parentCellLib) {
+        int cellNameIdx = is.readInt();
+        EDIFLibrary lib = null;
+        if((cellNameIdx & BinaryEDIFWriter.EDIF_SAME_LIB_FLAG) == BinaryEDIFWriter.EDIF_SAME_LIB_FLAG) {
+            cellNameIdx = cellNameIdx & ~BinaryEDIFWriter.EDIF_SAME_LIB_FLAG;
+            lib = parentCellLib;
+        } else {
+            lib = netlist.getLibrary(strings[is.readInt()]);
+        }
+        String cellName = strings[cellNameIdx];
+        if(lib == null) {
+            throw new RuntimeException("ERROR: Couldn't find Library for cell '" + cellName + "'");
+        }
+        EDIFCell cell = lib.getCell(cellName);
+        if(cell == null) {
+            throw new RuntimeException("ERROR: Couldn't find cell '" 
+                    + cellName + "' in Library '" + cellName + "'");
+        }
+        return cell;
+    }
+
+    /**
+     * Reads and creates a new EDIFCell from the Kryo-based input stream
+     * @param is Kryo-based input stream
+     * @param strings Indexed string lookup
+     * @param lib Parent library for which this EDIFCell should become a member
+     * @param netlist The current netlist being read
+     * @return The newly read and created EDIFCell
+     * @see BinaryEDIFWriter#writeEDIFCell(EDIFCell, Output, Map)
+     */
+    public static EDIFCell readEDIFCell(Input is, String[] strings, EDIFLibrary lib, EDIFNetlist netlist) {
+        EDIFCell c = new EDIFCell();
+        readEDIFObject(c, is, strings);
+        lib.addCell(c);
+        int portCount = is.readInt();
+        if((portCount & BinaryEDIFWriter.EDIF_UNIQUE_VIEW_FLAG) == BinaryEDIFWriter.EDIF_UNIQUE_VIEW_FLAG) {
+            portCount = portCount & ~BinaryEDIFWriter.EDIF_UNIQUE_VIEW_FLAG;
+            EDIFName view = new EDIFName();
+            readEDIFName(view, is, strings);
+            c.setView(view);
+        }
+        for(int i=0; i < portCount; i++) {
+            EDIFPort port = new EDIFPort();
+            readEDIFObject(port, is, strings);
+            int dirAndWidth = is.readInt();
+            int width = dirAndWidth & (BinaryEDIFWriter.PORT_WIDTH_MASK);
+            EDIFDirection dir = null;
+            if((dirAndWidth & BinaryEDIFWriter.EDIF_DIR_INPUT_MASK) == BinaryEDIFWriter.EDIF_DIR_INPUT_MASK) {
+                dir = EDIFDirection.INPUT;
+            }else if((dirAndWidth & BinaryEDIFWriter.EDIF_DIR_OUTPUT_MASK) == BinaryEDIFWriter.EDIF_DIR_OUTPUT_MASK) {
+                dir = EDIFDirection.OUTPUT;
+            }else if((dirAndWidth & BinaryEDIFWriter.EDIF_DIR_INOUT_MASK) == BinaryEDIFWriter.EDIF_DIR_INOUT_MASK) {
+                dir = EDIFDirection.INOUT;
+            }else {
+                throw new RuntimeException("ERROR: Couldn't read port direction in cell " 
+                        + c.getName());
+            }
+            port.setWidth(width);
+            port.setDirection(dir);
+            c.addPort(port);
+        }
+        int instCount = is.readInt();
+        for(int i=0; i < instCount; i++) {
+            EDIFCellInst inst = new EDIFCellInst();
+            readEDIFObject(inst, is, strings);
+            inst.setCellType(readEDIFCellRef(is, strings, netlist, lib));
+            c.addCellInst(inst);
+        }
+        int netCount = is.readInt();
+        for(int i=0; i < netCount; i++) {
+            EDIFNet net = new EDIFNet();
+            readEDIFObject(net, is, strings);
+            c.addNet(net);
+            int portRefCount = is.readInt();
+            for(int j=0; j < portRefCount; j++) {
+                String name = strings[is.readInt()];
+                int index = is.readInt();
+                int instRef = is.readInt();
+                if(instRef == BinaryEDIFWriter.EDIF_NULL_INST) {
+                    net.createPortInst(c.getPort(name), index); 
+                } else {
+                    EDIFCellInst inst = c.getCellInst(strings[instRef]);
+                    EDIFPort port = inst.getPort(name);
+                    net.createPortInst(port, index, inst);
+                }
+            }
+        }
+        return c;
+    }
+
+    /**
+     * Reads a binary EDIF (.bedf) file and creates a new EDIFNetlist object.  
+     * @param fileName Name of the file to read
+     * @return The newly created netlist populated from the binary EDIF file
+     * @see BinaryEDIFWriter#writeBinaryEDIF(String, EDIFNetlist)
+     */
+    public static EDIFNetlist readBinaryEDIF(String fileName) {
+        return BinaryEDIFReader.readBinaryEDIF(Paths.get(fileName));
+    }
+
+    /**
+     * Reads a binary EDIF (.bedf) file and creates a new EDIFNetlist object.  
+     * @param path Name of the file to read
+     * @return The newly created netlist populated from the binary EDIF file
+     * @see BinaryEDIFWriter#writeBinaryEDIF(Path, EDIFNetlist)
+     */
+    public static EDIFNetlist readBinaryEDIF(Path path) {
+        Input is = FileTools.getKryoInputStream(path.toString());
+        if(!is.readString().equals(BinaryEDIFWriter.EDIF_BINARY_FILE_TAG)) {
+            throw new RuntimeException("ERROR: Cannot recognize EDIF Binary format");
+        }
+        if(!is.readString().equals(BinaryEDIFWriter.EDIF_BINARY_FILE_VERSION)) {
+            throw new RuntimeException("ERROR: Unsupported EDIF Binary format version");
+        }
+        EDIFNetlist netlist = new EDIFNetlist();
+        String[] strings = FileTools.readStringArray(is);
+        int numLibraries = is.readInt();
+        for(int i=0; i < numLibraries; i++) {
+            EDIFLibrary lib = new EDIFLibrary();
+            readEDIFName(lib, is, strings);
+            netlist.addLibrary(lib);
+            int numCells = is.readInt();
+            for(int j=0; j < numCells; j++) {
+                readEDIFCell(is, strings, lib, netlist);
+            }
+        }
+        readEDIFName(netlist, is, strings);
+        int numComments = is.readInt();
+        for(int i=0; i < numComments; i++) {
+            netlist.addComment(is.readString());
+        }
+        readEDIFDesign(is, strings, netlist);
+        
+        is.close();
+        return netlist;
+    }
+
+}

--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
@@ -43,7 +43,7 @@ import com.xilinx.rapidwright.util.FileTools;
 public class BinaryEDIFReader {
     
     /**
-     * Reads an EDIFName object from kryo-based input stream.
+     * Reads an EDIFName object from Kryo-based input stream.
      * @param o The object to populate
      * @param is Kryo-based input stream
      * @param strings Indexed string lookup

--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
@@ -69,7 +69,11 @@ public class BinaryEDIFReader {
      */
     static void readEDIFObject(EDIFPropertyObject o, Input is, String[] strings) {
         if(readEDIFName(o, is, strings)) {
-            int numProps = is.readShortUnsigned();
+            int numProps = is.readInt();
+            if((numProps & BinaryEDIFWriter.EDIF_HAS_OWNER) == BinaryEDIFWriter.EDIF_HAS_OWNER) {
+                numProps = ~BinaryEDIFWriter.EDIF_HAS_OWNER & numProps;
+                o.setOwner(strings[is.readInt()]);
+            }
             for(int i=0; i < numProps; i++) {
                 EDIFName key = new EDIFName();
                 if(readEDIFName(key, is, strings)) {
@@ -168,6 +172,7 @@ public class BinaryEDIFReader {
             }
             port.setWidth(width);
             port.setDirection(dir);
+            port.setIsLittleEndian();
             c.addPort(port);
         }
         int instCount = is.readInt();

--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
@@ -37,8 +37,10 @@ import com.xilinx.rapidwright.util.FileTools;
  * A Reader for the RapidWright Binary EDIF Format
  *  
  * Provides a binary alternative to textual EDIF that is ~10-15X smaller and loads 5-10X faster.
- * This is intended as a cached version of text-based EDIF as it cannot be read by Vivado.  One
- * additional tradeoff is that it takes about 2.5-3X longer to write than text-based EDIF.
+ * This is intended as a RapidWright-only cache (with the extension *.bedf) of this text-based
+ * EDIF and cannot be read by Vivado.  One additional tradeoff is that it takes about 2.5-3X
+ * longer to write than text-based EDIF, but it is expected that this binary alternative will
+ * be written once and read many times.
  */
 public class BinaryEDIFReader {
     

--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFReader.java
@@ -1,3 +1,28 @@
+/*
+ * 
+ * Copyright (c) 2022 Xilinx, Inc. 
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright. 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+/**
+ * 
+ */
 package com.xilinx.rapidwright.edif;
 
 import java.nio.file.Path;

--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFWriter.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFWriter.java
@@ -1,3 +1,28 @@
+/*
+ * 
+ * Copyright (c) 2022 Xilinx, Inc. 
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright. 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+/**
+ * 
+ */
 package com.xilinx.rapidwright.edif;
 
 import java.nio.file.Path;
@@ -174,7 +199,7 @@ public class BinaryEDIFWriter {
     static void writeEDIFCellRef(EDIFCell ref, Output os, Map<String,Integer> stringMap,
                                          EDIFLibrary parentCellLib) {
         int libMask = ref.getLibrary().equals(parentCellLib) ? EDIF_SAME_LIB_FLAG : 0; 
-        os.writeInt(libMask | stringMap.get(ref.getName()));            
+        os.writeInt(libMask | stringMap.get(ref.getLegalEDIFName()));            
         if(libMask != EDIF_SAME_LIB_FLAG) {
             os.writeInt(stringMap.get(ref.getLibrary().getName()));
         }

--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFWriter.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFWriter.java
@@ -1,0 +1,282 @@
+package com.xilinx.rapidwright.edif;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.xilinx.rapidwright.util.FileTools;
+
+/**
+ * A Writer for the RapidWright Binary EDIF Format
+ *  
+ * Provides a binary alternative to textual EDIF that is ~10-15X smaller and loads 5-10X faster.
+ * This is intended as a cached version of text-based EDIF as it cannot be read by Vivado.  One
+ * additional tradeoff is that it takes about 2.5-3X longer to write than text-based EDIF.
+ */
+public class BinaryEDIFWriter {
+    
+    public static final String EDIF_BINARY_FILE_TAG = "RAPIDWRIGHT_EDIF_BINARY";
+    public static final String EDIF_BINARY_FILE_VERSION = "0.0.1";
+    
+    public static final int EDIF_NAME_FLAG = 0x80000000;
+    public static final int EDIF_UNIQUE_VIEW_FLAG = 0x80000000;
+    public static final int EDIF_SAME_LIB_FLAG = 0x80000000;
+    public static final int EDIF_PROP_FLAG = 0x40000000;
+
+    public static final int EDIF_DIR_INPUT_MASK  = 0x40000000;
+    public static final int EDIF_DIR_OUTPUT_MASK = 0x20000000;
+    public static final int EDIF_DIR_INOUT_MASK  = 0x10000000;
+    public static final int EDIF_RENAME_MASK     = 0x80000000; 
+    public static final int PORT_WIDTH_MASK      = ~(EDIF_RENAME_MASK 
+                                                   | EDIF_DIR_INPUT_MASK 
+                                                   | EDIF_DIR_OUTPUT_MASK 
+                                                   | EDIF_DIR_INOUT_MASK);
+    public static final int EDIF_PROP_TYPE_BIT   = 30;
+    public static final int EDIF_PROP_VALUE_MASK  = 0x3fffffff;
+    public static final int EDIF_NULL_INST       = -1;
+    public static final int EDIF_MACRO_LIB       = 0x40000000;
+    
+
+    private static void addStringToStringMap(String s, Map<String,Integer> stringMap) {
+        stringMap.computeIfAbsent(s, v -> stringMap.size());
+        if(stringMap.size() >= EDIF_PROP_FLAG) {
+            throw new RuntimeException("ERROR: Too many unique strings for this encoding");
+        }
+    }
+    
+    private static void addNameToStringMap(EDIFName o, Map<String,Integer> stringMap) {
+        addStringToStringMap(o.getName(), stringMap);
+        addStringToStringMap(o.getLegalEDIFName(), stringMap);
+    }
+    
+    private static void addObjectToStringMap(EDIFPropertyObject o, Map<String,Integer> stringMap) {
+        addNameToStringMap(o, stringMap);
+        for(Entry<EDIFName, EDIFPropertyValue> e : o.getProperties().entrySet()) {
+            addNameToStringMap(e.getKey(), stringMap);
+            addStringToStringMap(e.getValue().getValue(), stringMap);
+        }
+    }
+    
+    /**
+     * This method iterates over an entire EDIFNetlist to enumerate all Strings.  This is done to
+     * provide a fast lookup array at the front of the file when loading the Binary EDIF.
+     * @param netlist The netlist to include in the String map.
+     * @return A new map keyed by all unique strings in the netlist mapped to unique integers.
+     */
+    public static Map<String, Integer> createStringMap(EDIFNetlist netlist) {
+        Map<String, Integer> stringMap = new HashMap<>();
+        for(EDIFLibrary lib : netlist.getLibraries()) {
+            addNameToStringMap(lib, stringMap);
+            for(EDIFCell cell : lib.getCells()) {
+                addObjectToStringMap(cell, stringMap);
+                addNameToStringMap(cell.getEDIFView(), stringMap);
+                for(EDIFCellInst inst : cell.getCellInsts()) {
+                    addObjectToStringMap(inst, stringMap);
+                }
+                for(EDIFNet net : cell.getNets()) {
+                    addObjectToStringMap(net, stringMap);
+                    for(EDIFPortInst pi : net.getPortInsts()) {
+                        String name = pi.getPort().isBus() ? pi.getPort().getBusName() : pi.getName();
+                        addStringToStringMap(name, stringMap);
+                    }
+                }
+                for(EDIFPort port : cell.getPorts()) {
+                    addObjectToStringMap(port, stringMap);
+                }
+            }
+        }        
+        addNameToStringMap(netlist, stringMap);
+        addObjectToStringMap(netlist.getDesign(), stringMap);
+        return stringMap;
+    }
+    
+    /**
+     * Writes, in a compact manner, the EDIFName provided.  Assumes the follow data is not a 
+     * EDIF property map
+     * @param o The EDIFName to write
+     * @param os The kryo output stream
+     * @param stringMap The string map to reference enumerations from
+     * @see BinaryEDIFReader#readEDIFName(EDIFName, Input, String[])
+     */
+    private static void writeEDIFName(EDIFName o, Output os, Map<String,Integer> stringMap) {
+        writeEDIFName(o, os, stringMap, false);
+    }
+    
+    /**
+     * Writes, in a compact manner, the EDIFName provided. 
+     * @param o The EDIFName to write
+     * @param os The kryo output stream
+     * @param stringMap The string map to reference enumerations from
+     * @param hasPropMap Flag that is set in the final word indicating to the parser if it should
+     * expect an EDIF property map
+     * @see BinaryEDIFReader#readEDIFName(EDIFName, Input, String[])
+     */
+    private static void writeEDIFName(EDIFName o, Output os, Map<String,Integer> stringMap, 
+            boolean hasPropMap) {
+        if(o.getEDIFName() != null) {
+            int edifName = stringMap.get(o.getEDIFName());
+            os.writeInt(EDIF_NAME_FLAG | edifName);
+        }
+        os.writeInt((hasPropMap ? EDIF_PROP_FLAG : 0) | stringMap.get(o.getName()));
+    }
+    
+    /**
+     * Writes the common attributes of an EDIFPropertyObject (EDIFName and property map) 
+     * @param o The object write
+     * @param os The Kryo-based output stream 
+     * @param stringMap Map of String to enumeration integers
+     * @see #readEDIFObject(EDIFPropertyObject, Output, Map)
+     */
+    private static void writeEDIFObject(EDIFPropertyObject o, Output os, Map<String,Integer> stringMap) {
+        boolean hasProperties = o.getProperties().size() > 0;
+        writeEDIFName(o, os, stringMap, hasProperties);
+        if(hasProperties) {
+            if(o.getProperties().size() > 0x0000ffff) {
+                throw new RuntimeException("ERROR: EDIF object exceeded number of encoded "
+                        + "properties on object '" + o.getName() + "'");
+            }
+            os.writeShort(o.getProperties().size());
+            for(Entry<EDIFName, EDIFPropertyValue> e : o.getProperties().entrySet()) {
+                writeEDIFName(e.getKey(), os, stringMap);
+                int propType = e.getValue().getType().ordinal();
+                os.writeInt(propType << EDIF_PROP_TYPE_BIT | stringMap.get(e.getValue().getValue()));
+            }            
+        }
+    }
+    
+    /**
+     * Writes the EDIFDesign object 
+     * @param design The object to write
+     * @param os The Kryo-based output stream
+     * @param stringMap Map of String to enumeration integers
+     * @see BinaryEDIFReader#readEDIFDesign(Input, String[], EDIFNetlist)
+     */
+    static void writeEDIFDesign(EDIFDesign design, Output os, Map<String,Integer> stringMap) {
+        writeEDIFObject(design, os, stringMap);
+        EDIFCell topCell = design.getTopCell();
+        writeEDIFCellRef(topCell, os, stringMap, null);            
+    }
+    
+    /**
+     * Writes a reference to an EDIFCell.  It uses a single bit to encoded if the written EDIFCell 
+     * is in the same EDIFLibrary as the parent cell library.  If it is not, then it will write the
+     * 32-bit integer naming the other library.
+     * @param ref The cell to reference
+     * @param os The Kryo-based output stream
+     * @param stringMap Map of String to enumeration integers
+     * @param parentCellLib The current library context, or null if it is for EDIFDesign
+     * @see BinaryEDIFReader#readEDIFCellRef(Input, String[], EDIFNetlist, EDIFLibrary)
+     */
+    static void writeEDIFCellRef(EDIFCell ref, Output os, Map<String,Integer> stringMap,
+                                         EDIFLibrary parentCellLib) {
+        int libMask = ref.getLibrary().equals(parentCellLib) ? EDIF_SAME_LIB_FLAG : 0; 
+        os.writeInt(libMask | stringMap.get(ref.getName()));            
+        if(libMask != EDIF_SAME_LIB_FLAG) {
+            os.writeInt(stringMap.get(ref.getLibrary().getName()));
+        }
+    }
+    
+    /**
+     * Writes the provided EDIFCell to Kryo-based output stream.
+     * @param c The current cell to write
+     * @param os The Kryo-based output stream
+     * @param stringMap Map of string to integer enumerations to use to reference strings
+     * @see BinaryEDIFReader#readEDIFCell(Input, String[], EDIFLibrary, EDIFNetlist)
+     */
+    public static void writeEDIFCell(EDIFCell c, Output os, Map<String,Integer> stringMap) { 
+        writeEDIFObject(c, os, stringMap);
+        boolean hasUniqueView = c.getEDIFView() != EDIFCell.DEFAULT_VIEW;
+        os.writeInt((hasUniqueView ? EDIF_UNIQUE_VIEW_FLAG : 0) | c.getPorts().size());
+        if(hasUniqueView) {
+            writeEDIFName(c.getEDIFView(), os, stringMap);
+        }
+        for(EDIFPort p : c.getPorts()) {
+            writeEDIFObject(p, os, stringMap);
+            int dirAndWidth = p.getWidth();
+            if(dirAndWidth >= EDIF_DIR_INOUT_MASK) {
+                throw new RuntimeException("ERROR: Port " + p.getName() + " is too wide ("+
+                        dirAndWidth+") to be encoded in this file format.");
+            }
+            EDIFDirection dir = p.getDirection();
+            if(dir == EDIFDirection.INPUT) {
+                dirAndWidth |= EDIF_DIR_INPUT_MASK;
+            }else if(dir == EDIFDirection.OUTPUT) {
+                dirAndWidth |= EDIF_DIR_OUTPUT_MASK;
+            }else if(dir == EDIFDirection.INOUT) {
+                dirAndWidth |= EDIF_DIR_INOUT_MASK;
+            }
+            if(!p.getLegalEDIFName().equals(p.getName())){
+                dirAndWidth |= EDIF_RENAME_MASK; 
+            }
+            os.writeInt(dirAndWidth);
+        }
+
+        os.writeInt(c.getCellInsts().size());
+        for(EDIFCellInst i : c.getCellInsts()) {
+            writeEDIFObject(i, os, stringMap);
+            writeEDIFCellRef(i.getCellType(), os, stringMap, c.getLibrary());
+        }
+        os.writeInt(c.getNets().size());
+        for(EDIFNet n : c.getNets()) {
+            writeEDIFObject(n, os, stringMap);
+            os.writeInt(n.getPortInsts().size());
+            for(EDIFPortInst pi : n.getPortInsts()) {
+                String name = pi.getPort().isBus() ? pi.getPort().getBusName() : pi.getName();
+                os.writeInt(stringMap.get(name));
+                os.writeInt(pi.getIndex());
+                os.writeInt(pi.getCellInst() == null ? 
+                        EDIF_NULL_INST : stringMap.get(pi.getCellInst().getName()));
+            }
+        }
+    }
+    
+    /**
+     * Writes the provided netlist as a binary EDIF file (.bedf).  This has the advantage of being
+     * an order of magnitude smaller in size and faster to load.
+     * @param fileName Name of the file to write
+     * @param netlist The current netlist to write
+     * @see BinaryEDIFReader#readBinaryEDIF(String)
+     */
+    public static void writeBinaryEDIF(String fileName, EDIFNetlist netlist) {
+        writeBinaryEDIF(Paths.get(fileName), netlist);
+    }
+    
+    /**
+     * Writes the provided netlist as a binary EDIF file (.bedf).  This has the advantage of being
+     * an order of magnitude smaller in size and faster to load.
+     * @param path Path to the file to write
+     * @param netlist The current netlist to write
+     * @see BinaryEDIFReader#readBinaryEDIF(Path)
+     */
+    public static void writeBinaryEDIF(Path path, EDIFNetlist netlist) {
+        Map<String, Integer> stringMap = createStringMap(netlist);
+        Output os = FileTools.getKryoOutputStream(path.toString());
+        os.writeString(EDIF_BINARY_FILE_TAG);
+        os.writeString(EDIF_BINARY_FILE_VERSION);
+        String[] strings = new String[stringMap.size()];
+        for(Entry<String,Integer> e : stringMap.entrySet()) {
+            strings[e.getValue()] = e.getKey();
+        }
+        FileTools.writeStringArray(os, strings);
+        os.writeInt(netlist.getLibraries().size());
+        for(EDIFLibrary lib : netlist.getLibrariesInExportOrder()) {
+            writeEDIFName(lib, os, stringMap);
+            os.writeInt(lib.getCells().size());
+            for(EDIFCell cell : lib.getValidCellExportOrder()) {
+                writeEDIFCell(cell, os, stringMap);
+            }
+        }
+        writeEDIFName(netlist, os, stringMap);
+        // Comments are likely to be unique
+        os.writeInt(netlist.getComments().size());
+        for(String comment : netlist.getComments()) {
+            os.writeString(comment);
+        }
+        writeEDIFDesign(netlist.getDesign(), os, stringMap);
+        os.close();
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -359,11 +359,11 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
 	 * @param view the view to set
 	 */
 	public void setView(String view) {
-		this.view = new EDIFName(view);
+		setView(new EDIFName(view));
 	}
 	
 	public void setView(EDIFName view) {
-		this.view = view;
+		this.view = DEFAULT_VIEW.equals(view) ? DEFAULT_VIEW : view;
 	}
 	
 	public Collection<EDIFPort> getPorts(){

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -61,7 +61,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
         super(name);
         setCellType(cellType);
         if(parentCell != null) parentCell.addCellInst(this);
-        viewref = cellType != null ? cellType.getEDIFView() : DEFAULT_VIEWREF;
+        setViewref(cellType != null ? cellType.getEDIFView() : DEFAULT_VIEWREF);
     }
     
     /**
@@ -72,7 +72,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
         super((EDIFPropertyObject)inst);
         this.parentCell = parentCell;
         this.cellType = inst.cellType;
-        this.viewref = new EDIFName(inst.viewref);
+        setViewref(new EDIFName(inst.viewref));
     }
     
     /**
@@ -86,7 +86,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
      * @param viewref the viewref to set
      */
     public void setViewref(EDIFName viewref) {
-        this.viewref = viewref;
+        this.viewref = EDIFCell.DEFAULT_VIEW.equals(viewref) ? EDIFCell.DEFAULT_VIEW : viewref;
     }
     
     /**
@@ -203,7 +203,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
      */
     public void setCellType(EDIFCell cellType) {
         this.cellType = cellType;
-        this.viewref = cellType != null ? cellType.getEDIFView() : null;
+        setViewref(cellType != null ? cellType.getEDIFView() : null);
     }
     
     public void updateCellType(EDIFCell cellType) {

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1710,6 +1710,22 @@ public class EDIFNetlist extends EDIFName {
         addEncryptedCells(encryptedCells);
     }
 
+    public static EDIFNetlist readBinaryEDIF(Path path) {
+        return BinaryEDIFReader.readBinaryEDIF(path);
+    }
+    
+    public static EDIFNetlist readBinaryEDIF(String fileName) {
+        return BinaryEDIFReader.readBinaryEDIF(fileName);
+    }
+    
+    public void writeBinaryEDIF(Path path) {
+        BinaryEDIFWriter.writeBinaryEDIF(path, this);
+    }
+    
+    public void writeBinaryEDIF(String fileName) {
+        BinaryEDIFWriter.writeBinaryEDIF(fileName, this);
+    }
+    
 	public static void main(String[] args) throws FileNotFoundException {
 		CodePerfTracker t = new CodePerfTracker("EDIF Import/Export", true);
 		t.start("Read EDIF");

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -683,7 +683,7 @@ public class EDIFTools {
 		edif = EDIFTools.loadEDIFFile(edifFileName);
 		t.stop(); 
 		t.start("Write EDIF file");
-		EDIFTools.writeEDIFFile(edifFileName.replace(".edf", "_byu.edf"), edif, "partname");
+		EDIFTools.writeEDIFFile(edifFileName.replace(".edf", "_out.edf"), edif, "partname");
 		t.stop().printSummary();
 	}
 

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -139,10 +139,15 @@ public class EDIFTools {
 
 	public static final String LOAD_TCL_SUFFIX = "_load.tcl";
 	
-	/** Flag to switch EDIF files to KRYO files to make Java debugging faster  (must run once without debugging mode first, once set to true) */
-	public static final boolean EDIF_DEBUG = false;
-
 	public static int UNIQUE_COUNT = 0;
+
+	/**
+	 * Flag to set a feature where any .edf file that is attempted to be loaded will check if an
+	 * existing binary EDIF has already been generated and will load that instead (faster).  This 
+	 * will also enable generation of binary EDIF files after a successful EDIF file loading to be
+	 * used on the next load.
+	 */
+	public static final boolean ENABLE_EDIF_BINARY_CACHING = System.getenv("RW_ENABLE_EDIF_BINARY_CACHING") != null;
 	
 	private static String getUniqueNetSuffix() {
 	    return "_created_net" + UNIQUE_COUNT++;
@@ -674,21 +679,9 @@ public class EDIFTools {
 		String edifFileName = args[0];
 		EDIFNetlist edif;
 		
-		if(EDIFTools.EDIF_DEBUG && FileTools.isFileNewer(edifFileName + ".dat", edifFileName)){
-			t.start("Read EDIF from Kryo");
-			edif = FileTools.readObjectFromKryoFile(edifFileName + ".dat", EDIFNetlist.class);
-			t.stop();
-		}else{
-			t.start("Read EDIF from ASCII EDIF file");
-			edif = EDIFTools.loadEDIFFile(edifFileName);
-			t.stop(); 
-			if(!(new File(edifFileName + ".dat").exists()) || FileTools.isFileNewer(edifFileName, edifFileName + ".dat") ){
-				t.start("Write EDIF Kryo (.dat) file");
-				if(EDIFTools.EDIF_DEBUG) FileTools.writeObjectToKryoFile(edifFileName + ".dat", edif);
-				t.stop();
-			}
-			
-		}
+		t.start("Read EDIF from ASCII EDIF file");
+		edif = EDIFTools.loadEDIFFile(edifFileName);
+		t.stop(); 
 		t.start("Write EDIF file");
 		EDIFTools.writeEDIFFile(edifFileName.replace(".edf", "_byu.edf"), edif, "partname");
 		t.stop().printSummary();
@@ -730,6 +723,13 @@ public class EDIFTools {
 	}
 
 	public static EDIFNetlist readEdifFile(Path edifFileName){
+	    if(ENABLE_EDIF_BINARY_CACHING) {
+	        Path bedif = edifFileName.getParent().resolve(
+	                        edifFileName.getFileName().toString().replace(".edf", ".bedf"));
+	        if(Files.exists(bedif) && FileTools.isFileNewer(bedif, edifFileName)) {
+	            return BinaryEDIFReader.readBinaryEDIF(bedif);
+	        }
+	    }
 		EDIFNetlist edif;
 		File edifFile = edifFileName.toFile();
 		File parent = edifFile.getParentFile();
@@ -751,15 +751,7 @@ public class EDIFTools {
 					+ "be passed to resulting DCP load script.");
 			}
 		}
-		Path kryoFile = FileTools.appendExtension(edifFileName , ".dat");
-		if(EDIFTools.EDIF_DEBUG && FileTools.isFileNewer(kryoFile, edifFileName)){
-			edif = FileTools.readObjectFromKryoFile(kryoFile, EDIFNetlist.class);
-		}else{
-			edif = loadEDIFFile(edifFileName);
-			if(!Files.exists(kryoFile) || FileTools.isFileNewer(edifFileName, kryoFile)){
-				if(EDIFTools.EDIF_DEBUG) FileTools.writeObjectToKryoFile(kryoFile, edif);
-			}
-		}
+		edif = loadEDIFFile(edifFileName);
 		if(edifDirectoryName != null) {
 			File origDir = new File(edifDirectoryName);
 			edif.setOrigDirectory(edifDirectoryName);
@@ -773,7 +765,11 @@ public class EDIFTools {
 			}
 			edif.setEncryptedCells(new ArrayList<>(Arrays.asList(ednFiles)));
 		}
-		
+		if(ENABLE_EDIF_BINARY_CACHING) {
+		    Path bedif = edifFileName.getParent().resolve(
+                    edifFileName.getFileName().toString().replace(".edf", ".bedf"));
+		    BinaryEDIFWriter.writeBinaryEDIF(bedif, edif);
+		}
 		return edif;
 	}
 

--- a/test/com/xilinx/rapidwright/edif/TestBinaryEDIF.java
+++ b/test/com/xilinx/rapidwright/edif/TestBinaryEDIF.java
@@ -1,0 +1,180 @@
+/*
+ * 
+ * Copyright (c) 2022 Xilinx, Inc. 
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright. 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+/**
+ * 
+ */
+package com.xilinx.rapidwright.edif;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.CheckOpenFiles;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.util.FileTools;
+
+public class TestBinaryEDIF {
+
+    
+    /**
+     * Tests EDIFPropertyObjects for equivalence (EDIFName and EDIF property maps are equal and 
+     * contain equivalent data.
+     * @param golden The reference object
+     * @param test The test object
+     * @return True if the two objects are equivalent
+     */
+    private boolean equivalentEDIFPropObject(EDIFPropertyObject golden, EDIFPropertyObject test) {
+        Assertions.assertEquals(golden.getEDIFName(), test.getEDIFName());
+        Assertions.assertEquals(golden.getProperties().size(), test.getProperties().size());
+        for(Entry<EDIFName, EDIFPropertyValue> e : golden.getProperties().entrySet()) {
+            EDIFPropertyValue testValue = test.getProperty(e.getKey().getName());
+            Assertions.assertNotNull(testValue);
+            Assertions.assertEquals(e.getValue().getType(), testValue.getType());
+            Assertions.assertEquals(e.getValue().getValue(), testValue.getValue());
+        }
+        return true;
+    }
+    
+    /**
+     * Checks if the two provided EDIFCells are equivalent.  They are equivalent if they have the 
+     * same EDIFName, same number and equivalent objects of EDIFPorts, EDIFCellInsts and EDIFNets.  
+     * Within EDIFNets, it also checks that the EDIFPortInsts are equivalent.  
+     * @param golden The reference cell
+     * @param test The test cell
+     * @return True if the two cells are equivalent, false otherwise.
+     */
+    private boolean equivalentEDIFCells(EDIFCell golden, EDIFCell test) {
+        Assertions.assertTrue(equivalentEDIFPropObject(golden, test));
+        Assertions.assertEquals(golden.getEDIFView(), test.getEDIFView());
+        Assertions.assertEquals(golden.getPorts().size(), test.getPorts().size());
+        for(EDIFPort port : golden.getPorts()) {
+            EDIFPort testPort = test.getPort(port.getBusName());
+            Assertions.assertNotNull(testPort);
+            Assertions.assertTrue(equivalentEDIFPropObject(port, testPort));
+            Assertions.assertEquals(port.getLeft(), testPort.getLeft());
+            Assertions.assertEquals(port.getRight(), testPort.getRight());
+        }
+        Assertions.assertEquals(golden.getCellInsts().size(), test.getCellInsts().size());
+        for(EDIFCellInst inst : golden.getCellInsts()) {
+            EDIFCellInst testInst = test.getCellInst(inst.getName());
+            Assertions.assertNotNull(testInst);
+            Assertions.assertTrue(equivalentEDIFPropObject(inst, testInst));
+            Assertions.assertEquals(inst.getViewref(), testInst.getViewref());
+            Assertions.assertEquals(inst.getCellName(), testInst.getCellName());
+            Assertions.assertEquals(inst.getCellType().getLibrary().getEDIFName(), 
+                                    testInst.getCellType().getLibrary().getEDIFName());
+        }
+        Assertions.assertEquals(golden.getNets().size(), test.getNets().size());
+        for(EDIFNet net : golden.getNets()) {
+            EDIFNet testNet = test.getNet(net.getName());
+            Assertions.assertNotNull(testNet);
+            Assertions.assertTrue(equivalentEDIFPropObject(net, testNet));
+            Assertions.assertEquals(net.getPortInsts().size(), testNet.getPortInsts().size());
+            for(EDIFPortInst pInst : net.getPortInsts()) {
+                EDIFPortInst testPortInst = testNet.getPortInst(pInst.getCellInst(), pInst.getName());
+                Assertions.assertNotNull(testPortInst);
+                Assertions.assertEquals(pInst.getIndex(), testPortInst.getIndex());
+            }
+        }
+        return true;
+    }
+    
+    /**
+     * Checkes that two EDIF netlists are equivalent
+     * @param golden Reference netlist
+     * @param test Netlist that is being tested
+     * @return True if the two netlists have the same number of libraries, cells, ports, nets, 
+     * instances and port instances, false otherwise
+     */
+    private boolean equivalentEDIFNetlists(EDIFNetlist golden, EDIFNetlist test) {
+        Assertions.assertEquals(golden.getEDIFName(), test.getEDIFName());
+        Assertions.assertTrue(equivalentEDIFPropObject(golden.getDesign(), test.getDesign()));
+        Assertions.assertTrue(equivalentEDIFCells(golden.getDesign().getTopCell(), 
+                                                  test.getDesign().getTopCell()));
+        Assertions.assertEquals(golden.getLibraries().size(), test.getLibraries().size());
+        for(EDIFLibrary lib : golden.getLibraries()) {
+            EDIFLibrary testLib = test.getLibrary(lib.getName());
+            Assertions.assertNotNull(testLib);
+            for(EDIFCell cell : lib.getCells()) {
+                EDIFCell testCell = testLib.getCell(cell.getLegalEDIFName());
+                Assertions.assertNotNull(testCell);
+                Assertions.assertTrue(equivalentEDIFCells(cell, testCell));
+            }
+        }
+        return true;
+    }
+    
+    /**
+     * Compares two text-based EDIF files to see if they match 
+     * (except for their respective timestamp)
+     * @param golden Path to the golden EDIF file
+     * @param test Path to the test EDIF file
+     * @return True if the two files match (excluding timestamp), false otherwise 
+     */
+    private boolean compareEDIFFiles(Path golden, Path test) {
+        List<String> goldenLines = FileTools.getLinesFromTextFile(golden.toString());
+        List<String> testLines = FileTools.getLinesFromTextFile(test.toString());
+        if(goldenLines.size() != testLines.size()) return false;
+        int length = goldenLines.size();
+        for(int i=0 ; i < length; i++) {
+            if(!goldenLines.get(i).equals(testLines.get(i))) {
+                if(goldenLines.get(i).contains("(timeStamp ")) continue;
+                System.err.println("EDIF mismatch on line " + i + ": >>" 
+                        + goldenLines.get(i) +"<<  >>" + testLines.get(i) + "<<");
+                return false;
+            }
+        }
+        return true;
+    }
+    
+
+    @Test
+    @CheckOpenFiles
+    public void testBinaryEDIF(@TempDir Path tempDir) {
+        Path dcp = RapidWrightDCP.getPath("optical-flow.dcp");
+        boolean noXdef = true;
+        Design design = Design.readCheckpoint(dcp, noXdef);
+        EDIFNetlist netlist = design.getNetlist();
+        
+        Path goldenPath = tempDir.resolve("golden.edf");
+        netlist.exportEDIF(goldenPath);
+        
+        EDIFNetlist golden = EDIFTools.readEdifFile(goldenPath);
+        
+        Path binaryPath = tempDir.resolve("test.bedf"); 
+        netlist.writeBinaryEDIF(binaryPath);
+        EDIFNetlist test = EDIFNetlist.readBinaryEDIF(binaryPath);
+        
+        Assertions.assertTrue(equivalentEDIFNetlists(golden, test));
+        
+        Path testPath = tempDir.resolve("test.edf");
+        test.exportEDIF(testPath);
+
+        Assertions.assertTrue(compareEDIFFiles(goldenPath, testPath));
+    }
+}


### PR DESCRIPTION
Aims to provide a binary equivalent to text-based EDIF that is an order of magnitude smaller in file size and 5-10X faster to load.  Should include an optional switch to cache loaded text-based EDIF.