### PR TITLE
EDIFNetlist.{copy,migrate}CellAndSubCells() to copy into new same-named library

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -553,7 +553,7 @@ public class EDIFNetlist extends EDIFName {
 			if(cell.getLibrary().isHDIPrimitivesLibrary()){
 				destLib = getHDIPrimitivesLibrary();
 			}else{
-				destLib = getWorkLibrary();
+				destLib = addLibrary(new EDIFLibrary(cell.getLibrary().getName()));
 			}
 		}
 

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -443,7 +443,7 @@ public class EDIFNetlist extends EDIFName {
 			if(cell.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)){
 				destLib = getHDIPrimitivesLibrary();
 			}else{
-				destLib = getWorkLibrary();
+				destLib = addLibrary(new EDIFLibrary(cell.getLibrary().getName()));
 			}
 		}
 
@@ -486,7 +486,7 @@ public class EDIFNetlist extends EDIFName {
 			if(cell.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)){
 				destLibTop = getHDIPrimitivesLibrary();
 			}else{
-				destLibTop = getWorkLibrary();
+				destLibTop = addLibrary(new EDIFLibrary(cell.getLibrary().getName()));
 			}
 		}
 		if (destLibTop.containsCell(cell) && destLibTop.getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME))
@@ -513,7 +513,7 @@ public class EDIFNetlist extends EDIFName {
 					if (instCellType.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)) {
 						destLibSub = getHDIPrimitivesLibrary();
 					} else {
-						destLibSub = getWorkLibrary();
+						destLibSub = addLibrary(new EDIFLibrary(instCellType.getLibrary().getName()));
 					}
 				}
 				if (destLibSub.containsCell(instCellType) && destLibSub.getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME))

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -37,6 +37,8 @@ import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Part;
 import com.xilinx.rapidwright.device.PartNameTools;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class TestEDIFNetlist {
 
@@ -145,8 +147,9 @@ class TestEDIFNetlist {
                 e.getMessage());
     }
 
