### PR TITLE
DesignTools.batchRemoveSitePins() to do SitePinInst.detachSiteInst()

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1304,10 +1304,7 @@ public class DesignTools {
 	                    net.setSource(null);
 	                }
 	                pin.setNet(null);
-	                if(pin.getSiteInst() != null){
-	                    BELPin belPin = pin.getBELPin();
-	                    pin.getSiteInst().unrouteIntraSiteNet(belPin, belPin); 
-	                }
+	                pin.detachSiteInst();
 	                continue;
 	            }
 	            pins.add(pin);

--- a/test/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -22,12 +22,15 @@
  
 package com.xilinx.rapidwright.design;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
@@ -101,6 +104,33 @@ public class TestDesignTools {
             }else {
                 Assertions.assertNotEquals(dstSiteInst.getNetFromSiteWire(siteWireName), 
                                         dstDesign.getVccNet());
+            }
+        }
+    }
+
+    @Test
+    public void testBatchRemoveSitePins() {
+        Path dcpPath = RapidWrightDCP.getPath("picoblaze_ooc_X10Y235.dcp");
+        Design design = Design.readCheckpoint(dcpPath);
+
+        SiteInst si = design.getSiteInstFromSiteName("SLICE_X14Y238");
+        Assertions.assertNotNull(si);
+
+        Map<Net, Set<SitePinInst>> deferredRemovals = new HashMap<>();
+        for (SitePinInst spi : si.getSitePinInsts()) {
+            Net net = spi.getNet();
+            Assertions.assertNotNull(net);
+            deferredRemovals.computeIfAbsent(net, ($) -> new HashSet<>()).add(spi);
+        }
+
+        DesignTools.batchRemoveSitePins(deferredRemovals, true);
+
+        Assertions.assertTrue(si.getSitePinInstMap().isEmpty());
+
+        Map<String,Net> netSiteWireMap = si.getNetSiteWireMap();
+        for (Map.Entry<Net, Set<SitePinInst>> e : deferredRemovals.entrySet()) {
+            for (SitePinInst spi : e.getValue()) {
+                Assertions.assertFalse(netSiteWireMap.containsKey(spi.getSiteWireName()));
             }
         }
     }


### PR DESCRIPTION
This ensures that the `SiteInst.getNetFromSiteWire()` is updated correctly, on top of unrouting the (directly-connected) intra-site sitewire as done currently.

What remains to be done is to rip up any indirectly-connected sitewires too (e.g. those behind a site PIP)