### PR TITLE
Enables top-level relocation, custom site type list

### DIFF
--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -44,6 +44,7 @@ import com.xilinx.rapidwright.device.SiteTypeEnum;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.edif.EDIFHierCellInst;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.interchange.PhysNetlistWriter;
 import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.Utils;
 
@@ -90,7 +91,7 @@ public class RelocationTools {
                                    int tileRowOffset,
                                    Set<SiteTypeEnum> siteTypes) {
         EDIFNetlist netlist = design.getNetlist();
-        EDIFHierCellInst instanceCell = netlist.getHierCellInstFromName(instanceName);
+        EDIFHierCellInst instanceCell = instanceName.length()==0 ? netlist.getTopHierCellInst() : netlist.getHierCellInstFromName(instanceName);
         if (instanceCell == null) {
             System.out.println("ERROR: Logical cell with instance name '" + instanceName + "' not found");
             return false;
@@ -130,7 +131,7 @@ public class RelocationTools {
         boolean error = false;
         for (SiteInst si : siteInsts) {
             for (Cell c : si.getCells()) {
-                if (!c.isLocked() && !cells.contains(c)) {
+                if (!c.isLocked() && !cells.contains(c) && !c.getType().equals(PhysNetlistWriter.PORT)) {
                     System.out.println("ERROR: Failed to relocate SiteInst '" + si.getName()
                             + "' as it contains Cells both inside and outside of '" + instanceName + "'");
                     error = true;

--- a/src/com/xilinx/rapidwright/examples/RelocateHierarchy.java
+++ b/src/com/xilinx/rapidwright/examples/RelocateHierarchy.java
@@ -22,8 +22,11 @@
 
 package com.xilinx.rapidwright.examples;
 
+import java.util.Set;
+
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.tools.RelocationTools;
+import com.xilinx.rapidwright.device.SiteTypeEnum;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 
 /**
@@ -41,8 +44,8 @@ import com.xilinx.rapidwright.tests.CodePerfTracker;
 public class RelocateHierarchy {
 
     public static void main(String[] args) {
-        if (args.length != 5) {
-            System.out.println("USAGE: <input_dcp> <hierarchical_path> <tile_col_offset> <tile_row_offset> <output_dcp>");
+        if (args.length != 5 && args.length != 6) {
+            System.out.println("USAGE: <input_dcp> <hierarchical_path> <tile_col_offset> <tile_row_offset> <output_dcp> [comma separated list of additional SiteTypeEnums to relocate]");
             return;
         }
 
@@ -57,7 +60,15 @@ public class RelocateHierarchy {
         int colOffset = Integer.parseInt(args[2]);
         int rowOffset = Integer.parseInt(args[3]);
 
-        if (!RelocationTools.relocate(design, hierarchyPrefix, colOffset, rowOffset)) {
+        Set<SiteTypeEnum> customSet = RelocationTools.defaultSiteTypes;
+        
+        if(args.length == 6) {
+            for(String siteTypeEnum : args[5].split(",")) {
+                customSet.add(SiteTypeEnum.valueOf(siteTypeEnum));                
+            }
+        }
+        
+        if (!RelocationTools.relocate(design, hierarchyPrefix, colOffset, rowOffset, customSet)) {
             throw new RuntimeException("ERROR: Relocation failed");
         }
 


### PR DESCRIPTION
Makes some changes to support relocation of an entire DCP (top level) by providing the empty string `''` as an argument to the hierarchy prefix parameter.  Also enables a command-line option to augment the set of `SiteTypeEnum` types that are to be relocated.