### PR TITLE
Test for Design.createModuleInst() copying Module's EDIFNetlist

### DIFF
--- a/src/com/xilinx/rapidwright/debug/ILAInserter.java
+++ b/src/com/xilinx/rapidwright/debug/ILAInserter.java
@@ -148,7 +148,6 @@ public class ILAInserter {
 		// Turn ILA into a module and instantiate it into the design
 		Module m = new Module(ila);
 		ModuleInst mi = original.createModuleInst(ila.getName(), m);
-		original.getNetlist().migrateCellAndSubCells(ila.getTopEDIFCell());
 		if(m.getAnchor() != null) {
 			mi.place(m.getAnchor());
 		}

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -568,7 +568,7 @@ public class EDIFNetlist extends EDIFName {
 			}
 			return newCell;
 		} else {
-			if (copiedCells.contains(existingCell)) {
+			if (destLib.isHDIPrimitivesLibrary() || copiedCells.contains(existingCell)) {
 				return existingCell;
 			}
 			throw new RuntimeException("ERROR: Destination netlist already contains EDIFCell named " +

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -537,6 +537,38 @@ public class EDIFNetlist extends EDIFName {
 			}
 		}
 	}
+
+	/**
+	 * This copies the cell and all of its descendants into this netlist.
+	 * @param cell The cell (and all its descendants) to copy into this netlist's libraries
+	 */
+	public void copyCellAndSubCells(EDIFCell cell) {
+		copyCellAndSubCellsWorker(cell);
+	}
+
+	private EDIFCell copyCellAndSubCellsWorker(EDIFCell cell) {
+		EDIFLibrary destLib = getLibrary(cell.getLibrary().getName());
+		if(destLib == null){
+			if(cell.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)){
+				destLib = getHDIPrimitivesLibrary();
+			}else{
+				destLib = getWorkLibrary();
+			}
+		}
+
+		EDIFCell existingCell = destLib.getCell(cell.getLegalEDIFName());
+		if(existingCell == null){
+			EDIFCell newCell = new EDIFCell(destLib, cell, cell.getName());
+			for(EDIFCellInst inst : newCell.getCellInsts()){
+				inst.setCellType(copyCellAndSubCellsWorker(inst.getCellType()));
+				//The view might have changed
+				inst.getViewref().setName(inst.getCellType().getView());
+			}
+			return newCell;
+		} else {
+			return existingCell;
+		}
+	}
 	
 	private boolean checkIfAlreadyInLib(EDIFCell cell, EDIFLibrary lib) {
 		EDIFCell existing = lib.getCell(cell.getLegalEDIFName());

--- a/src/com/xilinx/rapidwright/examples/PicoBlazeArray.java
+++ b/src/com/xilinx/rapidwright/examples/PicoBlazeArray.java
@@ -146,7 +146,6 @@ public class PicoBlazeArray {
 				updateAnchorToBRAM(mod);
 				picoBlazeImpls.add(mod);
 			}
-			netlist.migrateCellAndSubCells(moduleNetlist.getTopCell());
 
 			t.stop().start("Place PicoBlaze modules");
 

--- a/src/com/xilinx/rapidwright/util/RelocateModulesIntoBlackboxes.java
+++ b/src/com/xilinx/rapidwright/util/RelocateModulesIntoBlackboxes.java
@@ -64,7 +64,6 @@ public class RelocateModulesIntoBlackboxes {
 	public static boolean relocateModuleInsts(Design top, Module mod, String cellAnchor, List<Pair<String, String>> blackboxes) {
 		System.out.println("\n\nRelocate " + mod.getName());
 
-		EDIFNetlist netlist = top.getNetlist();
 		top.setAutoIOBuffers(false);
 
 		Site frSite = mod.getAnchor();

--- a/src/com/xilinx/rapidwright/util/RelocateModulesIntoBlackboxes.java
+++ b/src/com/xilinx/rapidwright/util/RelocateModulesIntoBlackboxes.java
@@ -65,7 +65,6 @@ public class RelocateModulesIntoBlackboxes {
 		System.out.println("\n\nRelocate " + mod.getName());
 
 		EDIFNetlist netlist = top.getNetlist();
-		netlist.migrateCellAndSubCells(mod.getNetlist().getTopCell());
 		top.setAutoIOBuffers(false);
 
 		Site frSite = mod.getAnchor();
@@ -98,7 +97,6 @@ public class RelocateModulesIntoBlackboxes {
 			}
 
 			ModuleInst mi = top.createModuleInst(cell.getFirst(), mod, true);
-			mi.getCellInst().setCellType(mod.getNetlist().getTopCell());
 			mi.place(toSite);
 		}
 		System.out.println("\n");

--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -107,11 +107,7 @@ public class TestDesign {
         Module module = new Module(createSampleDesign());
 
         Design design = new Design("top", device.getDeviceName());
-        EDIFNetlist netlist = design.getNetlist();
-        netlist.migrateCellAndSubCells(module.getNetlist().getTopCell());
-
         ModuleInst mi = design.createModuleInst("inst", module);
-        mi.getCellInst().setCellType(module.getNetlist().getTopCell());
         mi.placeOnOriginalAnchor();
         String oldAnchor = mi.getAnchor().toString();
 

--- a/test/src/com/xilinx/rapidwright/design/TestModuleInst.java
+++ b/test/src/com/xilinx/rapidwright/design/TestModuleInst.java
@@ -25,9 +25,12 @@ package com.xilinx.rapidwright.design;
 import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.Tile;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -52,7 +55,7 @@ public class TestModuleInst {
         design = null;
 
         ModuleInst mi = emptyDesign.createModuleInst("inst", module);
-        mi.placeOnOriginalAnchor();
+        Assertions.assertTrue(mi.placeOnOriginalAnchor());
 
         Assertions.assertTrue(emptyDesign.getVccNet().hasPIPs());
         Assertions.assertTrue(emptyDesign.getGndNet().hasPIPs());
@@ -75,7 +78,7 @@ public class TestModuleInst {
 
             boolean skipIncompatible = true; // Otherwise it fails when trying to move
                                              // the gap routing in the clock net
-            mi.place(ds, skipIncompatible);
+            Assertions.assertTrue(mi.place(ds, skipIncompatible));
         }
 
         HashSet<PIP> newVccPips = new HashSet<>(emptyDesign.getVccNet().getPIPs());
@@ -115,6 +118,39 @@ public class TestModuleInst {
             // Now they should be equal
             Assertions.assertEquals(expectedVccPips, newVccPips);
             Assertions.assertEquals(expectedGndPips, newGndPips);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1,2,5})
+    void testEDIFNetlistIsCopied(int copies) {
+        String dcpPath = RapidWrightDCP.getString("picoblaze_ooc_X10Y235.dcp");
+        Design design = Design.readCheckpoint(dcpPath, CodePerfTracker.SILENT);
+        Design emptyDesign = new Design("emptyDesign", design.getPartName());
+
+        Module module = new Module(design, false);
+        design = null;
+
+        ModuleInst mi = emptyDesign.createModuleInst("inst", module);
+        Assertions.assertTrue(mi.placeOnOriginalAnchor());
+
+        EDIFNetlist netlist = module.getNetlist();
+        EDIFNetlist emptyDesignNetlist = emptyDesign.getNetlist();
+        EDIFCell moduleTopCell = netlist.getTopCell();
+        String moduleTopCellName = moduleTopCell.getLegalEDIFName();
+        EDIFCell copiedModuleTopCell = emptyDesignNetlist.getCell(moduleTopCellName);
+        Assertions.assertNotNull(copiedModuleTopCell);
+
+        Site ss = module.getAnchor();
+        Tile st = ss.getTile();
+        for (int i = 1; i < copies; i++) {
+            Tile dt = st.getTileXYNeighbor(0, -i * 5);
+            Site ds = ss.getCorrespondingSite(ss.getSiteTypeEnum(), dt);
+
+            mi = emptyDesign.createModuleInst("inst_copy" + i, module);
+            boolean skipIncompatible = true; // Otherwise it fails when trying to move
+                                             // the gap routing in the clock net
+            Assertions.assertTrue(mi.place(ds, skipIncompatible));
         }
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestModuleInst.java
+++ b/test/src/com/xilinx/rapidwright/design/TestModuleInst.java
@@ -140,6 +140,7 @@ public class TestModuleInst {
         String moduleTopCellName = moduleTopCell.getLegalEDIFName();
         EDIFCell copiedModuleTopCell = emptyDesignNetlist.getCell(moduleTopCellName);
         Assertions.assertNotNull(copiedModuleTopCell);
+        Assertions.assertEquals(copiedModuleTopCell, mi.getCellInst().getCellType());
 
         Site ss = module.getAnchor();
         Tile st = ss.getTile();
@@ -148,6 +149,7 @@ public class TestModuleInst {
             Site ds = ss.getCorrespondingSite(ss.getSiteTypeEnum(), dt);
 
             mi = emptyDesign.createModuleInst("inst_copy" + i, module);
+            Assertions.assertEquals(emptyDesignNetlist, mi.getCellInst().getCellType().getNetlist());
             boolean skipIncompatible = true; // Otherwise it fails when trying to move
                                              // the gap routing in the clock net
             Assertions.assertTrue(mi.place(ds, skipIncompatible));

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -100,4 +100,35 @@ class TestEDIFNetlist {
             Assertions.assertTrue(potentiallyModifiedCells.contains(modifiedCell));
         }
     }
+
+    @Test
+    public void testCopyCellsAndSubCells() {
+        String dcpPath = RapidWrightDCP.getString("picoblaze_ooc_X10Y235.dcp");
+        Design design = RapidWrightDCP.loadDCP(dcpPath);
+        EDIFNetlist srcNetlist = design.getNetlist();
+
+        EDIFNetlist dstNetlist = EDIFTools.createNewNetlist("dstNetlist");
+        dstNetlist.copyCellAndSubCells(srcNetlist.getTopCell());
+        for (EDIFLibrary srcLib : srcNetlist.getLibraries()) {
+            if (srcLib.isHDIPrimitivesLibrary())
+                continue;
+            EDIFLibrary dstLib = dstNetlist.getLibrary(srcLib.getName());
+            Assertions.assertEquals(srcLib, dstLib);
+            for (EDIFCell srcCell : srcLib.getCells()) {
+                EDIFCell dstCell = dstLib.getCell(srcCell.getLegalEDIFName());
+                // Check contents are equal, but not pointers
+                Assertions.assertEquals(srcCell, dstCell);
+                Assertions.assertTrue(srcCell != dstCell);
+                Assertions.assertTrue(srcCell.getLibrary().getNetlist() == srcNetlist);
+                Assertions.assertTrue(dstCell.getLibrary().getNetlist() == dstNetlist);
+                for (EDIFCellInst srcInst : srcCell.getCellInsts()) {
+                    EDIFCellInst dstInst = dstCell.getCellInst(srcInst.getName());
+                    Assertions.assertEquals(srcInst, dstInst);
+                    Assertions.assertTrue(srcInst != dstInst);
+                    Assertions.assertTrue(srcInst.getCellType().getLibrary().getNetlist() == srcNetlist);
+                    Assertions.assertTrue(dstInst.getCellType().getLibrary().getNetlist() == dstNetlist);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Since in the new release, `Module.addModule()` (called by `Module.createModuleInst()`) will copy the Module's netlist into the Design's netlist.

Supersedes #418.

Fixes a small bug in `EDIFTools.copyCellsAndSubCells()` whereby it would throw an exception if it encountered cells from the primitives library that it had not copied in.

Also removes now-redundant `EDIFNetlist.migrateCellsAndSubCells()` and `ModuleInst.getCellInst().setCellType()`.