### PR TITLE
Open files checker: Ignore file descriptors that fail to resolve to actual files

### DIFF
--- a/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
+++ b/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
@@ -66,12 +66,13 @@ public class CheckOpenFilesExtension implements BeforeTestExecutionCallback, Aft
             // (or may not) reflect updates to the directory that occur after returning from
             // this method.'
             return list.filter((p) -> Files.exists(p, LinkOption.NOFOLLOW_LINKS))
-                    .map(p -> {
+                    .flatMap(p -> {
                         try {
                             final Path linkTarget = Files.readSymbolicLink(p);
-                            return linkTarget.toString();
+                            return Stream.of(linkTarget.toString());
                         } catch (IOException e) {
-                            return p.toString();
+                            System.err.println("Ignoring file descriptor "+p+", could not resolve to actual file: "+e.getMessage());
+                            return Stream.empty();
                         }})
                     .filter(this::checkIgnore)
                     .sorted()


### PR DESCRIPTION
This is an attempt to fix the spurious failures we see in the open files checker.

My theory is that Java is doing something in the background that needs file IO. Those handles are only open for a very short time. If the `Files.list` call happens to land in that exact timeframe, those handles are included in the result. When we call `Files.readSymbolicLink`, the handle is already closed. The call fails with an exception. Right now, we return the file handle's virtual filename. This exact timing probably does not happen twice for one testcase, so the list of open files differs before and after the testcase. This leads to a testcase failure.

This PR changes the behaviour to ignore those file handles.