### PR TITLE
EDIFCellInst and EDIFNetlist small fixes

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -263,4 +263,24 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
     public String getUniqueKey() {
         return getCellType().getUniqueKey() + "_" + getParentCell().getUniqueKey() + "_" + getName();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o))
+            return false;
+        EDIFCellInst that = (EDIFCellInst) o;
+
+        if (!parentCell.equals(that.parentCell))
+            return false;
+
+        if (!cellType.equals(that.cellType))
+            return false;
+
+        if (!viewref.equals(that.viewref))
+            return false;
+
+        return true;
+    }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1203,7 +1203,8 @@ public class EDIFNetlist extends EDIFName {
 	 * @return The physical/parent net name or null if none could be found.
 	 */
 	public String getParentNetName(String netAlias){
-		return getParentNetMap().get(getHierNetFromName(netAlias)).getHierarchicalNetName();
+		EDIFHierNet parentNet = getParentNetMap().get(getHierNetFromName(netAlias));
+		return (parentNet != null) ? parentNet.getHierarchicalNetName() : null;
 	}
 	/**
 	 * Gets the canonical net for this net name.  This corresponds to the driving net


### PR DESCRIPTION
* Add `EDIFCellInst.equals()` override
* `EDIFNetlist.getParentNetName()` to be sensitive to `parentNet == null`