### PR TITLE
First cut at tracking logical cell changes

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -34,6 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Queue;
 
 /**
@@ -211,7 +212,10 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
 	}
 	
 	public EDIFNet removeNet(String name){
-		if(nets == null) return null;;
+		if(nets == null) return null;
+		if(isTrackingChanges()) {
+		    getNetlist().addModifiedCell(this);
+		}
 		return nets.remove(name);
 	}
 	/**
@@ -280,6 +284,9 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
 	
 	public EDIFCellInst removeCellInst(String name){
 		if(instances == null) return null;
+		if(isTrackingChanges()) {
+		    getNetlist().addModifiedCell(this);
+		}		
 		return instances.remove(name);
 	}
 	
@@ -331,6 +338,9 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
         }
         for(String s : portObjectsToRemove) {
             getPortMap().remove(s);
+        }
+        if(isTrackingChanges() && portObjectsToRemove.size() > 0) {
+            getNetlist().addModifiedCell(this);
         }
     }
 	
@@ -464,6 +474,9 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
 		instances = null;
 		nets = null;
 		internalPortMap = null;
+		if(isTrackingChanges()) {
+		    getNetlist().addModifiedCell(this);
+		}
 	}
 	
 	public void exportEDIF(Writer wr) throws IOException{
@@ -540,6 +553,30 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
 			}
 		}
 		return leafCells;
+    }
+
+    public EDIFNetlist getNetlist() {
+        EDIFLibrary lib = getLibrary();
+        return lib != null ? lib.getNetlist() : null;
+    }
+    
+    public boolean isTrackingChanges() {
+        EDIFNetlist netlist = getNetlist();
+        return netlist == null ? false : netlist.isTrackingCellChanges();
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EDIFCell edifCell = (EDIFCell) o;
+        return Objects.equals(library, edifCell.library);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), library);
     }
 }
  

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -181,6 +181,9 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
      */
     public void setParentCell(EDIFCell parent) {
         this.parentCell = parent;
+        if(parent.isTrackingChanges()) {
+            parent.getNetlist().addModifiedCell(parent);
+        }
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -181,9 +181,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
      */
     public void setParentCell(EDIFCell parent) {
         this.parentCell = parent;
-        if(parent.isTrackingChanges()) {
-            parent.getNetlist().addModifiedCell(parent);
-        }
+        parent.trackChange(EDIFChangeType.CELL_INST_ADD, getName());
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFChange.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFChange.java
@@ -1,0 +1,82 @@
+/*
+ * 
+ * Copyright (c) 2022 Xilinx, Inc. 
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright. 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.xilinx.rapidwright.edif;
+
+/**
+ * Represents a unit of change within an EDIFCell.  The 'name' of the object to add/remove and
+ * the associated 'type' of action taken. See also {@link EDIFChangeType}.
+ * 
+ */
+public class EDIFChange {
+
+    private EDIFChangeType type;
+    
+    private String name;
+
+    public EDIFChange(EDIFChangeType type, String name) {
+        super();
+        this.type = type;
+        this.name = name;
+    }
+
+    public EDIFChangeType getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        EDIFChange other = (EDIFChange) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (type != other.type)
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "EDIFChange [type=" + type + ", name=" + name + "]";
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/EDIFChangeNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFChangeNet.java
@@ -1,0 +1,79 @@
+/*
+ * 
+ * Copyright (c) 2022 Xilinx, Inc. 
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright. 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.xilinx.rapidwright.edif;
+
+/**
+ * Keeps track of an EDIFNet change such as an add or removal of a EDIFPortInst.
+ *
+ */
+public class EDIFChangeNet extends EDIFChange {
+
+    private String netName;
+    
+    private String instName; 
+
+    public EDIFChangeNet(EDIFChangeType type, String name, String netName, String instName) {
+        super(type, name);
+        this.netName = netName;
+        this.instName = instName;
+    }
+
+    public String getNetName() {
+        return netName;
+    }
+    
+    public String getInstName() {
+        return instName;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((netName == null) ? 0 : netName.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        EDIFChangeNet other = (EDIFChangeNet) obj;
+        if (netName == null) {
+            if (other.netName != null)
+                return false;
+        } else if (!netName.equals(other.netName))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "EDIFChangeNet [netName=" + netName + ", instName=" + instName + ", type=" + getType()
+                + ", portInstName=" + getName() + "]";
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/EDIFChangeType.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFChangeType.java
@@ -1,0 +1,39 @@
+/*
+ * 
+ * Copyright (c) 2022 Xilinx, Inc. 
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, Xilinx Research Labs.
+ *
+ * This file is part of RapidWright. 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.xilinx.rapidwright.edif;
+
+/**
+ * Enumerates a set of EDIFCell modification types. These are usually coupled with an EDIF
+ * object String name.  See also {@link EDIFChange}  
+ * 
+ */
+public enum EDIFChangeType {
+    CELL_INST_REMOVE,
+    CELL_INST_ADD,
+    NET_REMOVE,
+    NET_ADD,
+    PORT_REMOVE,
+    PORT_ADD,
+    PORT_INST_REMOVE,
+    PORT_INST_ADD,
+}

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -284,6 +284,9 @@ public class EDIFNet extends EDIFPropertyObject {
 	 */
 	public void setParentCell(EDIFCell parentCell) {
 		this.parentCell = parentCell;
+		if(parentCell.isTrackingChanges()) {
+		    parentCell.getNetlist().addModifiedCell(parentCell);
+		}
 	}
 	
 	public void exportEDIF(Writer wr) throws IOException {

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -78,6 +78,7 @@ public class EDIFNet extends EDIFPropertyObject {
 		}
 		portInst.setParentNet(this);
 		if(isParentCellNonNull) {
+		    // This does not explicitly track the port instance index, in most cases the name should be sufficient.
 		    trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
 		}
 		portInsts.add(portInst);

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -282,6 +282,7 @@ public class EDIFNet extends EDIFPropertyObject {
 	public EDIFPortInst removePortInst(EDIFCellInst inst, String portInstName){
         if (portInsts == null) return null;
         if(parentCell != null) {
+            // This does not explicitly track the port instance index, in most cases the name should be sufficient.
             trackChanges(EDIFChangeType.PORT_INST_REMOVE, inst, portInstName);
         }
         EDIFPortInst tmp = portInsts.remove(inst, portInstName);

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -282,7 +282,7 @@ public class EDIFNet extends EDIFPropertyObject {
 	public EDIFPortInst removePortInst(EDIFCellInst inst, String portInstName){
         if (portInsts == null) return null;
         if(parentCell != null) {
-            trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInstName);
+            trackChanges(EDIFChangeType.PORT_INST_REMOVE, inst, portInstName);
         }
         EDIFPortInst tmp = portInsts.remove(inst, portInstName);
 		if(tmp != null) tmp.setParentNet(null);

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1726,22 +1726,43 @@ public class EDIFNetlist extends EDIFName {
         BinaryEDIFWriter.writeBinaryEDIF(fileName, this);
     }
     
+    /**
+     * Checks a flag indicating if this netlist is currently tracking changes to its EDIFCells.
+     * Modified EDIFCells are tracked in a set which can be queried with {@link #getModifiedCells()}.
+     * EDIFCells are determined as modified if one of the following is true: 
+     *   (1) A port was removed, added or modified
+     *   (2) A net was removed, added or modified
+     *   (3) An instance was removed, added or modified 
+     * @return True if this netlist is tracking EDIFCell changes, false otherwise.
+     */
 	public boolean isTrackingCellChanges() {
         return trackCellChanges;
     }
 
+    /**
+     * Flag to track changes to EDIFCell changes to this netlist. See {@link #isTrackingCellChanges()}
+     * @param trackCellChanges True to enable tracking of EDIFCells, false to stop tracking
+     */
     public void setTrackCellChanges(boolean trackCellChanges) {
         this.trackCellChanges = trackCellChanges;
-        if(trackCellChanges && modifiedCells == null) {
-            modifiedCells = new HashSet<>();
-        }
     }
 
+    /**
+     * Gets the set of modified cells for this netlist.  These are accumulated when changes are 
+     * made to an EDIFCell and {@link #isTrackingCellChanges()} returns true.
+     * @return The set of modified EDIFCells
+     */
     public Set<EDIFCell> getModifiedCells() {
         return modifiedCells;
     }
     
+    /**
+     * Adds the EDIFCell to the set of modified EDIFCells for this netlist.
+     * @param cell The cell to add
+     * @return True if the cell was added to the set, false if the cell was already in the set.
+     */
     public boolean addModifiedCell(EDIFCell cell) {
+        if(modifiedCells == null) modifiedCells = new HashSet<>();
         return modifiedCells.add(cell);
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -104,6 +104,10 @@ public class EDIFNetlist extends EDIFName {
 	
 	private List<String> encryptedCells; 
 	
+	private boolean trackCellChanges = false;
+	
+	private Set<EDIFCell> modifiedCells = null;
+	
 	private boolean DEBUG = false;
 
 	/**
@@ -1722,7 +1726,26 @@ public class EDIFNetlist extends EDIFName {
         BinaryEDIFWriter.writeBinaryEDIF(fileName, this);
     }
     
-	public static void main(String[] args) throws FileNotFoundException {
+	public boolean isTrackingCellChanges() {
+        return trackCellChanges;
+    }
+
+    public void setTrackCellChanges(boolean trackCellChanges) {
+        this.trackCellChanges = trackCellChanges;
+        if(trackCellChanges && modifiedCells == null) {
+            modifiedCells = new HashSet<>();
+        }
+    }
+
+    public Set<EDIFCell> getModifiedCells() {
+        return modifiedCells;
+    }
+    
+    public boolean addModifiedCell(EDIFCell cell) {
+        return modifiedCells.add(cell);
+    }
+
+    public static void main(String[] args) throws FileNotFoundException {
 		CodePerfTracker t = new CodePerfTracker("EDIF Import/Export", true);
 		t.start("Read EDIF");
 		EDIFParser p = new EDIFParser(args[0]);

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -106,7 +106,7 @@ public class EDIFNetlist extends EDIFName {
 	
 	private boolean trackCellChanges = false;
 	
-	private Set<EDIFCell> modifiedCells = null;
+	private Map<EDIFCell, List<EDIFChange>> modifiedCells = null;
 	
 	private boolean DEBUG = false;
 
@@ -1746,26 +1746,22 @@ public class EDIFNetlist extends EDIFName {
     public void setTrackCellChanges(boolean trackCellChanges) {
         this.trackCellChanges = trackCellChanges;
     }
+    
+    public void trackChange(EDIFCell cell, EDIFChangeType type, String objectName) {
+        if(isTrackingCellChanges()) {
+            addTrackingChange(cell, new EDIFChange(type, objectName));
+        }
+    }
+    
+    public void addTrackingChange(EDIFCell cell, EDIFChange change) {
+        getModifiedCells().computeIfAbsent(cell, l -> new ArrayList<>()).add(change);
+    }
 
-    /**
-     * Gets the set of modified cells for this netlist.  These are accumulated when changes are 
-     * made to an EDIFCell and {@link #isTrackingCellChanges()} returns true.
-     * @return The set of modified EDIFCells
-     */
-    public Set<EDIFCell> getModifiedCells() {
+    public Map<EDIFCell, List<EDIFChange>> getModifiedCells(){
+        if(modifiedCells == null) modifiedCells = new HashMap<>();
         return modifiedCells;
     }
     
-    /**
-     * Adds the EDIFCell to the set of modified EDIFCells for this netlist.
-     * @param cell The cell to add
-     * @return True if the cell was added to the set, false if the cell was already in the set.
-     */
-    public boolean addModifiedCell(EDIFCell cell) {
-        if(modifiedCells == null) modifiedCells = new HashSet<>();
-        return modifiedCells.add(cell);
-    }
-
     public static void main(String[] args) throws FileNotFoundException {
 		CodePerfTracker t = new CodePerfTracker("EDIF Import/Export", true);
 		t.start("Read EDIF");

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -250,6 +250,9 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
 	 */
 	public void setParentCell(EDIFCell parentCell) {
 		this.parentCell = parentCell;
+		if(parentCell.isTrackingChanges()) {
+		    parentCell.getNetlist().addModifiedCell(parentCell);
+		}
 	}
 
 	/**

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -250,9 +250,7 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
 	 */
 	public void setParentCell(EDIFCell parentCell) {
 		this.parentCell = parentCell;
-		if(parentCell.isTrackingChanges()) {
-		    parentCell.getNetlist().addModifiedCell(parentCell);
-		}
+		parentCell.trackChange(EDIFChangeType.PORT_ADD, getName());
 	}
 
 	/**

--- a/test/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -25,6 +25,7 @@ package com.xilinx.rapidwright.edif;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
@@ -88,7 +89,7 @@ class TestEDIFNetlist {
 
         netlist.resetParentNetMap();
         
-        Set<EDIFCell> modifiedCells = netlist.getModifiedCells();
+        Map<EDIFCell,List<EDIFChange>> modifiedCells = netlist.getModifiedCells();
         
         Assertions.assertEquals(modifiedCells.size(), 8);
         
@@ -97,7 +98,7 @@ class TestEDIFNetlist {
             potentiallyModifiedCells.add(logNets.getParentInst().getCellType());
         }
         
-        for(EDIFCell modifiedCell : modifiedCells) {
+        for(EDIFCell modifiedCell : modifiedCells.keySet()) {
             Assertions.assertTrue(potentiallyModifiedCells.contains(modifiedCell));
         }
     }

--- a/test/com/xilinx/rapidwright/edif/TestEDIFTools.java
+++ b/test/com/xilinx/rapidwright/edif/TestEDIFTools.java
@@ -12,16 +12,19 @@ public class TestEDIFTools {
 
     public static final String UNIQUE_SUFFIX = "TestEDIFToolsWasHere";
     
+    public static final String TEST_SRC = "base_mb_i/microblaze_0/U0/"
+            + "MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Data_Flow_Logic_I/Gen_Bits[22]."
+            + "MEM_EX_Result_Inst/Using_FPGA.Native/Q"; 
+    public static final String TEST_SNK = "u_ila_0/inst/PROBE_PIPE."
+            + "shift_probes_reg[0][7]/D"; 
+    
     @Test
     public void testConnectPortInstsThruHier() {
         Design d = Design.readCheckpoint(RapidWrightDCP.getPath("microblazeAndILA_3pblocks.dcp"), true);
         EDIFNetlist netlist = d.getNetlist();
         
-        EDIFHierPortInst srcPortInst = netlist.getHierPortInstFromName("base_mb_i/microblaze_0/U0/"
-                + "MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Data_Flow_Logic_I/Gen_Bits[22]."
-                + "MEM_EX_Result_Inst/Using_FPGA.Native/Q");
-        EDIFHierPortInst snkPortInst = netlist.getHierPortInstFromName("u_ila_0/inst/PROBE_PIPE."
-                + "shift_probes_reg[0][7]/D");
+        EDIFHierPortInst srcPortInst = netlist.getHierPortInstFromName(TEST_SRC);
+        EDIFHierPortInst snkPortInst = netlist.getHierPortInstFromName(TEST_SNK);
         
         // Disconnect sink in anticipation of connecting to another net
         snkPortInst.getNet().removePortInst(snkPortInst.getPortInst());


### PR DESCRIPTION
This adds a capability to the logical netlist to keep track of `EDIFCell` objects that are modified by monitoring basic APIs.  It does not consider cells that have their name changed or to switch to a different library as a trigger for tracking.