### PR TITLE
Rewrite of EDIFTools.connectPortInstsThruHier() 

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1123,6 +1123,7 @@ public class DesignTools {
 
 	/**
 	 * This method will completely remove a placed cell (both logical and physical) from a design.
+	 * In the case where the removed cell is the last user of a shared control signal (CLK, CE, SR) then that pin will also be removed and unrouted immediately if deferRemovals is null, otherwise it is added to this map.
 	 * @param design The design where the cell is instantiated
 	 * @param cell The cell to remove
 	 * @param deferRemovals An optional map that, if passed in non-null will be populated with 

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1043,7 +1043,7 @@ public class DesignTools {
 	            String sitePinName = getRoutedSitePinFromPhysicalPin(c, net, pin.getName());
 	            SitePinInst spi = siteInst.getSitePinInst(sitePinName);
 	            siteInst.unrouteIntraSiteNet(spi.getBELPin(), pin);
-	            boolean preserveOtherRoutes = true;
+	            boolean preserveOtherRoutes = false;
 	            spi.getNet().removePin(spi, preserveOtherRoutes);
 	        }
 	    }

--- a/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
@@ -22,6 +22,7 @@
  */
 package com.xilinx.rapidwright.edif;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -138,11 +139,62 @@ public class EDIFHierCellInst {
     public EDIFHierCellInst getChild(EDIFCellInst relativeChild) {
         return new EDIFHierCellInst(cellInsts, cellInsts.length+1, relativeChild);
     }
+    
+    public List<EDIFHierCellInst> getImmediateChildren(){
+        List<EDIFHierCellInst> children = new ArrayList<>();
+        for(EDIFCellInst child : getCellType().getCellInsts()) {
+            children.add(getChild(child));
+        }
+        return children;
+    }
 
     public EDIFHierCellInst getSibling(EDIFCellInst relativeSibling) {
         return new EDIFHierCellInst(cellInsts, cellInsts.length, relativeSibling);
     }
 
+    /**
+     * Checks if the provided instance is an ancestor (hierarchical parent) of this instance. For 
+     * example, if this = "disneyland/tomorrow_land/space_mountain" and 
+     * inst = "disneyland/tomorrow_land", this method would return true.  however, if 
+     * inst = "disneyland/adventure_land", it would return false. 
+     *  
+     * @param inst The hierarchical instance in question to check if it is  
+     * @return True if the provided instance is a hierarchical ancestor of this instance.
+     */
+    public boolean isAncestor(EDIFHierCellInst inst) {
+        EDIFCellInst[] other = inst.cellInsts;
+        if(other.length >= cellInsts.length) return false;
+        for(int i=0; i < other.length; i++) {
+            if(cellInsts.length > i) {
+                if(!cellInsts[i].getName().equals(other[i].getName())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+    
+    /**
+     * Given this instance and the provided instance o, it determines the closest common ancestor
+     * between the two instances.  In some cases, this can default to the top cell design instance.
+     * For example, if this instance = "a/b/c/d" and o = "a/b/e/f", the method would return "a/b".  
+     * @param o The other instance to check for a common ancestor.
+     * @return The closest common ancestor between this instance and the provided instance.
+     */
+    public EDIFHierCellInst getCommonAncestor(EDIFHierCellInst o) {
+        EDIFCellInst[] oCellInsts = o.cellInsts;
+        int min = Integer.min(cellInsts.length, oCellInsts.length);
+        int idx = 0;
+        for(int i=0; i< min; i++) { 
+            if(cellInsts[i] == oCellInsts[i]) {
+                idx++;
+            } else {
+                break;
+            }
+        }
+        return new EDIFHierCellInst(oCellInsts, idx, null);
+    }
+    
     public boolean isAbsolute() {
         return isToplevelInst(cellInsts[0]);
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
@@ -22,7 +22,6 @@
  */
 package com.xilinx.rapidwright.edif;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -139,14 +138,6 @@ public class EDIFHierCellInst {
     public EDIFHierCellInst getChild(EDIFCellInst relativeChild) {
         return new EDIFHierCellInst(cellInsts, cellInsts.length+1, relativeChild);
     }
-    
-    public List<EDIFHierCellInst> getImmediateChildren(){
-        List<EDIFHierCellInst> children = new ArrayList<>();
-        for(EDIFCellInst child : getCellType().getCellInsts()) {
-            children.add(getChild(child));
-        }
-        return children;
-    }
 
     public EDIFHierCellInst getSibling(EDIFCellInst relativeSibling) {
         return new EDIFHierCellInst(cellInsts, cellInsts.length, relativeSibling);
@@ -154,15 +145,15 @@ public class EDIFHierCellInst {
 
     /**
      * Checks if the provided instance is an ancestor (hierarchical parent) of this instance. For 
-     * example, if this = "disneyland/tomorrow_land/space_mountain" and 
-     * inst = "disneyland/tomorrow_land", this method would return true.  however, if 
-     * inst = "disneyland/adventure_land", it would return false. 
+     * example, if this="disneyland/tomorrow_land/space_mountain" and 
+     * potentialAncestor="disneyland/tomorrow_land", this method would return true.  however, if 
+     * potentialAncestor="disneyland/adventure_land", it would return false. 
      *  
-     * @param inst The hierarchical instance in question to check if it is  
+     * @param potentialAncestor The hierarchical instance in question to check if it is  
      * @return True if the provided instance is a hierarchical ancestor of this instance.
      */
-    public boolean isAncestor(EDIFHierCellInst inst) {
-        EDIFCellInst[] other = inst.cellInsts;
+    public boolean isDescendantOf(EDIFHierCellInst potentialAncestor) {
+        EDIFCellInst[] other = potentialAncestor.cellInsts;
         if(other.length >= cellInsts.length) return false;
         for(int i=0; i < other.length; i++) {
             if(cellInsts.length > i) {
@@ -182,6 +173,11 @@ public class EDIFHierCellInst {
      * @return The closest common ancestor between this instance and the provided instance.
      */
     public EDIFHierCellInst getCommonAncestor(EDIFHierCellInst o) {
+        if(!isAbsolute() || !o.isAbsolute()) {
+            throw new RuntimeException("ERROR: Can only get a common ancestor of absolute "
+                    + "EDIFHierCellInsts. this.isAbsolute()=" + this.isAbsolute() 
+                    + ", o.isAbsolute()=" + o.isAbsolute());
+        }
         EDIFCellInst[] oCellInsts = o.cellInsts;
         int min = Integer.min(cellInsts.length, oCellInsts.length);
         int idx = 0;

--- a/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
@@ -30,7 +30,11 @@ import java.util.Objects;
 
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
+import com.xilinx.rapidwright.device.BELPin;
+import com.xilinx.rapidwright.util.Pair;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -185,10 +189,32 @@ public class EDIFHierPortInst {
 	 * @return The connected site pin to the connected to this cell pin.
 	 */
 	public SitePinInst getRoutedSitePinInst(Design design) {
-		String cellName = getFullHierarchicalInstName();
-		Cell cell = design.getCell(cellName);
+		Cell cell = getPhysicalCell(design);
 		if(cell == null) return null;
 		return cell.getSitePinFromPortInst(getPortInst(), null);
+	}
+	
+	/**
+	 * Gets the physical cell to which this port instance has been placed
+	 * @param design The design corresponding to the implementation of this port instance's netlist
+	 * @return The placed physical cell mapped for this port instance or null if none could be found
+	 */
+	public Cell getPhysicalCell(Design design) {
+	    String cellName = getFullHierarchicalInstName();
+	    Cell cell = design.getCell(cellName);
+	    return cell;	    
+	}
+
+	/**
+	 * Gets the physical site instance and BEL pin location where this port instance has been placed
+	 * @param design The design corresponding to the implementation of this port instance's netlist
+	 * @return The site instance and BELPin for this port instance
+	 */
+	public Pair<SiteInst, BELPin> getRoutedBELPin(Design design) {
+	    Cell cell = getPhysicalCell(design);
+	    if(cell == null) return null;
+	    BELPin belPin = cell.getBELPin(this);
+	    return new Pair<>(cell.getSiteInst(), belPin);
 	}
 	
 	/**

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -201,6 +201,35 @@ public class EDIFNet extends EDIFPropertyObject {
 	}
 
 	/**
+	 * Gets the first top level port instance from the stored list in the net.  If multiple top level
+	 * port instances exist on the net, this only returns the first found. For a comprehensive list
+	 * call {@link #getAllTopLevelPortInsts()}.
+	 * @return The first top level port instance found in the net, or null if none exists.
+	 */
+	public EDIFPortInst getTopLevelPortInst() {
+	    for(EDIFPortInst portInst : getPortInsts()) {
+	        if(portInst.isTopLevelPort()) {
+	            return portInst;
+	        }
+	    }
+	    return null;
+	}
+	
+	/**
+	 * Gets all top level port instances connected to this net.  
+	 * @return A list of all top level port instances connected to this net.
+	 */
+	public List<EDIFPortInst> getAllTopLevelPortInsts() {
+	    List<EDIFPortInst> topPortInsts = new ArrayList<>();
+	    for(EDIFPortInst portInst : getPortInsts()) {
+            if(portInst.isTopLevelPort()) {
+                topPortInsts.add(portInst);
+            }
+        }
+	    return topPortInsts;
+	}
+	
+	/**
 	 * Removes the port instance provided from the net. The net stores the port instances using a 
 	 * sorted ArrayList (@link EDIFPortInstList).  Worst case O(n) to remove.
 	 * @param portInst The port instance to remove from the net.

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -487,7 +487,7 @@ public class EDIFTools {
 	    for(EDIFHierPortInst hierPortInst : new EDIFHierPortInst[] {src, snk}) {
 	        EDIFHierCellInst hierParentInst = hierPortInst.getHierarchicalInst();
 	        EDIFNet currNet = hierPortInst.getNet();
-	        if(currNet == null) {
+	        if(currNet == null && !(hierParentInst.equals(commonAncestor) && hierPortInst == snk)) {
 	            currNet = createUniqueNet(hierParentInst.getCellType(), newName);
 	            currNet.addPortInst(hierPortInst.getPortInst());
 	        }
@@ -537,11 +537,12 @@ public class EDIFTools {
 	            }
 	        }
 	    }
-	    // Make final connection in the common ancestor instance
-	    EDIFNet snkNet = finalSrc.getNet();
+	    // Disconnect sink from existing net if connected
+	    EDIFNet snkNet = finalSnk.getNet();
 	    if(snkNet != null) {
 	        snkNet.removePortInst(finalSnk.getPortInst());
 	    }
+	    // Make final connection in the common ancestor instance
 	    finalSrc.getNet().addPortInst(finalSnk.getPortInst());   
 	}
 

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -498,11 +498,11 @@ public class EDIFTools {
 	            if(exitPath != null) {
 	                // Follow existing connection to parent instance
 	                outerPortInst = hierParentInst.getInst().getPortInst(exitPath.getName());
-	                hierParentInst = hierParentInst.getParent();
 	                if(outerPortInst == null) {
 	                    outerPortInst = new EDIFPortInst(exitPath.getPort(), null,
 	                            exitPath.getIndex(), hierParentInst.getInst());
 	                }
+	                hierParentInst = hierParentInst.getParent();
 	                currNet = outerPortInst.getNet();
 	                if(currNet == null) {
 	                    currNet = createUniqueNet(hierParentInst.getCellType(), newName);

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -527,7 +527,7 @@ public class EDIFTools {
 	                } else {
 	                    currNet = createUniqueNet(hierParentInst.getCellType(), newName);
 	                }
-	                outerPortInst = currNet.createPortInst(newName, prevInst);
+	                outerPortInst = currNet.createPortInst(port, prevInst);
 	            }
 	            EDIFHierPortInst currPortInst = new EDIFHierPortInst(hierParentInst, outerPortInst);
 	            if(hierPortInst == src) {

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -493,13 +493,7 @@ public class EDIFTools {
 	        }
 
 	        while(hierParentInst.getInst() != commonAncestor.getInst()) {
-	            EDIFPortInst exitPath = null;
-	            for(EDIFPortInst portInst : currNet.getPortInsts()) {
-	                if(portInst.isTopLevelPort()) {
-	                    exitPath = portInst;
-	                    break;
-	                }
-	            }                    
+	            EDIFPortInst exitPath = currNet.getTopLevelPortInst();
 	            EDIFPortInst outerPortInst = null;
 	            if(exitPath != null) {
 	                // Follow existing connection to parent instance

--- a/test/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
+++ b/test/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
@@ -1,0 +1,55 @@
+package com.xilinx.rapidwright.edif;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.python.google.common.base.Strings;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+
+public class TestEDIFHierCellInst {
+
+    @Test
+    public void testIsAncestor() {
+        Design d = Design.readCheckpoint(RapidWrightDCP.getPath("microblazeAndILA_3pblocks.dcp"), true);
+        EDIFNetlist netlist = d.getNetlist();
+
+        EDIFHierCellInst topInst = netlist.getTopHierCellInst();
+        Queue<EDIFHierCellInst> q = new LinkedList<>(topInst.getImmediateChildren());
+        while(!q.isEmpty()) {
+            EDIFHierCellInst curr = q.poll();
+            Assertions.assertTrue(curr.isAncestor(topInst));
+            Assertions.assertFalse(topInst.isAncestor(curr));
+            q.addAll(curr.getImmediateChildren());
+        }
+    }
+    
+    @Test
+    public void testgetCommonAncestor() {
+        Design d = Design.readCheckpoint(RapidWrightDCP.getPath("microblazeAndILA_3pblocks.dcp"), true);
+        EDIFNetlist netlist = d.getNetlist();
+
+        String name0 = "base_mb_i/microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/"
+                        + "Data_Flow_Logic_I/Gen_Bits[22].MEM_EX_Result_Inst/Using_FPGA.Native";
+        String name1 = "base_mb_i/microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/"
+                + "PreFetch_Buffer_I1/Instruction_Prefetch_Mux[9].Gen_Instr_DFF/EX_Op3[22]_i_2";
+        
+        EDIFHierCellInst inst0 = netlist.getHierCellInstFromName(name0);
+        EDIFHierCellInst inst1 = netlist.getHierCellInstFromName(name1);
+        
+        EDIFHierCellInst commonAncestor = inst0.getCommonAncestor(inst1);
+        
+        String commonPrefix = Strings.commonPrefix(name0, name1); 
+        Assertions.assertEquals(commonAncestor.getFullHierarchicalInstName(), 
+                commonPrefix.substring(0, commonPrefix.lastIndexOf('/')));
+        
+        String name2 = "u_ila_0/inst/ila_core_inst/basic_trigger_reg";
+        
+        EDIFHierCellInst inst2 = netlist.getHierCellInstFromName(name2);
+        commonAncestor = inst1.getCommonAncestor(inst2);
+        Assertions.assertEquals(commonAncestor, netlist.getTopHierCellInst());
+    }
+}

--- a/test/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
+++ b/test/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
@@ -18,12 +18,13 @@ public class TestEDIFHierCellInst {
         EDIFNetlist netlist = d.getNetlist();
 
         EDIFHierCellInst topInst = netlist.getTopHierCellInst();
-        Queue<EDIFHierCellInst> q = new LinkedList<>(topInst.getImmediateChildren());
+        Queue<EDIFHierCellInst> q = new LinkedList<>();
+        topInst.addChildren(q);
         while(!q.isEmpty()) {
             EDIFHierCellInst curr = q.poll();
-            Assertions.assertTrue(curr.isAncestor(topInst));
-            Assertions.assertFalse(topInst.isAncestor(curr));
-            q.addAll(curr.getImmediateChildren());
+            Assertions.assertTrue(curr.isDescendantOf(topInst));
+            Assertions.assertFalse(topInst.isDescendantOf(curr));
+            curr.addChildren(q);
         }
     }
     

--- a/test/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
+++ b/test/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
@@ -29,7 +29,7 @@ public class TestEDIFHierCellInst {
     }
     
     @Test
-    public void testgetCommonAncestor() {
+    public void testGetCommonAncestor() {
         Design d = Design.readCheckpoint(RapidWrightDCP.getPath("microblazeAndILA_3pblocks.dcp"), true);
         EDIFNetlist netlist = d.getNetlist();
 

--- a/test/com/xilinx/rapidwright/edif/TestEDIFTools.java
+++ b/test/com/xilinx/rapidwright/edif/TestEDIFTools.java
@@ -1,0 +1,58 @@
+package com.xilinx.rapidwright.edif;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+
+public class TestEDIFTools {
+
+    public static final String UNIQUE_SUFFIX = "TestEDIFToolsWasHere";
+    
+    @Test
+    public void testConnectPortInstsThruHier() {
+        Design d = Design.readCheckpoint(RapidWrightDCP.getPath("microblazeAndILA_3pblocks.dcp"), true);
+        EDIFNetlist netlist = d.getNetlist();
+        
+        EDIFHierPortInst srcPortInst = netlist.getHierPortInstFromName("base_mb_i/microblaze_0/U0/"
+                + "MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Data_Flow_Logic_I/Gen_Bits[22]."
+                + "MEM_EX_Result_Inst/Using_FPGA.Native/Q");
+        EDIFHierPortInst snkPortInst = netlist.getHierPortInstFromName("u_ila_0/inst/PROBE_PIPE."
+                + "shift_probes_reg[0][7]/D");
+        
+        // Disconnect sink in anticipation of connecting to another net
+        snkPortInst.getNet().removePortInst(snkPortInst.getPortInst());
+        
+        EDIFTools.connectPortInstsThruHier(srcPortInst, snkPortInst, netlist, UNIQUE_SUFFIX);
+        
+        netlist.resetParentNetMap();
+        
+        
+        List<EDIFHierNet> netAliases = netlist.getNetAliases(srcPortInst.getHierarchicalNet());
+        Assertions.assertEquals(netAliases.size(), 16);
+        boolean containsSnkNet = false;
+        for(EDIFHierNet net : netAliases) {
+            if(net.getHierarchicalNetName().equals(snkPortInst.getHierarchicalNetName())) {
+                containsSnkNet = true;
+            }
+        }
+        Assertions.assertTrue(containsSnkNet);
+        
+        
+        List<EDIFHierPortInst> portInsts = netlist.getPhysicalPins(srcPortInst.getHierarchicalNet());
+        Assertions.assertEquals(portInsts.size(), 6);
+        boolean containsSnk = false;
+        for(EDIFHierPortInst sink : portInsts) {
+            if(sink.toString().equals(snkPortInst.toString())) {
+                containsSnk = true;
+            }
+        }
+        Assertions.assertTrue(containsSnk);
+        
+        
+        
+    }
+}


### PR DESCRIPTION
Improves and makes more robust EDIFTools.connectPortInstsThruHier() by leveraging the EDIFHierCellInst rewrite last year.  

Signed-off-by: Chris Lavin <clavin@xilinx.com>