### PR TITLE
if additional maven repo is specify, only get api-lib from there

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -8,8 +8,15 @@ targetCompatibility = 8
 repositories {
     if (project.hasProperty('additionalMavenRepo')) {
       project.logger.lifecycle('Adding Maven Repository at '+additionalMavenRepo)
-      maven{
-        url additionalMavenRepo
+      exclusiveContent {
+        forRepository {
+          maven {
+            url additionalMavenRepo
+          }
+        }
+        filter {
+          includeModule("com.xilinx.rapidwright", "rapidwright-api-lib")
+        }
       }
     }
     if (project.hasProperty('useMavenLocal') && useMavenLocal == "True") {


### PR DESCRIPTION
If we specify an additional Maven repo during build, but the repository does not contain the rapidwright-api-lib (e.g. because of version mismatch), we silently fall back to getting the library from master.

This PR changes this behavior: If we speciffy an additional Maven repo, and the rapidwright-api-lib is not there, we fail the build.