### PR TITLE
Fix for RW_PARALLEL != 0

### DIFF
--- a/src/com/xilinx/rapidwright/util/ParallelismTools.java
+++ b/src/com/xilinx/rapidwright/util/ParallelismTools.java
@@ -54,15 +54,6 @@ public class ParallelismTools {
      */
     public static final String RW_PARALLEL = "RW_PARALLEL";
 
-    private static boolean parallel = true;
-    
-    static {
-        String value = System.getenv(RW_PARALLEL);
-        if(value != null) {
-            setParallel(!(value.equals("0") || value.toLowerCase().equals("false")));
-        }
-    }
-
     /** A fixed-size thread pool with as many threads as there are processors
      * minus one, fed by a single task queue */
     private static final ThreadPoolExecutor pool = new ThreadPoolExecutor(
@@ -75,6 +66,13 @@ public class ParallelismTools {
                 t.setDaemon(true);
                 return t;
             });
+
+    private static boolean parallel = true;
+
+    static {
+        String value = System.getenv(RW_PARALLEL);
+        setParallel(!(value.equals("0") || value.equalsIgnoreCase("false")));
+    }
 
     /**
      * Global setter to control parallel processing.

--- a/src/com/xilinx/rapidwright/util/ParallelismTools.java
+++ b/src/com/xilinx/rapidwright/util/ParallelismTools.java
@@ -71,7 +71,7 @@ public class ParallelismTools {
 
     static {
         String value = System.getenv(RW_PARALLEL);
-        setParallel(!(value.equals("0") || value.equalsIgnoreCase("false")));
+        setParallel(value == null || !(value.equals("0") || value.equalsIgnoreCase("false")));
     }
 
     /**


### PR DESCRIPTION
Setting the environment variable `RW_PARALLEL` to not zero means to enable parallelism.

Doing so means that ` pool.prestartAllCoreThreads();` gets called, but `pool` has not yet been initialized, so juggle the ordering.