### PR TITLE
Get all leaf port insts for a given EDIFHierNet

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
@@ -147,7 +147,7 @@ public class EDIFHierNet {
 	 */
 	@Override
 	public String toString() {
-		return "EDIFHierNet [hierarchicalInstName=" + hierarchicalInst + ", net=" + net + "]";
+		return getHierarchicalNetName();
 	}
 
 

--- a/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
@@ -155,9 +155,24 @@ public class EDIFHierNet {
 		return hierarchicalInst;
 	}
 	
-	public List<EDIFHierPortInst> getLeafHierPortInsts(){
+	/**
+	 * Gets all connected leaf port instances on this hierarchical net and its aliases.  
+	 * @return The list of all leaf cell port instances connected to this hierarchical net and its 
+	 * aliases.
+	 */
+	public List<EDIFHierPortInst> getLeafHierPortInsts() {
+	    return getLeafHierPortInsts(true);
+	}
+	
+	/**
+	 * Gets all connected leaf port instances on this hierarchical net and its aliases.
+	 * @param includeSourcePins A flag to include source pins in the result.  Setting this to false
+	 * only returns the sinks.
+	 * @return The list of all leaf cell port instances connected to this hierarchical net and its 
+     * aliases.
+	 */
+	public List<EDIFHierPortInst> getLeafHierPortInsts(boolean includeSourcePins) {
 	    List<EDIFHierPortInst> leafCellPins = new ArrayList<>();
-	    List<EDIFHierNet> aliases = new ArrayList<>();
 	    Queue<EDIFHierNet> queue = new ArrayDeque<>();
 	    queue.add(this);
 	    HashSet<EDIFHierNet> visited = new HashSet<>();
@@ -168,13 +183,14 @@ public class EDIFHierNet {
 	        if (!visited.add(net)) {
 	            continue;
 	        }
-	        aliases.add(net);
 	        for(EDIFPortInst relP : net.getNet().getPortInsts()){
 	            EDIFHierPortInst p = new EDIFHierPortInst(net.getHierarchicalInst(), relP);
 
 	            boolean isCellPin = relP.getCellInst() != null && relP.getCellInst().getCellType().isLeafCellOrBlackBox();
 	            if(isCellPin) {
-	                leafCellPins.add(p);
+	                if(p.isInput() || (includeSourcePins && p.isOutput())) {
+	                    leafCellPins.add(p);
+	                }
 	            }
 
 	            boolean isToplevelInput = p.getHierarchicalInst().isTopLevelInst() && relP.getCellInst() == null && p.isInput();

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1471,42 +1471,7 @@ public class EDIFNetlist extends EDIFName {
 	 * of the provided net 
 	 */
 	public List<EDIFHierPortInst> getSinksFromNet(EDIFHierNet net){
-		Queue<EDIFHierNet> q = new LinkedList<>();
-		q.add(net);
-		ArrayList<EDIFHierPortInst> sinks = new ArrayList<>();
-		HashSet<EDIFHierNet> visited = new HashSet<>();
-		while(!q.isEmpty()){
-			EDIFHierNet curr = q.poll();
-			if(!visited.add(curr)) continue;
-			for(EDIFPortInst portInst : curr.getNet().getPortInsts()){
-				if(portInst.isOutput()) continue;
-				final EDIFHierPortInst hierPort = new EDIFHierPortInst(curr.getHierarchicalInst(), portInst);
-				if(portInst.isTopLevelPort()){
-					// Going up in hierarchy
-					final EDIFHierNet hierarchicalNet = hierPort.getHierarchicalInst().isTopLevelInst() ?
-					        null : hierPort.getPortInParent().getHierarchicalNet();
-					if (hierarchicalNet == null) {
-						continue;
-					}
-					q.add(hierarchicalNet);
-				}else {
-					if(portInst.getCellInst().getCellType().isPrimitive()){
-						// We found a sink
-						sinks.add(hierPort);
-						continue;
-					}else{
-						// Going down in hierarchy
-						EDIFHierNet internalNet = hierPort.getInternalNet();
-						if(internalNet != null) {
-							q.add(internalNet);
- 						}
-					}
-				}
-			}
-			
-		}
-		
-		return sinks;
+		return net.getLeafHierPortInsts(false);
 	}
 	
 	/**

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -552,9 +552,8 @@ public class EDIFTools {
 	            if(snkNet != net) {
 	                net.getParentCell().removeNet(net);
 	                snkNet.addPortInst(finalSrc.getPortInst());
-	            } else {
-	                return;
 	            }
+	            return;
 	        }else {
 	            snkNet.removePortInst(finalSnk.getPortInst());	            
 	        }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierNet.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierNet.java
@@ -1,0 +1,32 @@
+package com.xilinx.rapidwright.edif;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+
+public class TestEDIFHierNet {
+
+    @Test
+    public void testGetLeafHierPortInsts() {
+        Design design = RapidWrightDCP.loadDCP("bnn.dcp");
+        
+        EDIFNetlist netlist = design.getNetlist();
+        
+        for(EDIFHierNet parentNet : netlist.getParentNetMap().values()) {
+            Set<EDIFHierPortInst> goldSet = new HashSet<>(netlist.getPhysicalPins(parentNet)); 
+            Set<EDIFHierPortInst> testSet = new HashSet<>(parentNet.getLeafHierPortInsts());
+            Assertions.assertEquals(goldSet.size(), testSet.size());
+            
+            for(EDIFHierPortInst portInst : goldSet) {
+                Assertions.assertTrue(testSet.remove(portInst));
+            }
+            Assertions.assertTrue(testSet.isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
This contains two changes to support the ECO flow.

1. A new method that gets all leaf port insts on an EDIFHierNet
2. Fixes to EDIFTools.connectPortInstsThruHier()