### PR TITLE
optimized method to find net leaf source

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
@@ -241,4 +241,34 @@ public class EDIFHierNet {
 
 	    return leafCellPins;
 	}
+
+	/**
+	 * Gets a single connected leaf output port instances on this hierarchical net and its aliases.
+	 * This output port instance sources the whole net.
+	 *
+	 * If there are multiple drivers, this returns an arbitrary one.
+	 * @return A hierarchical output port instance or null
+	 */
+	public EDIFHierPortInst getLeafSource() {
+		for (EDIFPortInst portInst : getNet().getPortInsts()) {
+			if (portInst.getCellInst() == null) {
+				if (portInst.isInput()) {
+					//We are sourced from the outside
+					final EDIFHierPortInst hierarchical = new EDIFHierPortInst(hierarchicalInst, portInst);
+					if (hierarchical.getHierarchicalInst().isTopLevelInst()) {
+						return null;
+					}
+					return hierarchical.getPortInParent().getHierarchicalNet().getLeafSource();
+				}
+			} else if (portInst.isOutput()) {
+				final EDIFHierPortInst hierarchical = new EDIFHierPortInst(hierarchicalInst, portInst);
+				if (hierarchical.getPortInst().getCellInst().getCellType().isLeafCellOrBlackBox()) {
+					return hierarchical;
+				} else {
+					return hierarchical.getInternalNet().getLeafSource();
+				}
+			}
+		}
+		return null;
+	}
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierNet.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierNet.java
@@ -23,14 +23,12 @@
 package com.xilinx.rapidwright.edif;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestEDIFHierNet {
 
@@ -49,6 +47,25 @@ public class TestEDIFHierNet {
                 Assertions.assertTrue(testSet.remove(portInst));
             }
             Assertions.assertTrue(testSet.isEmpty());
+
+            EDIFHierPortInst goldSource = findOutput(goldSet);
+
+            goldSet.stream().map(EDIFHierPortInst::getHierarchicalNet).distinct().forEach(net -> {
+                Assertions.assertEquals(goldSource, net.getLeafSource());
+            });
         }
+    }
+
+    private EDIFHierPortInst findOutput(Set<EDIFHierPortInst> set) {
+        EDIFHierPortInst source = null;
+        for (EDIFHierPortInst edifHierPortInst : set) {
+            if (edifHierPortInst.isOutput()) {
+                if (source != null) {
+                    Assertions.fail("multiple sources, at least "+ source +" and "+ edifHierPortInst);
+                }
+                source = edifHierPortInst;
+            }
+        }
+        return source;
     }
 }


### PR DESCRIPTION
This adds a function to get the leaf `EDIFHierPortInst` of a `EDIFHierNet`.

This can already be done by searching the list returned by `EDIFHierNet.getLeafHierPortInsts` for outputs, but this method does not have to walk the net's whole hierarchy. Instead, it uses the ports' directions to walk straight to the source.