-    @Test
-    public void testCopyCellsAndSubCellsNewLibrary() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testCopyCellsAndSubCellsIntoLibrary(boolean existing) {
         EDIFDesign srcDesign = new EDIFDesign();
         EDIFNetlist srcNetlist = EDIFTools.createNewNetlist("srcNetlist");
         srcNetlist.setDesign(srcDesign);
@@ -155,14 +158,83 @@ class TestEDIFNetlist {
         srcDesign.setTopCell(srcCell);
 
         EDIFNetlist dstNetlist = EDIFTools.createNewNetlist("dstNetlist");
+        EDIFLibrary dstLibraryBefore = null;
+        if (existing) {
+            dstLibraryBefore = dstNetlist.addLibrary(new EDIFLibrary(srcLibrary.getName()));
+        }
+
         dstNetlist.copyCellAndSubCells(srcNetlist.getTopCell());
 
-        EDIFLibrary dstLibrary = dstNetlist.getLibrary(srcLibrary.getName());
-        Assertions.assertNotNull(dstLibrary);
-        Assertions.assertFalse(srcLibrary == dstLibrary);
+        EDIFLibrary dstLibraryAfter = dstNetlist.getLibrary(srcLibrary.getName());
+        Assertions.assertNotNull(dstLibraryAfter);
+        if (existing) {
+            Assertions.assertTrue(dstLibraryBefore == dstLibraryAfter);
+        }
+        Assertions.assertFalse(srcLibrary == dstLibraryAfter);
 
-        EDIFCell dstCell = dstLibrary.getCell(srcCell.getName());
+        EDIFCell dstCell = dstLibraryAfter.getCell(srcCell.getName());
         Assertions.assertNotNull(dstCell);
+        // Copy really makes a copy of the source cell
         Assertions.assertFalse(srcCell == dstCell);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testMigrateCellsAndSubCellsIntoLibrary(boolean existing) {
+        EDIFDesign srcDesign = new EDIFDesign();
+        EDIFNetlist srcNetlist = EDIFTools.createNewNetlist("srcNetlist");
+        srcNetlist.setDesign(srcDesign);
+        EDIFLibrary srcLibrary = srcNetlist.addLibrary(new EDIFLibrary("srcLibrary"));
+        EDIFCell srcCell = new EDIFCell(srcLibrary, "srcCell");
+        srcDesign.setTopCell(srcCell);
+
+        EDIFNetlist dstNetlist = EDIFTools.createNewNetlist("dstNetlist");
+        EDIFLibrary dstLibraryBefore = null;
+        if (existing) {
+            dstLibraryBefore = dstNetlist.addLibrary(new EDIFLibrary(srcLibrary.getName()));
+        }
+
+        dstNetlist.migrateCellAndSubCells(srcNetlist.getTopCell());
+
+        EDIFLibrary dstLibraryAfter = dstNetlist.getLibrary(srcLibrary.getName());
+        Assertions.assertNotNull(dstLibraryAfter);
+        if (existing) {
+            Assertions.assertTrue(dstLibraryBefore == dstLibraryAfter);
+        }
+        Assertions.assertFalse(srcLibrary == dstLibraryAfter);
+
+        EDIFCell dstCell = dstLibraryAfter.getCell(srcCell.getName());
+        Assertions.assertNotNull(dstCell);
+        // Migration re-uses the same cell
+        Assertions.assertTrue(srcCell == dstCell);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testMigrateCellsAndSubCells(boolean uniquify) {
+        EDIFNetlist dstNetlist = EDIFTools.createNewNetlist("dstNetlist");
+        final String srcLibraryName = "srcLibrary";
+        final String srcCellName = "srcCell";
+        for (int i = 0; i < 3; i++) {
+            EDIFDesign srcDesign = new EDIFDesign();
+            EDIFNetlist srcNetlist = EDIFTools.createNewNetlist("srcNetlist");
+            srcNetlist.setDesign(srcDesign);
+            EDIFLibrary srcLibrary = srcNetlist.addLibrary(new EDIFLibrary(srcLibraryName));
+            EDIFCell srcCell = new EDIFCell(srcLibrary, srcCellName);
+            srcDesign.setTopCell(srcCell);
+
+            dstNetlist.migrateCellAndSubCells(srcNetlist.getTopCell(), uniquify);
+        }
+
+        EDIFLibrary dstLibrary = dstNetlist.getLibrary(srcLibraryName);
+        Assertions.assertNotNull(dstLibrary);
+        Assertions.assertNotNull(dstLibrary.getCell(srcCellName));
+        if (uniquify) {
+            Assertions.assertNotNull(dstLibrary.getCell(srcCellName + "_parameterized0"));
+            Assertions.assertNotNull(dstLibrary.getCell(srcCellName + "_parameterized1"));
+            Assertions.assertEquals(dstLibrary.getCells().size(), 3);
+        } else {
+            Assertions.assertEquals(dstLibrary.getCells().size(), 1);
+        }
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -144,4 +144,25 @@ class TestEDIFNetlist {
         Assertions.assertEquals("ERROR: Destination netlist already contains EDIFCell named 'picoblaze_top' in library 'work'",
                 e.getMessage());
     }
+
+    @Test
+    public void testCopyCellsAndSubCellsNewLibrary() {
+        EDIFDesign srcDesign = new EDIFDesign();
+        EDIFNetlist srcNetlist = EDIFTools.createNewNetlist("srcNetlist");
+        srcNetlist.setDesign(srcDesign);
+        EDIFLibrary srcLibrary = srcNetlist.addLibrary(new EDIFLibrary("srcLibrary"));
+        EDIFCell srcCell = new EDIFCell(srcLibrary, "srcCell");
+        srcDesign.setTopCell(srcCell);
+
+        EDIFNetlist dstNetlist = EDIFTools.createNewNetlist("dstNetlist");
+        dstNetlist.copyCellAndSubCells(srcNetlist.getTopCell());
+
+        EDIFLibrary dstLibrary = dstNetlist.getLibrary(srcLibrary.getName());
+        Assertions.assertNotNull(dstLibrary);
+        Assertions.assertFalse(srcLibrary == dstLibrary);
+
+        EDIFCell dstCell = dstLibrary.getCell(srcCell.getName());
+        Assertions.assertNotNull(dstCell);
+        Assertions.assertFalse(srcCell == dstCell);
+    }
 }


### PR DESCRIPTION
Rather than into the work library, if source library doesn't exist in destination netlist.

Fixes #512.