### PR TITLE
Fixes macro expansion for exceptional case

### DIFF
--- a/src/com/xilinx/rapidwright/device/IOStandard.java
+++ b/src/com/xilinx/rapidwright/device/IOStandard.java
@@ -37,6 +37,7 @@ public enum IOStandard {
 	ANALOG,
 	ANALOG_SE,
 	BLVDS_25,
+	DEFAULT,
 	DIFF_AIO12_LVAUX,
 	DIFF_HSTL_I,
 	DIFF_HSTL_II,

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A cell instance in a logical (EDIF) netlist.  Instantiates
@@ -272,7 +273,8 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
             return false;
         EDIFCellInst that = (EDIFCellInst) o;
 
-        if (!parentCell.equals(that.parentCell))
+        
+        if (!Objects.equals(parentCell,that.parentCell))
             return false;
 
         if (!cellType.equals(that.cellType))

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1611,7 +1611,7 @@ public class EDIFNetlist extends EDIFName {
 		// Update all cell references to macro versions
 		for(EDIFLibrary lib : getLibraries()) {
 			boolean isHDILib = lib.isHDIPrimitivesLibrary(); 
-			for(EDIFCell cell : lib.getCells()) { 
+			for(EDIFCell cell : new ArrayList<>(lib.getCells())) { 
 				for(EDIFCellInst inst : cell.getCellInsts()) {
 					String cellName = inst.getCellType().getName();
 					if(toReplace.contains(cellName)) {
@@ -1651,6 +1651,15 @@ public class EDIFNetlist extends EDIFName {
 						    newCell = copy;
 						}
 						inst.setCellType(newCell);
+						for(EDIFCellInst childInst : newCell.getCellInsts()) {
+						    // Check if we already have a copy
+						    EDIFCell existingCellType = netlistPrims.getCell(childInst.getCellName()); 
+						    if(existingCellType == null) {
+						        existingCellType = new EDIFCell(netlistPrims, childInst.getCellType());
+						        primsToRemoveOnCollapse.add(existingCellType.getName());
+						    }
+						    childInst.setCellType(existingCellType);
+						}
 					}
 				}
 			}

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -114,12 +114,12 @@ public class EDIFNetlist extends EDIFName {
 	 * Map that stores prim to macro expansions conditional based on IOStandards
 	 * (Start Prim to End Macro (if set IOStandard is in set))
 	 */
-	public static final Map<String,Pair<String,EnumSet<IOStandard>>> macroExpandExceptionMap;
+	public static final Map<Series, Map<String,Pair<String,EnumSet<IOStandard>>>> macroExpandExceptionMap;
 	/**
      * Reverse map that stores macro to prim collapse conditional based on IOStandards
      * (Macro to Prim (if set IOStandard is in set))
      */
-	public static final Map<String,Pair<String,EnumSet<IOStandard>>> macroCollapseExceptionMap;
+	public static final Map<Series, Map<String,Pair<String,EnumSet<IOStandard>>>> macroCollapseExceptionMap;
 
 	public static final String IOSTANDARD_PROP = "IOStandard";
 	
@@ -159,14 +159,23 @@ public class EDIFNetlist extends EDIFName {
 	                                        );
 
 	    macroExpandExceptionMap = new HashMap<>();
-	    // Prim -> Macro (when set IOStandard matches expansion set)
-	    macroExpandExceptionMap.put("OBUFDS", new Pair<>("OBUFDS_DUAL_BUF", obufExpansion));
-	    macroExpandExceptionMap.put("OBUFTDS", new Pair<>("OBUFTDS_DUAL_BUF", obufExpansion));
-	    
 	    macroCollapseExceptionMap = new HashMap<>();
-	    for(Entry<String,Pair<String,EnumSet<IOStandard>>> e : macroExpandExceptionMap.entrySet()) {
-	        Pair<String,EnumSet<IOStandard>> newPair = new Pair<>(e.getKey(), e.getValue().getSecond());
-	    	macroCollapseExceptionMap.put(e.getValue().getFirst(), newPair);
+	    for(Series s : Series.values()) {
+	        Map<String,Pair<String,EnumSet<IOStandard>>> seriesMacroExpandExceptionMap = new HashMap<>();
+	        Map<String,Pair<String,EnumSet<IOStandard>>> seriesMacroCollapseExceptionMap = new HashMap<>();
+	        
+	        if(s == Series.Versal) continue;
+	        // Prim -> Macro (when set IOStandard matches expansion set)
+	        seriesMacroExpandExceptionMap.put("OBUFDS", new Pair<>("OBUFDS_DUAL_BUF", obufExpansion));
+	        seriesMacroExpandExceptionMap.put("OBUFTDS", new Pair<>("OBUFTDS_DUAL_BUF", obufExpansion));
+	        macroExpandExceptionMap.put(s, seriesMacroCollapseExceptionMap);
+	        
+	        
+	        for(Entry<String,Pair<String,EnumSet<IOStandard>>> e : seriesMacroExpandExceptionMap.entrySet()) {
+	            Pair<String,EnumSet<IOStandard>> newPair = new Pair<>(e.getKey(), e.getValue().getSecond());
+	            seriesMacroCollapseExceptionMap.put(e.getValue().getFirst(), newPair);
+	        }
+	        macroCollapseExceptionMap.put(s, seriesMacroCollapseExceptionMap);
 	    }
 	}
 	
@@ -1581,9 +1590,13 @@ public class EDIFNetlist extends EDIFName {
 		EDIFLibrary macros = Design.getMacroPrimitives(series);
 		EDIFLibrary netlistPrims = getHDIPrimitivesLibrary();
 
+		Map<String, Pair<String, EnumSet<IOStandard>>> seriesMacroExpandExceptionMap = 
+		                       macroExpandExceptionMap.getOrDefault(series, Collections.emptyMap());
+		
 		// Find the macro primitives to replace
 		Set<String> toReplace = new HashSet<String>();
-		Set<String> possibleExceptions = macroExpandExceptionMap.keySet();
+		Set<String> possibleExceptions = seriesMacroExpandExceptionMap == null ? 
+		        Collections.emptySet() : seriesMacroExpandExceptionMap.keySet();
 		for(EDIFCell c : netlistPrims.getCells()) {
 			if(macros.containsCell(c.getName())) {
 				toReplace.addAll(getAllDecendantCellTypes(macros.getCell(c.getName())));
@@ -1616,7 +1629,7 @@ public class EDIFNetlist extends EDIFName {
 					String cellName = inst.getCellType().getName();
 					if(toReplace.contains(cellName)) {
 						if(!isHDILib) {
-						    Pair<String, EnumSet<IOStandard>> exception = macroExpandExceptionMap.get(cellName);
+						    Pair<String, EnumSet<IOStandard>> exception = seriesMacroExpandExceptionMap.get(cellName);
 						    if(exception != null) {
 						        EDIFPropertyValue value = inst.getProperty(IOSTANDARD_PROP);
 						        if(value == null) {
@@ -1675,11 +1688,13 @@ public class EDIFNetlist extends EDIFName {
 		EDIFLibrary macros = Design.getMacroPrimitives(series);
 		EDIFLibrary prims = getHDIPrimitivesLibrary();
 		ArrayList<EDIFCell> reinsert = new ArrayList<EDIFCell>();
+		Map<String, Pair<String, EnumSet<IOStandard>>> seriesMacroCollapseExceptionMap = 
+		        macroCollapseExceptionMap.getOrDefault(series, Collections.emptyMap());
 		for(EDIFCell cell : prims.getCells()) {
 			if(macros.containsCell(cell.getName())) {
 				cell.makePrimitive();
-				if(macroCollapseExceptionMap.containsKey(cell.getName())) {
-					cell.rename(macroCollapseExceptionMap.get(cell.getName()).getFirst());
+				if(seriesMacroCollapseExceptionMap.containsKey(cell.getName())) {
+					cell.rename(seriesMacroCollapseExceptionMap.get(cell.getName()).getFirst());
 					reinsert.add(cell);
 				}
 			}

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -170,7 +170,6 @@ public class EDIFNetlist extends EDIFName {
 	        seriesMacroExpandExceptionMap.put("OBUFTDS", new Pair<>("OBUFTDS_DUAL_BUF", obufExpansion));
 	        macroExpandExceptionMap.put(s, seriesMacroCollapseExceptionMap);
 	        
-	        
 	        for(Entry<String,Pair<String,EnumSet<IOStandard>>> e : seriesMacroExpandExceptionMap.entrySet()) {
 	            Pair<String,EnumSet<IOStandard>> newPair = new Pair<>(e.getKey(), e.getValue().getSecond());
 	            seriesMacroCollapseExceptionMap.put(e.getValue().getFirst(), newPair);
@@ -1605,7 +1604,6 @@ public class EDIFNetlist extends EDIFName {
 			    toReplace.add(c.getName());
 			}
 		}
-		
 		
 		// Replace macro primitives in library and import pre-requisite cells if needed
 		for(String cellName : toReplace) {


### PR DESCRIPTION
Fixes an issue with an `OBUF` to `OBUFDS_DUAL_BUF` expansion in an UltraScale+ part and properly handles it when `DEFAULT` is set to the voltage standard.