### PR TITLE
Fix thread pool for single processor case

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+	jvm_opt: [, -Dorg.gradle.jvmargs=-XX:ActiveProcessorCount=1]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +47,7 @@ jobs:
         run: ./gradlew assemble
 
       - name: Test
-        run: ./gradlew test
+        run: ./gradlew test ${{ matrix.jvm_opt }}
 
       - name: Archive Java Test Report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-	jvm_opt: [, -Dorg.gradle.jvmargs=-XX:ActiveProcessorCount=1]
+        single_threaded: [0, 1]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
         run: ./gradlew assemble
 
       - name: Test
-        run: ./gradlew test ${{ matrix.jvm_opt }}
+        run: ./gradlew -PlimitToSingleProc=${{ matrix.single_threaded }} test 
 
       - name: Archive Java Test Report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        single_threaded: [0, 1]
+        single_threaded: [multi-threaded, single-threaded]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/common.gradle
+++ b/common.gradle
@@ -45,7 +45,7 @@ dependencies {
 if (org.gradle.api.JavaVersion.current().isJava10Compatible()) {
 	applicationDefaultJvmArgs = ["--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"]
 }
-if(project.hasProperty('limitToSingleProc') && limitToSingleProc.equals("1")) {
+if(project.hasProperty('limitToSingleProc') && limitToSingleProc.equals("single-threaded")) {
 	applicationDefaultJvmArgs << "-XX:ActiveProcessorCount=1"
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -45,7 +45,7 @@ dependencies {
 if (org.gradle.api.JavaVersion.current().isJava10Compatible()) {
 	applicationDefaultJvmArgs = ["--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"]
 }
-if(limitToSingleProc.equals("1")) {
+if(project.hasProperty('limitToSingleProc') && limitToSingleProc.equals("1")) {
 	applicationDefaultJvmArgs << "-XX:ActiveProcessorCount=1"
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -5,8 +5,6 @@ apply plugin: "java-test-fixtures"
 sourceCompatibility = 8
 targetCompatibility = 8
 
-def rapidwrightDir = System.getenv("RAPIDWRIGHT_PATH") ?: file('.').toString()
-
 repositories {
     if (project.hasProperty('additionalMavenRepo')) {
       project.logger.lifecycle('Adding Maven Repository at '+additionalMavenRepo)
@@ -47,6 +45,10 @@ dependencies {
 if (org.gradle.api.JavaVersion.current().isJava10Compatible()) {
 	applicationDefaultJvmArgs = ["--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"]
 }
+if(limitToSingleProc.equals("1")) {
+	applicationDefaultJvmArgs << "-XX:ActiveProcessorCount=1"
+}
+
 
 configurations.implementation.canBeResolved = true
 configurations.testImplementation.canBeResolved = true
@@ -58,11 +60,11 @@ tasks.withType(Test) {
   //Propagate JVM settings to test JVM
   jvmArgs applicationDefaultJvmArgs
 
-  environment 'RAPIDWRIGHT_PATH', rapidwrightDir
+  environment 'RAPIDWRIGHT_PATH', gradle.ext.rapidwrightDir
 
   //We need to rerun tests when the data files change
-  if (file(rapidwrightDir + '/data').exists()) {
-    inputs.dir file(rapidwrightDir + '/data')
+  if (new File(gradle.ext.rapidwrightDir, 'data').exists()) {
+    inputs.dir new File(gradle.ext.rapidwrightDir, 'data')
   }
 }
 

--- a/src/com/xilinx/rapidwright/util/ParallelismTools.java
+++ b/src/com/xilinx/rapidwright/util/ParallelismTools.java
@@ -62,21 +62,24 @@ public class ParallelismTools {
 
     /** A fixed-size thread pool with as many threads as there are processors
      * minus one, fed by a single task queue */
-    private static final ThreadPoolExecutor pool = new ThreadPoolExecutor(
-            maxParallelism() - 1,
-            maxParallelism() - 1,
-            0, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(),
-            (r) -> {
-                Thread t = Executors.defaultThreadFactory().newThread(r);
-                t.setDaemon(true);
-                t.setName("RapidWright-ParallelismTools-Worker-"+ threadId.getAndIncrement());
-                return t;
-            });
+    private static final ThreadPoolExecutor pool;
 
     private static boolean parallel = true;
 
     static {
+        int maxParallelism = maxParallelism(); 
+        pool = new ThreadPoolExecutor(
+                maxParallelism - 1,
+                Integer.max(maxParallelism - 1, 1),
+                0, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(),
+                (r) -> {
+                    Thread t = Executors.defaultThreadFactory().newThread(r);
+                    t.setDaemon(true);
+                    t.setName("RapidWright-ParallelismTools-Worker-"+ threadId.getAndIncrement());
+                    return t;
+                });
+        
         String value = System.getenv(RW_PARALLEL);
         setParallel(value == null || !(value.equals("0") || value.equalsIgnoreCase("false")));
     }

--- a/src/com/xilinx/rapidwright/util/ParallelismTools.java
+++ b/src/com/xilinx/rapidwright/util/ParallelismTools.java
@@ -62,24 +62,21 @@ public class ParallelismTools {
 
     /** A fixed-size thread pool with as many threads as there are processors
      * minus one, fed by a single task queue */
-    private static final ThreadPoolExecutor pool;
+    private static final ThreadPoolExecutor pool = new ThreadPoolExecutor(
+            maxParallelism() - 1,
+            maxParallelism() - 1,
+            0, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(),
+            (r) -> {
+                Thread t = Executors.defaultThreadFactory().newThread(r);
+                t.setDaemon(true);
+                t.setName("RapidWright-ParallelismTools-Worker-"+ threadId.getAndIncrement());
+                return t;
+            });
 
     private static boolean parallel = true;
 
     static {
-        int maxParallelism = maxParallelism(); 
-        pool = new ThreadPoolExecutor(
-                maxParallelism - 1,
-                Integer.max(maxParallelism - 1, 1),
-                0, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<>(),
-                (r) -> {
-                    Thread t = Executors.defaultThreadFactory().newThread(r);
-                    t.setDaemon(true);
-                    t.setName("RapidWright-ParallelismTools-Worker-"+ threadId.getAndIncrement());
-                    return t;
-                });
-        
         String value = System.getenv(RW_PARALLEL);
         setParallel(value == null || !(value.equals("0") || value.equalsIgnoreCase("false")));
     }


### PR DESCRIPTION
When running in the `mybinder.org` Docker, only a single processor core is allocated to run the Jupyter Notebook.  The parameters to `ThreadPoolExecutor` were not legal and was throwing an `IllegalArgumentException`:

```
jshell> import com.xilinx.rapidwright.util.ParallelismTools;

jshell> ParallelismTools.get
get(            getParallel()
jshell> ParallelismTools.getParallel()
|  Exception java.lang.ExceptionInInitializerError
|        at (#2:1)
|  Caused by: java.lang.IllegalArgumentException
|        at ThreadPoolExecutor.<init> (ThreadPoolExecutor.java:1293)
|        at ThreadPoolExecutor.<init> (ThreadPoolExecutor.java:1215)
|        at ParallelismTools.<clinit> (ParallelismTools.java:67)
|        ...
```

This fixes the issue.