### PR TITLE
Work around for placed designs in Interchange Format

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -318,6 +318,7 @@ public class PhysNetlistWriter {
             // We need to traverse the net inside sites to fully populate routing spec
             ArrayList<RouteBranchNode> routingSources = new ArrayList<>();
             for(PIP p : net.getPIPs()) {
+                if(p.getEndWireName() == null) continue;
                 routingSources.add(new RouteBranchNode(p));
             }
             for(SitePinInst spi : net.getPins()) {


### PR DESCRIPTION
There is currently a deficiency in the Interchange Schema (see #134 and #464) that doesn't allow the partially routed clock of a placed design to be represented correctly.  This PR is an example work-around until the Interchange Schema can be updated with the necessary constructs.  Note, this simply omits the routings stubs in the clock routing and will be lost through translation.  These should be able to be reconstructed by running `update_clock_routing` in Vivado.