### PR TITLE
Allows copyImplementation() to work with a dest top cell.

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2130,9 +2130,11 @@ public class DesignTools {
 	}
 
 	/**
-	 * Copies the logic and implementation of a set of cells from one design to another.
+	 * Copies the logic and implementation of a set of cells from one design to another.  This will
+	 * replace the destination logical cell instances with those of the source design. 
 	 * @param src The source design (with partial or full implementation)
-	 * @param dest The destination design (with matching cell instance interfaces) 
+	 * @param dest The destination design (with matching cell instance interfaces). If targeting
+	 * the top instance, use an empty String ("") 
 	 * @param lockPlacement Flag indicating if the destination implementation copy should have the 
 	 * 	placement locked
 	 * @param lockRouting Flag indicating if the destination implementation copy should have the 

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2133,14 +2133,14 @@ public class DesignTools {
 	 * Copies the logic and implementation of a set of cells from one design to another.  This will
 	 * replace the destination logical cell instances with those of the source design. 
 	 * @param src The source design (with partial or full implementation)
-	 * @param dest The destination design (with matching cell instance interfaces). If targeting
-	 * the top instance, use an empty String ("") 
+	 * @param dest The destination design (with matching cell instance interfaces).  
 	 * @param lockPlacement Flag indicating if the destination implementation copy should have the 
 	 * 	placement locked
 	 * @param lockRouting Flag indicating if the destination implementation copy should have the 
 	 * 	routing locked
 	 * @param srcToDestInstNames A map of source (key) to destination (value) pairs of cell 
-	 * instances from which to copy the implementation
+	 * instances from which to copy the implementation. If targeting the top instance, use an 
+	 * empty String ("") as the destination instance name.
 	 */
 	public static void copyImplementation(Design src, Design dest, boolean lockPlacement, 
 			boolean lockRouting, Map<String,String> srcToDestInstNames) {


### PR DESCRIPTION
This was originally included in #385, but it has been isolated here as its own PR.