### PR TITLE
Support to enable netlist parser to sort EDIFPortInstList at end

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -636,6 +636,17 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
         return null;
     }
 
+    public void sortEDIFPortInstLists() {
+        for (EDIFNet net : getNets()) {
+            EDIFPortInstList list = net.getEDIFPortInstList();
+            if(list != null) list._reSortList();
+        }
+        for (EDIFCellInst inst : getCellInsts()) {
+            EDIFPortInstList list = inst.getEDIFPortInstList();
+            if(list != null) list._reSortList();
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -639,11 +639,11 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
     public void sortEDIFPortInstLists() {
         for (EDIFNet net : getNets()) {
             EDIFPortInstList list = net.getEDIFPortInstList();
-            if(list != null) list._reSortList();
+            if (list != null) list.reSortList();
         }
         for (EDIFCellInst inst : getCellInsts()) {
             EDIFPortInstList list = inst.getEDIFPortInstList();
-            if(list != null) list._reSortList();
+            if (list != null) list.reSortList();
         }
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -125,7 +125,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
      * @param deferSort The EDIFPortInstList maintains a sorted list of EDIFPortInst 
      * objects and sorts them upon insertion.  Setting this flag to true will skip a sort addition
      * but the caller is responsible to conclude a batch of additions with a call to 
-     * {@link EDIFPortInstList#_reSortList()}.  This is useful when a large number of EDIFPortInsts 
+     * {@link EDIFPortInstList#reSortList()}.  This is useful when a large number of EDIFPortInsts 
      * will be added consecutively (such as parsing a netlist).
      */
     protected void addPortInst(EDIFPortInst epr, boolean deferSort) {
@@ -134,7 +134,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
             throw new RuntimeException("ERROR: Incorrect EDIFPortInst '"+
                 epr.getFullName()+"' being added to EDIFCellInst " + toString());
         if (deferSort) {
-            portInsts._parseAdd(epr);
+            portInsts.deferSortAdd(epr);
         } else {
             portInsts.add(epr);
         }

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -114,11 +114,25 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
      * @param epr The port instance to add
      */
     protected void addPortInst(EDIFPortInst epr) {
+        addPortInst(epr, false);
+    }
+
+    /**
+     * Adds a new EDIFPortInst to this cell instance. The port instances are stored
+     * in a sorted ArrayList, so worst case is O(n).
+     * 
+     * @param epr The port instance to add
+     */
+    protected void addPortInst(EDIFPortInst epr, boolean parserCreate) {
         if (portInsts == null) portInsts = new EDIFPortInstList();
         if (!epr.getCellInst().equals(this))
             throw new RuntimeException("ERROR: Incorrect EDIFPortInst '"+
                 epr.getFullName()+"' being added to EDIFCellInst " + toString());
-        portInsts.add(epr);
+        if (parserCreate) {
+            portInsts._parseAdd(epr);
+        } else {
+            portInsts.add(epr);
+        }
     }
 
     /**
@@ -242,6 +256,10 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
         if (val != null && val.getValue().toLowerCase().equals("1"))
             return true;
         return false;
+    }
+
+    protected EDIFPortInstList getEDIFPortInstList() {
+        return portInsts;
     }
 
     public static final byte[] EXPORT_CONST_INSTANCE_BEGIN = "         (instance ".getBytes(StandardCharsets.UTF_8);

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -122,13 +122,18 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
      * in a sorted ArrayList, so worst case is O(n).
      * 
      * @param epr The port instance to add
+     * @param deferSort The EDIFPortInstList maintains a sorted list of EDIFPortInst 
+     * objects and sorts them upon insertion.  Setting this flag to true will skip a sort addition
+     * but the caller is responsible to conclude a batch of additions with a call to 
+     * {@link EDIFPortInstList#_reSortList()}.  This is useful when a large number of EDIFPortInsts 
+     * will be added consecutively (such as parsing a netlist).
      */
-    protected void addPortInst(EDIFPortInst epr, boolean parserCreate) {
+    protected void addPortInst(EDIFPortInst epr, boolean deferSort) {
         if (portInsts == null) portInsts = new EDIFPortInstList();
         if (!epr.getCellInst().equals(this))
             throw new RuntimeException("ERROR: Incorrect EDIFPortInst '"+
                 epr.getFullName()+"' being added to EDIFCellInst " + toString());
-        if (parserCreate) {
+        if (deferSort) {
             portInsts._parseAdd(epr);
         } else {
             portInsts.add(epr);

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -81,8 +81,13 @@ public class EDIFNet extends EDIFPropertyObject {
      * using a sorted ArrayList (@link EDIFPortInstList). Worst case O(n) to add.
      * 
      * @param portInst The port instance to add to this net.
+     * @param deferSort The EDIFPortInstList maintains a sorted list of EDIFPortInst 
+     * objects and sorts them upon insertion.  Setting this flag to true will skip a sort addition
+     * but the caller is responsible to conclude a batch of additions with a call to 
+     * {@link EDIFPortInstList#_reSortList()}.  This is useful when a large number of EDIFPortInsts 
+     * will be added consecutively (such as parsing a netlist).
      */
-    public void addPortInst(EDIFPortInst portInst, boolean parserCreate) {
+    public void addPortInst(EDIFPortInst portInst, boolean deferSort) {
         if (portInsts == null) portInsts = new EDIFPortInstList();
         boolean isParentCellNonNull = parentCell != null;
         EDIFCellInst inst = portInst.getCellInst();
@@ -94,7 +99,7 @@ public class EDIFNet extends EDIFPropertyObject {
             // This does not explicitly track the port instance index, in most cases the name should be sufficient.
             trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
         }
-        if (parserCreate) {
+        if (deferSort) {
             portInsts._parseAdd(portInst);
         } else {
             portInsts.add(portInst);

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -73,6 +73,16 @@ public class EDIFNet extends EDIFPropertyObject {
      * @param portInst The port instance to add to this net.
      */
     public void addPortInst(EDIFPortInst portInst) {
+        addPortInst(portInst, false);
+    }
+
+    /**
+     * Adds the EDIFPortInst to this logical net. The net stores the port instances
+     * using a sorted ArrayList (@link EDIFPortInstList). Worst case O(n) to add.
+     * 
+     * @param portInst The port instance to add to this net.
+     */
+    public void addPortInst(EDIFPortInst portInst, boolean parserCreate) {
         if (portInsts == null) portInsts = new EDIFPortInstList();
         boolean isParentCellNonNull = parentCell != null;
         EDIFCellInst inst = portInst.getCellInst();
@@ -84,7 +94,11 @@ public class EDIFNet extends EDIFPropertyObject {
             // This does not explicitly track the port instance index, in most cases the name should be sufficient.
             trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
         }
-        portInsts.add(portInst);
+        if (parserCreate) {
+            portInsts._parseAdd(portInst);
+        } else {
+            portInsts.add(portInst);
+        }
     }
 
     public void trackChanges(EDIFChangeType type, EDIFCellInst inst, String portInstName) {
@@ -148,7 +162,28 @@ public class EDIFNet extends EDIFPropertyObject {
      * @return The newly created port instance or null if none could be created on
      *         the cell or cell instance.
      */
-    private EDIFPortInst createPortInstFromPortInstName(String portInstName, EDIFCell cell, EDIFCellInst inst) {
+    public EDIFPortInst createPortInstFromPortInstName(String portInstName, EDIFCell cell, EDIFCellInst inst) {
+        return createPortInstFromPortInstName(portInstName, cell, inst, false);
+    }
+
+    /**
+     * Creates a port instance from a name. Navigates port naming issues when bussed
+     * names can collide with single bit port names.
+     * 
+     * @param portInstName Proposed name of the new port instance
+     * @param cell         The cell from which to draw the port
+     * @param inst         If this is not null, the port instance is added to the
+     *                     external facing port connection. If this is null, it will
+     *                     add it to the inward facing port connection.
+     * @param parserCreate A flag to indicate if this PortInst is being created
+     *                     during parsing of a netlist. Usually this is false. When
+     *                     true, it does not sort the insertion of this PortInst
+     *                     into the EDIFPortInstList.
+     * @return The newly created port instance or null if none could be created on
+     *         the cell or cell instance.
+     */
+    public EDIFPortInst createPortInstFromPortInstName(String portInstName, EDIFCell cell,
+            EDIFCellInst inst, boolean parserCreate) {
         EDIFPort port = cell.getPortByPortInstName(portInstName);
         if (port == null) return null;
         int portIdx = -1;
@@ -156,7 +191,7 @@ public class EDIFNet extends EDIFPropertyObject {
             int idx = EDIFTools.getPortIndexFromName(portInstName);
             portIdx = port.getPortIndexFromNameIndex(idx);
         }
-        return new EDIFPortInst(port, this, portIdx, inst);
+        return new EDIFPortInst(port, this, portIdx, inst, parserCreate);
     }
 
     public EDIFPortInst createPortInst(String portName, int index, EDIFCellInst cellInst) {
@@ -343,6 +378,10 @@ public class EDIFNet extends EDIFPropertyObject {
     public void setParentCell(EDIFCell parentCell) {
         this.parentCell = parentCell;
         parentCell.trackChange(EDIFChangeType.NET_ADD, getName());
+    }
+
+    protected EDIFPortInstList getEDIFPortInstList() {
+        return portInsts;
     }
 
     public static final byte[] EXPORT_CONST_NET_START = "         (net ".getBytes(StandardCharsets.UTF_8);

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -84,7 +84,7 @@ public class EDIFNet extends EDIFPropertyObject {
      * @param deferSort The EDIFPortInstList maintains a sorted list of EDIFPortInst 
      * objects and sorts them upon insertion.  Setting this flag to true will skip a sort addition
      * but the caller is responsible to conclude a batch of additions with a call to 
-     * {@link EDIFPortInstList#_reSortList()}.  This is useful when a large number of EDIFPortInsts 
+     * {@link EDIFPortInstList#reSortList()}.  This is useful when a large number of EDIFPortInsts 
      * will be added consecutively (such as parsing a netlist).
      */
     public void addPortInst(EDIFPortInst portInst, boolean deferSort) {
@@ -100,7 +100,7 @@ public class EDIFNet extends EDIFPropertyObject {
             trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
         }
         if (deferSort) {
-            portInsts._parseAdd(portInst);
+            portInsts.deferSortAdd(portInst);
         } else {
             portInsts.add(portInst);
         }
@@ -180,15 +180,17 @@ public class EDIFNet extends EDIFPropertyObject {
      * @param inst         If this is not null, the port instance is added to the
      *                     external facing port connection. If this is null, it will
      *                     add it to the inward facing port connection.
-     * @param parserCreate A flag to indicate if this PortInst is being created
-     *                     during parsing of a netlist. Usually this is false. When
-     *                     true, it does not sort the insertion of this PortInst
-     *                     into the EDIFPortInstList.
+     * @param deferSort    The EDIFPortInstList maintains a sorted list of EDIFPortInst 
+     *                     objects and sorts them upon insertion.  Setting this flag to 
+     *                     true will skip a sort addition but the caller is responsible 
+     *                     to conclude a batch of additions with a call to 
+     *                     {@link EDIFPortInstList#reSortList()}.  This is useful when 
+     *                     a large number of EDIFPortInsts.
      * @return The newly created port instance or null if none could be created on
      *         the cell or cell instance.
      */
     public EDIFPortInst createPortInstFromPortInstName(String portInstName, EDIFCell cell,
-            EDIFCellInst inst, boolean parserCreate) {
+            EDIFCellInst inst, boolean deferSort) {
         EDIFPort port = cell.getPortByPortInstName(portInstName);
         if (port == null) return null;
         int portIdx = -1;
@@ -196,7 +198,7 @@ public class EDIFNet extends EDIFPropertyObject {
             int idx = EDIFTools.getPortIndexFromName(portInstName);
             portIdx = port.getPortIndexFromNameIndex(idx);
         }
-        return new EDIFPortInst(port, this, portIdx, inst, parserCreate);
+        return new EDIFPortInst(port, this, portIdx, inst, deferSort);
     }
 
     public EDIFPortInst createPortInst(String portName, int index, EDIFCellInst cellInst) {

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -86,6 +86,20 @@ public class EDIFPortInst {
      * @param cellInst This instance on which this port ref corresponds.
      */
     public EDIFPortInst(EDIFPort port, EDIFNet parentNet, int index, EDIFCellInst cellInst) {
+        this(port, parentNet, index, cellInst, false);
+    }
+
+    /**
+     * Constructor to create a new port ref on the provided instance and connect
+     * it to the provided net
+     * @param port The port on the cell this port ref uses
+     * @param parentNet The net this port ref should be added to
+     * @param index For port refs part of a bussed port, this is the index into
+     * the bussed array, for single bit ports, it should be -1.
+     * @param cellInst This instance on which this port ref corresponds.
+     */
+    public EDIFPortInst(EDIFPort port, EDIFNet parentNet, int index, EDIFCellInst cellInst,
+            boolean parserCreate) {
         if (index == -1 && port.isBus()) {
             throw new RuntimeException("ERROR: Use a different constructor, "
                     + "need index for bussed port " + port.getName());
@@ -104,8 +118,9 @@ public class EDIFPortInst {
         this.index = index;
         this.port = port;
         this.name = getPortInstNameFromPort();
-        setCellInst(cellInst);
-        if (parentNet != null) parentNet.addPortInst(this);
+        setCellInst(cellInst, parserCreate);
+        if (parentNet != null)
+            parentNet.addPortInst(this, parserCreate);
     }
 
     protected EDIFPortInst() {
@@ -154,12 +169,19 @@ public class EDIFPortInst {
      * @param cellInst the cellInst to set
      */
     public void setCellInst(EDIFCellInst cellInst) {
-        if (this.cellInst != null) {
+        setCellInst(cellInst, false);
+    }
+
+    /**
+     * @param cellInst the cellInst to set
+     */
+    public void setCellInst(EDIFCellInst cellInst, boolean parserCreate) {
+        if (this.cellInst != null && !parserCreate) {
             this.cellInst.removePortInst(this);
         }
         this.cellInst = cellInst;
         if (cellInst != null) {
-            cellInst.addPortInst(this);
+            cellInst.addPortInst(this, parserCreate);
         }
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -34,7 +34,7 @@ import java.nio.charset.StandardCharsets;
  * Represents an instance of a port on an {@link EDIFCellInst}.
  * Created on: May 11, 2017
  */
-public class EDIFPortInst {
+public class EDIFPortInst implements Comparable<EDIFPortInst> {
 
     private String name;
 
@@ -97,9 +97,14 @@ public class EDIFPortInst {
      * @param index For port refs part of a bussed port, this is the index into
      * the bussed array, for single bit ports, it should be -1.
      * @param cellInst This instance on which this port ref corresponds.
+     * @param deferSort The EDIFPortInstList maintains a sorted list of EDIFPortInst 
+     * objects and sorts them upon insertion.  Setting this flag to true will skip a sort addition
+     * but the caller is responsible to conclude a batch of additions with a call to 
+     * {@link EDIFPortInstList#_reSortList()}.  This is useful when a large number of EDIFPortInsts 
+     * will be added consecutively (such as parsing a netlist).
      */
     public EDIFPortInst(EDIFPort port, EDIFNet parentNet, int index, EDIFCellInst cellInst,
-            boolean parserCreate) {
+            boolean deferSort) {
         if (index == -1 && port.isBus()) {
             throw new RuntimeException("ERROR: Use a different constructor, "
                     + "need index for bussed port " + port.getName());
@@ -118,9 +123,9 @@ public class EDIFPortInst {
         this.index = index;
         this.port = port;
         this.name = getPortInstNameFromPort();
-        setCellInst(cellInst, parserCreate);
+        setCellInst(cellInst, deferSort);
         if (parentNet != null)
-            parentNet.addPortInst(this, parserCreate);
+            parentNet.addPortInst(this, deferSort);
     }
 
     protected EDIFPortInst() {
@@ -173,15 +178,21 @@ public class EDIFPortInst {
     }
 
     /**
+     * Sets the corresponding cell instance for this port instance.
      * @param cellInst the cellInst to set
+     * @param deferSort The EDIFPortInstList maintains a sorted list of EDIFPortInst 
+     * objects and sorts them upon insertion.  Setting this flag to true will skip a sort addition
+     * but the caller is responsible for conclude a batch of additions with a call to 
+     * {@link EDIFPortInstList#_reSortList()}.  This is useful when a large number of EDIFPortInsts 
+     * will be added consecutively (such as parsing a netlist).
      */
-    public void setCellInst(EDIFCellInst cellInst, boolean parserCreate) {
-        if (this.cellInst != null && !parserCreate) {
+    public void setCellInst(EDIFCellInst cellInst, boolean deferSort) {
+        if (this.cellInst != null && !deferSort) {
             this.cellInst.removePortInst(this);
         }
         this.cellInst = cellInst;
         if (cellInst != null) {
-            cellInst.addPortInst(this, parserCreate);
+            cellInst.addPortInst(this, deferSort);
         }
     }
 
@@ -323,5 +334,13 @@ public class EDIFPortInst {
     public String toString() {
         if (cellInst == null) return name;
         return cellInst.getName() + EDIFTools.EDIF_HIER_SEP + name;
+    }
+
+    @Override
+    public int compareTo(EDIFPortInst o) {
+        EDIFCellInst cellInst = o.getCellInst();
+        String cellInstName = cellInst == null ? null : cellInst.getName();
+        String portInstName = o.getName();
+        return EDIFPortInstList.compare(this, cellInstName, portInstName);
     }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -100,7 +100,7 @@ public class EDIFPortInst implements Comparable<EDIFPortInst> {
      * @param deferSort The EDIFPortInstList maintains a sorted list of EDIFPortInst 
      * objects and sorts them upon insertion.  Setting this flag to true will skip a sort addition
      * but the caller is responsible to conclude a batch of additions with a call to 
-     * {@link EDIFPortInstList#_reSortList()}.  This is useful when a large number of EDIFPortInsts 
+     * {@link EDIFPortInstList#reSortList()}.  This is useful when a large number of EDIFPortInsts 
      * will be added consecutively (such as parsing a netlist).
      */
     public EDIFPortInst(EDIFPort port, EDIFNet parentNet, int index, EDIFCellInst cellInst,
@@ -183,7 +183,7 @@ public class EDIFPortInst implements Comparable<EDIFPortInst> {
      * @param deferSort The EDIFPortInstList maintains a sorted list of EDIFPortInst 
      * objects and sorts them upon insertion.  Setting this flag to true will skip a sort addition
      * but the caller is responsible for conclude a batch of additions with a call to 
-     * {@link EDIFPortInstList#_reSortList()}.  This is useful when a large number of EDIFPortInsts 
+     * {@link EDIFPortInstList#reSortList()}.  This is useful when a large number of EDIFPortInsts 
      * will be added consecutively (such as parsing a netlist).
      */
     public void setCellInst(EDIFCellInst cellInst, boolean deferSort) {

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInstList.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInstList.java
@@ -95,7 +95,7 @@ public class EDIFPortInstList extends ArrayList<EDIFPortInst> {
      * @return 0 if the left and corresponding right Strings are equal.  A number less than 0 if
      * left is lexicographically before right, or a number greater than 0 if left is after right.
      */
-    private static int compare(EDIFPortInst left, String rightInstName, String rightPortInstName) {
+    protected static int compare(EDIFPortInst left, String rightInstName, String rightPortInstName) {
         if (left.getCellInst() == null) {
             if (rightInstName == null) {
                 // left and right are both a top-level port insts, compare their port insts name only
@@ -122,13 +122,6 @@ public class EDIFPortInstList extends ArrayList<EDIFPortInst> {
     }
 
     public void _reSortList() {
-        Collections.sort(this, new Comparator<EDIFPortInst>() {
-            public int compare(EDIFPortInst left, EDIFPortInst right) {
-                EDIFCellInst cellInst = right.getCellInst();
-                String cellInstName = cellInst == null ? null : cellInst.getName();
-                String portInstName = right.getName();
-                return EDIFPortInstList.compare(left, cellInstName, portInstName);
-            }
-        });
+        Collections.sort(this);
     }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInstList.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInstList.java
@@ -24,6 +24,8 @@
 package com.xilinx.rapidwright.edif;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 
 /**
  * Customized ArrayList<EDIFPortInst> for the {@link EDIFNet} and {@link EDIFCellInst} classes.
@@ -93,7 +95,7 @@ public class EDIFPortInstList extends ArrayList<EDIFPortInst> {
      * @return 0 if the left and corresponding right Strings are equal.  A number less than 0 if
      * left is lexicographically before right, or a number greater than 0 if left is after right.
      */
-    private int compare(EDIFPortInst left, String rightInstName, String rightPortInstName) {
+    private static int compare(EDIFPortInst left, String rightInstName, String rightPortInstName) {
         if (left.getCellInst() == null) {
             if (rightInstName == null) {
                 // left and right are both a top-level port insts, compare their port insts name only
@@ -113,5 +115,20 @@ public class EDIFPortInstList extends ArrayList<EDIFPortInst> {
         // compare their port inst names.
         int compare = left.getCellInst().getName().compareTo(rightInstName);
         return compare == 0 ? left.getName().compareTo(rightPortInstName) : compare;
+    }
+
+    public void _parseAdd(EDIFPortInst e) {
+        super.add(e);
+    }
+
+    public void _reSortList() {
+        Collections.sort(this, new Comparator<EDIFPortInst>() {
+            public int compare(EDIFPortInst left, EDIFPortInst right) {
+                EDIFCellInst cellInst = right.getCellInst();
+                String cellInstName = cellInst == null ? null : cellInst.getName();
+                String portInstName = right.getName();
+                return EDIFPortInstList.compare(left, cellInstName, portInstName);
+            }
+        });
     }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInstList.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInstList.java
@@ -117,11 +117,20 @@ public class EDIFPortInstList extends ArrayList<EDIFPortInst> {
         return compare == 0 ? left.getName().compareTo(rightPortInstName) : compare;
     }
 
-    public void _parseAdd(EDIFPortInst e) {
+    /**
+     * Adds an element without sorting it and appending it to the end of the list.  This method
+     * should be used with caution and generally always in conjunction with {@link #reSortList()} 
+     * after a batch of additions. 
+     * @param e The element to add
+     */
+    public void deferSortAdd(EDIFPortInst e) {
         super.add(e);
     }
 
-    public void _reSortList() {
+    /**
+     * Invokes this list to be re sorted (it maintains a sorted list upon add).  
+     */
+    public void reSortList() {
         Collections.sort(this);
     }
 }


### PR DESCRIPTION
By itself, this PR doesn't change the existing EDIF parser behaviour; it just provides the capability to defer sorting and the ability to perform that sort at some later point.