### PR TITLE
Give OS time to catch up before checking open files

### DIFF
--- a/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
+++ b/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
@@ -56,6 +56,7 @@ public class CheckOpenFilesExtension implements BeforeTestExecutionCallback, Aft
         return name.substring(0,atPosition);
     }
     private List<String> getOpenFiles() {
+        try {Thread.sleep(10);} catch (InterruptedException e1) {}
         final Path fdList = Paths.get("/proc/" + getOwnPid() + "/fd");
         if (!Files.exists(fdList)) {
             //We are probably not on Linux, fail silently


### PR DESCRIPTION
Ideally, we'd call `System.gc()` right before `getOpenFiles()` to ensure that everything is cleaned up properly before and after the test, but that doubles the test runtime.  But perhaps some spurious failures are just due to a race condition between tests starting and finishing.  This inserts 10ms before the start and end of each test's call to `getOpenFiles()`, this might help remove the false positives in testing, but we'll have to deploy it to be sure.