### PR TITLE
Fixes for copy cell to DCP

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1433,6 +1433,13 @@ public class DesignTools {
 		EDIFCellInst futureBlackBox = hierarchicalCell.getInst();
 		if(futureBlackBox == null) throw new RuntimeException("ERROR: Couldn't find cell " + hierarchicalCell + " in source design " + d.getName());
 		
+		if(hierarchicalCell.getCellType() == d.getTopEDIFCell()) {
+		    d.unplaceDesign();
+		    d.getTopEDIFCell().makePrimitive();
+		    d.getTopEDIFCell().addProperty(EDIFCellInst.BLACK_BOX_PROP, true);
+		    return;
+		}
+		
 		Set<SiteInst> touched = new HashSet<>();
 		Map<String,String> boundaryNets = new HashMap<>();
 		
@@ -2278,7 +2285,11 @@ public class DesignTools {
 			}
 			destNetlist.migrateCellAndSubCells(cellInst.getCellType());
 			EDIFHierCellInst bbInst = destNetlist.getHierCellInstFromName(e.getValue());
-			bbInst.getInst().setCellType(cellInst.getCellType());
+			EDIFCell destCell = destNetlist.getCell(cellInst.getCellType().getLegalEDIFName());
+			if(destNetlist.getTopCell() == bbInst.getCellType()) {
+			    destNetlist.getDesign().setTopCell(destCell);
+			}
+			bbInst.getInst().setCellType(destCell);
 			instsWithSeparator.add(e.getKey() + EDIFTools.EDIF_HIER_SEP);
 		}
 		destNetlist.resetParentNetMap();

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -489,7 +489,7 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
 	/**
 	 * Deletes internal representation.  
 	 */
-	protected void makePrimitive() { 
+	public void makePrimitive() { 
 		EDIFNetlist netlist = getNetlist();
 		if(netlist!= null && netlist.isTrackingCellChanges()) {
 		    for(EDIFCellInst inst : getCellInsts()) {

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -980,12 +980,28 @@ public class EDIFTools {
 	 * @return The newly created netlist from the provided cell inst.
 	 */
 	public static EDIFNetlist createNewNetlist(EDIFCellInst cellInst){
+	    List<String> librariesOrder = new ArrayList<>(cellInst.getCellType().getNetlist().getLibrariesMap().keySet());
 	    EDIFNetlist n = new EDIFNetlist(cellInst.getName());
 	    n.generateBuildComments();
 	    EDIFDesign eDesign = new EDIFDesign(cellInst.getName());
 	    n.setDesign(eDesign);
-	    eDesign.setTopCell(cellInst.getCellType());
-	    n.migrateCellAndSubCells(cellInst.getCellType());
+	    EDIFCell topCell = cellInst.getCellType();
+	    n.copyCellAndSubCells(topCell);
+	    eDesign.setTopCell(n.getLibrary(topCell.getLibrary().getName()).getCell(topCell.getName()));
+	    if(n.getLibraries().size() > 2) {
+	        // Put libraries in the same order as source netlist
+	        Map<String, EDIFLibrary> libs = new HashMap<>();
+	        for(EDIFLibrary lib : n.getLibraries()) {
+	            libs.put(lib.getName(), lib);
+	        }
+	        n.getLibrariesMap().clear();
+	        for(String libName : librariesOrder) {
+	            EDIFLibrary lib = libs.get(libName);
+	            if(lib != null) {
+	                n.getLibrariesMap().put(libName, lib);	                
+	            }
+	        }
+	    }
 	    return n;
 	}
 	

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -974,13 +974,12 @@ public class EDIFTools {
 	}
 
 	/**
-	 * Creates a new netlist from an existing EDIFCellInst in a netlist.  This operation is 
-	 * destructive to the source netlist.   
+	 * Creates a new netlist from an existing EDIFCellInst in a netlist.  This operation does not 
+	 * modify the source netlist.   
 	 * @param cellInst The new top cell/top cell inst in the netlist.
 	 * @return The newly created netlist from the provided cell inst.
 	 */
 	public static EDIFNetlist createNewNetlist(EDIFCellInst cellInst){
-	    List<String> librariesOrder = new ArrayList<>(cellInst.getCellType().getNetlist().getLibrariesMap().keySet());
 	    EDIFNetlist n = new EDIFNetlist(cellInst.getName());
 	    n.generateBuildComments();
 	    EDIFDesign eDesign = new EDIFDesign(cellInst.getName());
@@ -995,7 +994,7 @@ public class EDIFTools {
 	            libs.put(lib.getName(), lib);
 	        }
 	        n.getLibrariesMap().clear();
-	        for(String libName : librariesOrder) {
+	        for(String libName : cellInst.getCellType().getNetlist().getLibrariesMap().keySet()) {
 	            EDIFLibrary lib = libs.get(libName);
 	            if(lib != null) {
 	                n.getLibrariesMap().put(libName, lib);	                


### PR DESCRIPTION
Fixes issues related to issues in `HardwareContractMaker` in #390.  This accommodates scenarios where the top level hierarchy object is being used.  Also fixes an issue when creating a stand-alone netlist from an existing cell was not updating the top cell reference appropriately.