### PR TITLE
Save some memory in EDIF

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFName.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFName.java
@@ -163,7 +163,8 @@ public class EDIFName implements Comparable<EDIFName> {
 	}
 	
 	public <K, V> Map<K, V> getNewMap(){
-		return new HashMap<K,V>();
+		//Save some memory for small maps
+		return new HashMap<K,V>(2);
 	}
 
 	public int compareTo(EDIFName o) {

--- a/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
@@ -246,7 +246,7 @@ public class ParallelEDIFParser implements AutoCloseable{
                 w-> {
                     for (List<ParallelEDIFParserWorker.LinkPortInstData> list : w.linkPortInstData) {
                         for (ParallelEDIFParserWorker.LinkPortInstData linkPortInstData : list) {
-                            linkPortInstData.name();
+                            linkPortInstData.name(uniquifier);
                             linkPortInstData.add();
                         }
                     }

--- a/src/com/xilinx/rapidwright/edif/ParallelEDIFParserWorker.java
+++ b/src/com/xilinx/rapidwright/edif/ParallelEDIFParserWorker.java
@@ -360,9 +360,9 @@ public class ParallelEDIFParserWorker extends AbstractEDIFParserWorker implement
             portInst.setPort(port);
         }
 
-        public void name() {
+        public void name(StringPool uniquifier) {
             String portInstName = portInst.getPortInstNameFromPort();
-            portInst.setName(portInstName);
+            portInst.setName(uniquifier.uniquifyName(portInstName));
         }
 
         public void add() {


### PR DESCRIPTION
* Lower the initial size of HashMaps to conserve space
* The parallel EDIF parser did not uniquify port inst names