### PR TITLE
Fix DesignTools.getTrimmablePIPsFromPins() for bidir sink nodes

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1161,6 +1161,7 @@ public class DesignTools {
             }
             rPips.add(pip);
 
+            int endNodeFanout = 0;
             if (pip.isBidirectional()) {
                 rPips = reverseConnsStart.get(startNode);
                 if (rPips == null) {
@@ -1169,14 +1170,18 @@ public class DesignTools {
                 }
                 rPips.add(pip);
 
-                int fanoutCount = nodeSinkPins.contains(endNode) ? 2 : 1;
-                fanout.merge(endNode, fanoutCount, Integer::sum);
+                endNodeFanout = 1;
+            } else if (nodeSinkPins.contains(endNode)) {
+                endNodeFanout = 1;
+            }
+            if (endNodeFanout > 0) {
+                fanout.merge(endNode, endNodeFanout, Integer::sum);
             }
 
             // If a site pin was found and it belongs to this net, add an extra fanout to
             // reflect that it was both used for downstream connection as well as this site pin
-            int fanoutCount = nodeSinkPins.contains(startNode) ? 2 : 1;
-            fanout.merge(startNode, fanoutCount, Integer::sum);
+            int startNodeFanout = nodeSinkPins.contains(startNode) ? 2 : 1;
+            fanout.merge(startNode, startNodeFanout, Integer::sum);
         }
 
         HashSet<PIP> toRemove = new HashSet<>();

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -381,6 +381,53 @@ public class TestDesignTools {
         )));
     }
 
+    @Test
+    public void testGetTrimmablePIPsFromPinsBidirSinkNode() {
+        Design design = new Design("test", "xcvu19p-fsva3824-1-e");
+        Device device = design.getDevice();
+
+        Net net = createTestNet(design, "net", new String[]{
+                "INT_X115Y444/INT.LOGIC_OUTS_W30->INT_NODE_SDQ_91_INT_OUT1",                    // EQ
+                "INT_X115Y444/INT.INT_NODE_SDQ_91_INT_OUT1->>INT_INT_SDQ_7_INT_OUT0",
+                "INT_X115Y444/INT.INT_INT_SDQ_7_INT_OUT0->>INT_NODE_GLOBAL_10_INT_OUT0",
+                "INT_X115Y444/INT.INT_NODE_GLOBAL_10_INT_OUT0->>INT_NODE_IMUX_59_INT_OUT1",
+                "INT_X115Y444/INT.INT_NODE_IMUX_59_INT_OUT1->>BOUNCE_W_13_FT0",                 // F_I
+                "INT_X115Y444/INT.LOGIC_OUTS_W30->INT_NODE_SDQ_91_INT_OUT0",
+                "INT_X115Y444/INT.INT_NODE_SDQ_91_INT_OUT0->>EE2_W_BEG7",
+                "INT_X116Y444/INT.EE2_W_END7->INT_NODE_SDQ_88_INT_OUT0",
+                "INT_X116Y444/INT.INT_NODE_SDQ_88_INT_OUT0->>WW1_W_BEG6",
+                "INT_X115Y444/INT.WW1_W_END6->INT_NODE_SDQ_38_INT_OUT1",
+                "INT_X115Y444/INT.INT_NODE_SDQ_38_INT_OUT1->>INT_INT_SDQ_75_INT_OUT0",
+                "INT_X115Y444/INT.INT_INT_SDQ_75_INT_OUT0->>INT_NODE_GLOBAL_9_INT_OUT0",
+                "INT_X115Y444/INT.INT_NODE_GLOBAL_9_INT_OUT0->>INT_NODE_IMUX_37_INT_OUT0",
+                "INT_X115Y444/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8"                      // EX
+        });
+
+        SiteInst si = design.createSiteInst(design.getDevice().getSite("SLICE_X220Y444"));
+        SitePinInst DQ2 = net.createPin("EQ", si);
+        DQ2.setRouted(true);
+        SitePinInst F_I = net.createPin("F_I", si);
+        F_I.setRouted(true);
+        SitePinInst EX = net.createPin("EX", si);
+        EX.setRouted(true);
+
+        List<SitePinInst> pinsToUnroute = new ArrayList<>(3);
+        pinsToUnroute.add(EX);
+        Set<PIP> trimmable = DesignTools.getTrimmablePIPsFromPins(net, pinsToUnroute);
+        Assertions.assertEquals(9, trimmable.size());
+        Assertions.assertTrue(trimmable.containsAll(Arrays.asList(
+                device.getPIP("INT_X115Y444/INT.LOGIC_OUTS_W30->INT_NODE_SDQ_91_INT_OUT0"),
+                device.getPIP("INT_X115Y444/INT.INT_NODE_SDQ_91_INT_OUT0->>EE2_W_BEG7"),
+                device.getPIP("INT_X116Y444/INT.EE2_W_END7->INT_NODE_SDQ_88_INT_OUT0"),
+                device.getPIP("INT_X116Y444/INT.INT_NODE_SDQ_88_INT_OUT0->>WW1_W_BEG6"),
+                device.getPIP("INT_X115Y444/INT.WW1_W_END6->INT_NODE_SDQ_38_INT_OUT1"),
+                device.getPIP("INT_X115Y444/INT.INT_NODE_SDQ_38_INT_OUT1->>INT_INT_SDQ_75_INT_OUT0"),
+                device.getPIP("INT_X115Y444/INT.INT_INT_SDQ_75_INT_OUT0->>INT_NODE_GLOBAL_9_INT_OUT0"),
+                device.getPIP("INT_X115Y444/INT.INT_NODE_GLOBAL_9_INT_OUT0->>INT_NODE_IMUX_37_INT_OUT0"),
+                device.getPIP("INT_X115Y444/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8")
+        )));
+    }
+
     public static Net createTestNet(Design design, String netName, String[] pips) {
         Net net = design.createNet(netName);
         Device device = design.getDevice();


### PR DESCRIPTION
Seems like #543 didn't quite do the job for the case where a bidir PIP lands on a sink node.