### PR TITLE
Fix netlist issue when ordering cells for export

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
@@ -247,7 +247,7 @@ public class EDIFLibrary extends EDIFName {
 		yetToVisit.remove(cell.getLegalEDIFName());
 		for(EDIFCellInst i : cell.getCellInsts()){
 			EDIFCell childCell = i.getCellType();
-			if(containsCell(childCell) && yetToVisit.containsKey(childCell.getLegalEDIFName())){
+			if(childCell.getLibrary() == this && containsCell(childCell) && yetToVisit.containsKey(childCell.getLegalEDIFName())){
 				visit(childCell,visited,yetToVisit);
 			}
 		}

--- a/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
@@ -247,7 +247,7 @@ public class EDIFLibrary extends EDIFName {
 		yetToVisit.remove(cell.getLegalEDIFName());
 		for(EDIFCellInst i : cell.getCellInsts()){
 			EDIFCell childCell = i.getCellType();
-			if(childCell.getLibrary() == this && containsCell(childCell) && yetToVisit.containsKey(childCell.getLegalEDIFName())){
+			if(childCell.getLibrary() == this && yetToVisit.containsKey(childCell.getLegalEDIFName())){
 				visit(childCell,visited,yetToVisit);
 			}
 		}


### PR DESCRIPTION
During what seems like some rare circumstances, the ordering of cells on export can mistakenly find a false dependency if the library is not checked.  This ensures the library is checked as part of the new ordering so that identically named cells aren't mistaken.  