### PR TITLE
Fixes for copyImplementation()

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2263,7 +2263,8 @@ public class DesignTools {
 		// Populate black boxes with existing logical netlist cells
 		HashSet<String> instsWithSeparator = new HashSet<>();
 		for(Entry<String,String> e : srcToDestInstNames.entrySet()) {
-			EDIFHierCellInst cellInst = src.getNetlist().getHierCellInstFromName(e.getKey());
+			EDIFHierCellInst cellInst = e.getKey().length()==0 ? src.getNetlist().getTopHierCellInst() 
+			        : src.getNetlist().getHierCellInstFromName(e.getKey());
 			if(e.getValue().length() == 0) {
 			    // If its the top cell, remove the top cell from destNetlist
 			    EDIFLibrary destLib = destNetlist.getLibrary(cellInst.getCellType().getLibrary().getName());
@@ -2284,7 +2285,11 @@ public class DesignTools {
 		
 		Map<String,String> prefixes = new HashMap<>();
 		for(String srcPrefix : srcToDestInstNames.keySet()) {
-			prefixes.put(srcPrefix + "/", srcPrefix);
+		    if(srcPrefix.length()==0) {
+		        prefixes.put(srcPrefix, srcPrefix);
+		    }else {
+	                prefixes.put(srcPrefix + "/", srcPrefix);
+		    }
 		}
 		
 		// Identify cells to copy placement
@@ -2346,7 +2351,7 @@ public class DesignTools {
 			if((prefixMatch = StringTools.startsWithAny(net.getName(), prefixes.keySet())) != null) {
 			    newNetName = getNewHierName(newNetName, srcToDestInstNames, prefixes, prefixMatch);
 			}
-			EDIFNet logicalNet = destNetlist.getNetFromHierName(net.getName());
+			EDIFNet logicalNet = destNetlist.getNetFromHierName(newNetName);
 			Net copiedNet = dest.createNet(newNetName, logicalNet);
 			for(PIP p : net.getPIPs()) {
 				if(pipsToRemove.contains(p)) continue;
@@ -2355,6 +2360,14 @@ public class DesignTools {
 					p.setIsPIPFixed(true);
 				}
 			}
+			for(SitePinInst spi : net.getPins()) {
+			    if(pinsToRemove.contains(spi)) continue;
+			    SiteInst siteInst = dest.getSiteInstFromSite(spi.getSite());
+			    if(siteInst == null) {
+			        dest.createSiteInst(spi.getSite());
+			    }
+			    copiedNet.createPin(spi.getName(), siteInst);
+			}
 		}		
 	}
 	
@@ -2362,6 +2375,9 @@ public class DesignTools {
 	                                        Map<String,String> prefixes, String prefixMatch) {
 		String newCellPrefix = srcToDestInstNames.get(prefixes.get(prefixMatch));
 		int idx = prefixMatch.length() - (newCellPrefix.length() == 0 ? 0 : 1);
+		if(idx == -1) {
+		    return newCellPrefix + "/" + srcName;
+		}
 		return newCellPrefix + srcName.substring(idx);
 	}
 	


### PR DESCRIPTION
This PR fixes two issues:

1) When copying the implementation from one design to another, previously, `SitePinInst` objects were not re-created.  Normally this was not an issue as generally the design would quickly be written to a DCP which doesn't capture `SitePinInst` objects, Vivado will infer them based on routing and site routing.  However, the lack of these pins was obscuring the fan out calculation of nets when exporting the routing for a DCP and was incorrectly writing out the node tags such that messages in Vivado upon DCP read would appear, such as:

```
WARNING: [Designutils 20-5375] Skipping invalid subTree.
CRITICAL WARNING: [Designutils 20-205] Net hierarchical/net/name was unrouted during load.
```
This change adds the `SitePinInst` objects as part of the copy of the implementation.

2) When attempting to copy the implementation from a top level of a design to a hierarchical cell in the destination design, the code was not handling an empty instance name properly.  This fixes this issue.

