### PR TITLE
Fix for uniqueify netlist (previously flatten netlist)

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -473,7 +473,7 @@ public class EDIFTools {
 	 * Connects two existing logical port insts together by creating new ports and nets on all cells
 	 * instantiated between their levels of hierarchy.  It assumes the netlist cells involved only
 	 * have one instance (does not differentiate cells when creating the ports).  This assumption 
-	 * can be enforce by calling {@link #flattenNetlist(Design)}. If the src or snk
+	 * can be enforce by calling {@link #uniqueifyNetlist(Design)}. If the src or snk
 	 * port insts do net have nets connected, it will create them and connect them in their parent
 	 * cell definition.
 	 * @param src The logical port inst driver or source  
@@ -1116,10 +1116,10 @@ public class EDIFTools {
 	 * @param netlist The netlist to build the map from.
 	 * @return The populated map of cells to list of hierarchical instances.
 	 */
-	public static HashMap<EDIFLibrary, HashMap<EDIFCell, ArrayList<EDIFHierCellInst>>> 
+	public static Map<EDIFLibrary, Map<EDIFCell, List<EDIFHierCellInst>>> 
 							createCellInstanceMap(EDIFNetlist netlist) {
-		HashMap<EDIFLibrary, HashMap<EDIFCell, ArrayList<EDIFHierCellInst>>> cellInstMap = 
-				new HashMap<EDIFLibrary, HashMap<EDIFCell, ArrayList<EDIFHierCellInst>>>();
+		Map<EDIFLibrary, Map<EDIFCell, List<EDIFHierCellInst>>> cellInstMap = 
+				new HashMap<EDIFLibrary, Map<EDIFCell, List<EDIFHierCellInst>>>();
 		
 		Queue<EDIFHierCellInst> toProcess = new LinkedList<EDIFHierCellInst>();
 		netlist.getTopHierCellInst().addChildren(toProcess);
@@ -1128,10 +1128,10 @@ public class EDIFTools {
 			EDIFHierCellInst curr = toProcess.poll();
 			
 			EDIFLibrary lib = curr.getCellType().getLibrary();
-			HashMap<EDIFCell, ArrayList<EDIFHierCellInst>> cellMap = cellInstMap.computeIfAbsent(lib, k -> new HashMap<>());
+			Map<EDIFCell, List<EDIFHierCellInst>> cellMap = cellInstMap.computeIfAbsent(lib, k -> new HashMap<>());
 
 			EDIFCell cell = curr.getCellType();
-			ArrayList<EDIFHierCellInst> insts = cellMap.computeIfAbsent(cell, k -> new ArrayList<>());
+			List<EDIFHierCellInst> insts = cellMap.computeIfAbsent(cell, k -> new ArrayList<>());
 			insts.add(curr);
 
 			if(curr.getInst().getCellType().getCellInsts() == null) {
@@ -1144,32 +1144,44 @@ public class EDIFTools {
 	
 		return cellInstMap;
 	}
-	
+
 	/**
-	 * Flattens the netlist by creating unique cells within each library except primitives and 
-	 * macros.  It also updates references throughout the logical and physical netlist so all 
-	 * references are self-consistent.  This transformation is useful when performing netlist 
-	 * manipulations such as adding/removing cells, ports or nets within a design.
-	 * @param design The design containing the netlist to flatten.
+	 * Duplicates EDIFCells such that each EDIFCellInst only instantiates an EDIFCell once 
+	 * (except primitives and macros).
+	 * @param design The design containing the netlist to uniqueify.
+	 * @deprecated 
+	 * Please use {@link #uniqueifyNetlist(Design)} instead
+	 * To be removed in 2022.2.0
 	 */
 	public static void flattenNetlist(Design design) {
+	    uniqueifyNetlist(design);
+	}
+	
+	/**
+	 * Duplicates EDIFCells such that each EDIFCellInst only instantiates an EDIFCell once 
+	 * (except primitives and macros).  It also updates references throughout the logical and 
+	 * physical netlist so all references are self-consistent.  This transformation is useful when 
+	 * performing netlist manipulations such as adding/removing cells, ports or nets within a design.
+	 * @param design The design containing the netlist to uniqueify.
+	 */
+	public static void uniqueifyNetlist(Design design) {
 		if(design.getModuleInsts().size() > 0) {
-			System.err.println("ERROR: Cannot flatten netlist, design contains ModuleInstances. "
+			System.err.println("ERROR: Cannot uniqueify netlist, design contains ModuleInstances. "
 					+ "Please call Design.flattenDesign() first.");
 			return;
 		}
 		EDIFNetlist netlist = design.getNetlist();
 		EDIFLibrary macros = Design.getMacroPrimitives(design.getDevice().getSeries());
-		HashMap<EDIFLibrary, HashMap<EDIFCell, ArrayList<EDIFHierCellInst>>> instMap = 
-																	createCellInstanceMap(netlist);
+		Map<EDIFLibrary, Map<EDIFCell, List<EDIFHierCellInst>>> instMap = createCellInstanceMap(netlist);
 		// Don't uniqueify primitive cell instances
 		instMap.remove(netlist.getHDIPrimitivesLibrary());
 		
-		HashMap<EDIFCell, ArrayList<EDIFHierCellInst>> toUniqueify = new HashMap<EDIFCell, ArrayList<EDIFHierCellInst>>();
+		Map<EDIFCell, List<EDIFHierCellInst>> toUniqueify 
+		                                    = new HashMap<EDIFCell, List<EDIFHierCellInst>>();
 		
 		for(EDIFLibrary lib : instMap.keySet()) {
-			HashMap<EDIFCell, ArrayList<EDIFHierCellInst>> cellMap = instMap.get(lib);
-			for(Entry<EDIFCell,ArrayList<EDIFHierCellInst>> e : cellMap.entrySet()) {
+			Map<EDIFCell, List<EDIFHierCellInst>> cellMap = instMap.get(lib);
+			for(Entry<EDIFCell,List<EDIFHierCellInst>> e : cellMap.entrySet()) {
 				// Also skip macros
 				if(macros.containsCell(e.getKey())) continue;
 				// Identify multiple instantiated cells
@@ -1188,11 +1200,11 @@ public class EDIFTools {
 	private static int unique = 1;
 	
 	private static void duplicateMultiInstCell(Design design, EDIFCell cell, 
-									HashMap<EDIFCell, ArrayList<EDIFHierCellInst>> toUniqueify) {
+									Map<EDIFCell, List<EDIFHierCellInst>> toUniqueify) {
 		EDIFNetlist netlist = design.getNetlist();
 		// Check that all higher level cells don't have multiple shared cell definitions, before
 		// duplicating this one		
-		ArrayList<EDIFHierCellInst> insts = toUniqueify.get(cell);
+		List<EDIFHierCellInst> insts = toUniqueify.get(cell);
 		if(insts == null) {
 			// Already processed, or no duplicates
 			return;
@@ -1203,7 +1215,7 @@ public class EDIFTools {
 			for(int i=1; i < instParents.length; i++) {
 				EDIFCellInst parent = netlist.getCellInstFromHierName(sb.toString());
 				if(parent != null) {
-					ArrayList<EDIFHierCellInst> parentDuplicates = toUniqueify.get(parent.getCellType());
+					List<EDIFHierCellInst> parentDuplicates = toUniqueify.get(parent.getCellType());
 					if(parentDuplicates != null) {
 						duplicateMultiInstCell(design, parent.getCellType(), toUniqueify);
 					}					
@@ -1224,7 +1236,17 @@ public class EDIFTools {
 			EDIFCell newCell = new EDIFCell(origCell.getLibrary(), origCell, origCell.getName() 
 					+ "_RW" + unique++);
 			cellInst.getInst().setCellType(newCell);
-			
+			for(EDIFCellInst newInstCopy : newCell.getCellInsts()) {
+			    List<EDIFHierCellInst> instsToUniqueify = toUniqueify.get(newInstCopy.getCellType());
+			    if(instsToUniqueify == null) continue; 
+			    for(int i=0; i < instsToUniqueify.size(); i++) {
+			        EDIFHierCellInst hierInst = instsToUniqueify.get(i);
+			        if(newInstCopy.getName().equals(hierInst.getInst().getName()) 
+			                && hierInst.isDescendantOf(cellInst)) {
+			            instsToUniqueify.set(i, hierInst.getSibling(newInstCopy));			                
+			        }
+			    }
+			}
 			// Update any physical cell references
 			for(EDIFCellInst inst : newCell.getCellInsts()) {
 				String potentialLeafCell = cellInst.getFullHierarchicalInstName() 
@@ -1250,7 +1272,7 @@ public class EDIFTools {
 	
 	/**
 	 * Connects an existing logical net to another instances by creating intermediate logical
-	 * nets and ports.  Design must be fully flattened (see {@link EDIFTools#flattenNetlist(Design)}.
+	 * nets and ports.  Design must be fully flattened (see {@link EDIFTools#uniqueifyNetlist(Design)}.
 	 *
 	 * Note: EDIF cell instances and nets can contain '/' within their name. This function currently does not support
 	 * designs containing these constructs.

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -473,7 +473,7 @@ public class EDIFTools {
 	 * Connects two existing logical port insts together by creating new ports and nets on all cells
 	 * instantiated between their levels of hierarchy.  It assumes the netlist cells involved only
 	 * have one instance (does not differentiate cells when creating the ports).  This assumption 
-	 * can be enforce by calling {@link #uniqueifyNetlist(Design)}. If the src or snk
+	 * can be enforced by calling {@link #uniqueifyNetlist(Design)}. If the src or snk
 	 * port insts do net have nets connected, it will create them and connect them in their parent
 	 * cell definition.
 	 * @param src The logical port inst driver or source  
@@ -1179,9 +1179,8 @@ public class EDIFTools {
 		Map<EDIFCell, List<EDIFHierCellInst>> toUniqueify 
 		                                    = new HashMap<EDIFCell, List<EDIFHierCellInst>>();
 		
-		for(EDIFLibrary lib : instMap.keySet()) {
-			Map<EDIFCell, List<EDIFHierCellInst>> cellMap = instMap.get(lib);
-			for(Entry<EDIFCell,List<EDIFHierCellInst>> e : cellMap.entrySet()) {
+		for(Entry<EDIFLibrary, Map<EDIFCell, List<EDIFHierCellInst>>> libEntry : instMap.entrySet()) {
+			for(Entry<EDIFCell,List<EDIFHierCellInst>> e : libEntry.getValue().entrySet()) {
 				// Also skip macros
 				if(macros.containsCell(e.getKey())) continue;
 				// Identify multiple instantiated cells


### PR DESCRIPTION
This PR fixes an issue in `EDIFTools.uniqueifyNetlist()` (refactored from `EDIFTools.flattenNetlist()`) where it would fail to uniqueify cells that had parent cells that were also being uniqueified.  