### PR TITLE
Restore original EDIFPort.getBusName() behaviour

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -845,7 +845,7 @@ public class DesignTools {
         Map<String, EDIFPort> cellPorts = new HashMap<>(target.getPortMap());
         StringBuilder sb = new StringBuilder();
         for (EDIFPort p : src.getPorts()) {
-            EDIFPort otherPort = cellPorts.remove(p.getBusName());
+            EDIFPort otherPort = cellPorts.remove(p.getBusName(true));
             if (otherPort == null) {
                 otherPort = cellPorts.remove(p.getName());
                 if (otherPort == null) {

--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFWriter.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFWriter.java
@@ -111,7 +111,7 @@ public class BinaryEDIFWriter {
                 for (EDIFNet net : cell.getNets()) {
                     addObjectToStringMap(net, stringMap);
                     for (EDIFPortInst pi : net.getPortInsts()) {
-                        String name = pi.getPort().isBus() ? pi.getPort().getBusName() : pi.getName();
+                        String name = pi.getPort().isBus() ? pi.getPort().getBusName(true) : pi.getName();
                         addStringToStringMap(name, stringMap);
                     }
                 }
@@ -276,7 +276,7 @@ public class BinaryEDIFWriter {
         if (port.isBus()) {
             EDIFCell cell = portInst.getCellInst() == null ? portInst.getParentCell() : portInst.getCellInst().getCellType();
             EDIFPort portCollision = cell.getPort(portInst.getPort().getName());
-            returnValue = portCollision != null ? port.getName() : port.getBusName();
+            returnValue = portCollision != null ? port.getName() : port.getBusName(true);
         } else {
             returnValue = portInst.getName();
         }

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -112,12 +112,12 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
                     EDIFPort newPort = null;
                     if (prototype.getCellInst() != null) {
                         newPortInst.setCellInst(getCellInst(prototype.getCellInst().getName()));
-                        newPort = newPortInst.getCellInst().getCellType().getPort(prototype.getPort().getBusName());
+                        newPort = newPortInst.getCellInst().getCellType().getPort(prototype.getPort().getBusName(true));
                         if (newPort == null || newPort.getWidth() != prototype.getPort().getWidth()) {
                             newPort = newPortInst.getCellInst().getCellType().getPort(prototype.getPort().getName());
                         }
                     } else {
-                        newPort = getPort(prototype.getPort().getBusName());
+                        newPort = getPort(prototype.getPort().getBusName(true));
                         if (newPort == null || newPort.getWidth() != prototype.getPort().getWidth()) {
                             newPort = getPort(prototype.getPort().getName());
                         }
@@ -487,7 +487,7 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
         if (portMap.size() != cell.getPortMap().size()) return false;
 
         for (EDIFPort port : cell.getPorts()) {
-            EDIFPort match = portMap.remove(port.getBusName());
+            EDIFPort match = portMap.remove(port.getBusName(true));
             if (match == null) {
                 match = portMap.remove(port.getName());
                 if (match == null) {

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -238,7 +238,7 @@ public class EDIFCell extends EDIFPropertyObject implements EDIFEnumerable {
     public EDIFPort addPort(EDIFPort port) {
         if (ports == null) ports = getNewMap();
         port.setParentCell(this);
-        EDIFPort collision = ports.put(port.getBusName(), port);
+        EDIFPort collision = ports.put(port.getBusName(true), port);
         if (collision != null && port != collision) {
             throw new RuntimeException("ERROR: Port name collision on EDIFCell " + getName()
                     + ", trying to add port " + port

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -238,7 +238,7 @@ public class EDIFCellInst extends EDIFPropertyObject implements EDIFEnumerable {
         setCellTypeRaw(cellType);
         for (EDIFPortInst portInst : getPortInsts()) {
             EDIFPort origPort = portInst.getPort();
-            EDIFPort port = cellType.getPort(origPort.getBusName());
+            EDIFPort port = cellType.getPort(origPort.getBusName(true));
             if (port == null || port.getWidth() != origPort.getWidth()) {
                 port = cellType.getPort(origPort.getName());
             }

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -151,8 +151,11 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
 
     public String getBusName(boolean keepOpenBracket) {
         if (busName == null) {
-            int idx = EDIFTools.lengthOfNameWithoutBus(getName().toCharArray(), keepOpenBracket);
+            int idx = EDIFTools.lengthOfNameWithoutBus(getName().toCharArray(), true);
             busName = getName().substring(0, idx);
+        }
+        if (!keepOpenBracket && busName.charAt(busName.length() - 1) == '[') {
+            return busName.substring(0, busName.length() - 1);
         }
         return busName;
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -146,8 +146,12 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
     }
 
     public String getBusName() {
+        return getBusName(false);
+    }
+
+    public String getBusName(boolean keepOpenBracket) {
         if (busName == null) {
-            int idx = EDIFTools.lengthOfNameWithoutBus(getName().toCharArray(), true);
+            int idx = EDIFTools.lengthOfNameWithoutBus(getName().toCharArray(), keepOpenBracket);
             busName = getName().substring(0, idx);
         }
         return busName;
@@ -233,7 +237,7 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
     public String getPortInstNameFromPort(int index) {
         if (!isBus()) return getBusName();
         index = getPortIndexFromNameIndex(index);
-        return getBusName() + index + "]";
+        return getBusName(true) + index + "]";
     }
 
     /**
@@ -300,7 +304,7 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
      * @return
      */
     public boolean isBus() {
-        return width > 1 || !getName().equals(getBusName());
+        return width > 1 || !getName().equals(busName);
     }
 
     public int[] getBitBlastedIndicies() {

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -110,7 +110,7 @@ public class EDIFPortInst implements Comparable<EDIFPortInst> {
                     + "need index for bussed port " + port.getName());
         }
         if (cellInst != null) {
-            if (!port.equals(cellInst.getPort(port.getBusName()))) {
+            if (!port.equals(cellInst.getPort(port.getBusName(true)))) {
                 // check for name collision
                 if (!port.equals(cellInst.getPort(port.getName()))) {
                     throw new RuntimeException("ERROR: Provided port '"+

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPort.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPort.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestEDIFPort {
 
@@ -128,5 +130,27 @@ public class TestEDIFPort {
         Assertions.assertEquals(0, busPort.getRight());
         Assertions.assertEquals(busPort, cell.getPort("foo[0]["));
         Assertions.assertNotEquals(busPort, cell.getPort("foo[0]"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "bus[7:0],bus,8",
+            "bus[0:7],bus,8",
+            "bus[15][15:0],bus[15],8",
+            "foo,foo,1",
+            "foo[0],foo[0],1",
+            "foo[1],foo[1],1",
+            "foo[2][2],foo[2][2],1",
+            "foo[3][3:3],foo[3],1",
+    })
+    void testGetBusName(String portName, String busName, int width) {
+        String designName = "design";
+        final EDIFNetlist netlist = EDIFTools.createNewNetlist(designName);
+        final Design design = new Design(designName, Device.KCU105);
+        design.setNetlist(netlist);
+
+        EDIFCell cell = new EDIFCell(netlist.getWorkLibrary(), "cell_1");
+        EDIFPort busOutput = cell.createPort(portName, EDIFDirection.OUTPUT, width);
+        Assertions.assertEquals(busName, busOutput.getBusName());
     }
 }


### PR DESCRIPTION
Fixes #560, which describes a change in `EDIFPort.getBusName()` behaviour introduced in #547.

This PR adds an overload `EDIFPort.getBusName(boolean)` which determines whether the open bracket is preserved. The existing parameter-less method defaults to false, preserving old behaviour. Cases where the open bracket is needed to differentiate between bussy and bitty ports will call the new overload with `true`.