### PR TITLE
Work-around for old EDIF

### DIFF
--- a/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
+++ b/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
@@ -249,11 +249,14 @@ public abstract class AbstractEDIFParserWorker {
             String commentOrMetax = getNextToken(true);
             if(commentOrMetax.equals(COMMENT)){
                 currNetlist.addComment(getNextToken(false));
-
             }else if(commentOrMetax.equals(METAX)){
                 String key = getNextToken(false);
                 EDIFPropertyValue value = parsePropertyValue();
                 currNetlist.addMetax(key,value);
+            } else if(commentOrMetax.equals(PROPERTY)){
+                // Discard this property for now
+                parseProperty(new EDIFPropertyObject(), commentOrMetax);
+                continue;
             }else{
                 expect(COMMENT + "|" + METAX, commentOrMetax);
             }

--- a/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
+++ b/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
@@ -258,7 +258,7 @@ public abstract class AbstractEDIFParserWorker {
                 parseProperty(new EDIFPropertyObject(), commentOrMetax);
                 continue;
             }else{
-                expect(COMMENT + "|" + METAX, commentOrMetax);
+                expect(COMMENT + "|" + METAX + "|" + PROPERTY, commentOrMetax);
             }
             expect(RIGHT_PAREN, getNextToken(true));
         }


### PR DESCRIPTION
Some older EDIF files have properties on the Design.  This is a work-around fix that allows the EDIF to be parsed successfully.