### PR TITLE
Retry EDIFHierPortInst.getPhysicalCell() after escaping \ again

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
@@ -202,6 +202,10 @@ public class EDIFHierPortInst {
 	public Cell getPhysicalCell(Design design) {
 	    String cellName = getFullHierarchicalInstName();
 	    Cell cell = design.getCell(cellName);
+	    if (cell == null) {
+	        // Retry with backslashes escaped one more time
+	        cell = design.getCell(cellName.replace("\\", "\\\\"));
+	    }
 	    return cell;	    
 	}
 

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
@@ -1,0 +1,29 @@
+package com.xilinx.rapidwright.edif;
+
+import com.xilinx.rapidwright.design.Cell;
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.Unisim;
+import com.xilinx.rapidwright.device.Device;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestEDIFHierPortInst {
+    @Test
+    void testGetPhysicalCell() {
+        Design d = new Design("design", Device.KCU105);
+        EDIFNetlist n = d.getNetlist();
+        String cellName = "name\\.with\\.backslashes";
+        // Note: need to place cell as Cell.updateName() requires a SiteInst in order to acquire the Design
+        Cell c = d.createAndPlaceCell(cellName, Unisim.FDRE, "SLICE_X0Y0/AFF");
+        EDIFHierCellInst ehci = n.getHierCellInstFromName(cellName);
+        new EDIFPortInst(ehci.getCellType().getPort("Q"), null, ehci.getInst());
+
+        EDIFHierPortInst ehpi = n.getHierPortInstFromName(cellName + EDIFTools.EDIF_HIER_SEP + "Q");
+        Assertions.assertEquals(c, ehpi.getPhysicalCell(d));
+
+        // It's been observed that Vivado can doubly escape the physical Cell name
+        c.updateName(cellName.replace("\\", "\\\\"));
+        // Check that we can still find it in this case
+        Assertions.assertEquals(c, ehpi.getPhysicalCell(d));
+    }
+}

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
@@ -1,3 +1,25 @@
+/* 
+ * Copyright (c) 2022 Xilinx, Inc. 
+ * All rights reserved.
+ *
+ * Author: Eddie Hung, Xilinx Research Labs.
+ *  
+ * This file is part of RapidWright. 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+ 
 package com.xilinx.rapidwright.edif;
 
 import com.xilinx.rapidwright.design.Cell;


### PR DESCRIPTION
It's been observed that Vivado can doubly escape backslashes in the physical `Cell` name, so handle that case.