### PR TITLE
Jobqueue improvements

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -56,7 +56,11 @@ configurations.testFixturesImplementation.canBeResolved = true
 configurations.api.canBeResolved = true
 
 tasks.withType(Test) {
-  maxHeapSize = "5G"
+  if (System.getenv("GITHUB_ACTION")) {
+    maxHeapSize = "5G"
+  } else {
+    maxHeapSize = "10G"
+  }
   //Propagate JVM settings to test JVM
   jvmArgs applicationDefaultJvmArgs
 

--- a/src/com/xilinx/rapidwright/util/Job.java
+++ b/src/com/xilinx/rapidwright/util/Job.java
@@ -28,6 +28,9 @@ package com.xilinx.rapidwright.util;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 
 /**
@@ -138,4 +141,17 @@ public abstract class Job {
 		return Long.toString(jobNumber);
 	}
 
+	public Optional<List<String>> getLastLogLines() {
+		String logFileName = getLogFilename();
+		if(new File(logFileName).exists()){
+			ArrayList<String> lines = FileTools.getLinesFromTextFile(logFileName);
+			int start = lines.size() >= 8 ? lines.size()-8 : 0;
+			return Optional.of(IntStream.range(start, lines.size()).mapToObj(lines::get).collect(Collectors.toList()));
+		}
+		return Optional.empty();
+	}
+
+	public String getLogFilename() {
+		return getRunDir() + File.separator + Job.DEFAULT_COMMAND_LOG_FILE;
+	}
 }

--- a/src/com/xilinx/rapidwright/util/JobQueue.java
+++ b/src/com/xilinx/rapidwright/util/JobQueue.java
@@ -42,7 +42,9 @@ public class JobQueue {
 	
 	public static int MAX_LSF_CONCURRENT_JOBS = 120;
 	
-	public static boolean USE_LSF_IF_AVAILABLE = true; 
+	public static boolean USE_LSF_IF_AVAILABLE = true;
+
+	private final boolean printJobStart;
 	
 	private Queue<Job> waitingToRun;
 	
@@ -55,10 +57,14 @@ public class JobQueue {
 	public static final String LSF_QUEUE_OPTION = "-lsf_queue";
 	
 	
-	public JobQueue(){
+	public JobQueue(boolean printJobStart){
 		waitingToRun = new LinkedList<>();
 		running = new ConcurrentLinkedQueue<>();
 		finished = new LinkedList<>();
+		this.printJobStart = printJobStart;
+	}
+	public JobQueue() {
+		this(true);
 	}
 	
 	public boolean addJob(Job j){
@@ -80,7 +86,9 @@ public class JobQueue {
 				Job j = waitingToRun.poll();
 				long pid = j.launchJob();
 				running.add(j);
-				System.out.println("Running job [" + pid + "] " + j.getCommand() + " in " + j.getRunDir());
+				if (printJobStart) {
+					System.out.println("Running job [" + pid + "] " + j.getCommand() + " in " + j.getRunDir());
+				}
 				launched = true;
 			}
 

--- a/src/com/xilinx/rapidwright/util/JobQueue.java
+++ b/src/com/xilinx/rapidwright/util/JobQueue.java
@@ -26,7 +26,6 @@
 package com.xilinx.rapidwright.util;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Queue;
@@ -111,19 +110,16 @@ public class JobQueue {
 			if(!curr){
 				if(failedCount == 0){
 					// Let's just print the first error output
-					String logFileName = j.getRunDir() + File.separator + Job.DEFAULT_COMMAND_LOG_FILE;
-					if(logFileName != null && new File(logFileName).exists()){
-						ArrayList<String> lines = FileTools.getLinesFromTextFile(logFileName);
+					j.getLastLogLines().ifPresent(lastLogLines -> {
 						System.err.println("***************************************************************************");
 						System.err.println("* ERROR: Job " + j.getJobNumber() + " failed");
-						System.err.println("* LOG FILE: " + logFileName);
+						System.err.println("* LOG FILE: " + j.getLogFilename());
 						System.err.println("*  Here are the last few lines of the log:");
-						int start = lines.size() >= 8 ? lines.size()-8 : 0; 
-						for(int i=start; i < lines.size(); i++){
-							System.err.println(lines.get(i));
+						for (String l : lastLogLines) {
+							System.err.println(l);
 						}
 						System.err.println("***************************************************************************");
-					}
+					});
 				}
 				failedCount++;
 			}


### PR DESCRIPTION
* Move printing of last log lines into Job class
* Allow not printing job command (generates large amount of logs if using together with Job.setRapidWrightCommand)
* Increase max tests memory if not running on Github