### PR TITLE
Rewrite unroute source/sink pin methods in DesignTools

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1100,7 +1100,7 @@ public class DesignTools {
 
         Map<Node, List<PIP>> pipMap = new HashMap<>();
         for (PIP pip : src.getNet().getPIPs()) {
-            Node node = pip.getStartNode();
+            Node node = pip.isReversed() ? pip.getEndNode() : pip.getStartNode();
             pipMap.computeIfAbsent(node, k -> new ArrayList<>()).add(pip);
         }
 
@@ -1116,7 +1116,7 @@ public class DesignTools {
             List<PIP> pips = pipMap.get(curr);
             if (pips != null) {
                 for (PIP p : pips) {
-                    Node endNode = p.getEndNode();
+                    Node endNode = p.isReversed() ? p.getStartNode() : p.getEndNode();
                     q.add(endNode);
                     pipsToRemove.add(p);
                     SitePinInst sink = sinkNodes.get(endNode);

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1143,7 +1143,7 @@ public class DesignTools {
      */
     public static Set<PIP> getTrimmablePIPsFromPins(Net net, Collection<SitePinInst> pins) {
         // Map listing the PIPs that drive a Node
-        Map<Node,ArrayList<PIP>> endNodeToPips = new HashMap<>();
+        Map<Node,ArrayList<PIP>> reverseConns = new HashMap<>();
         Map<Node,Integer> fanout = new HashMap<>();
         Set<Node> nodeSinkPins = new HashSet<>();
         for (SitePinInst sinkPin : net.getSinkPins()) {
@@ -1153,7 +1153,7 @@ public class DesignTools {
             Node endNode = pip.isReversed() ? pip.getStartNode() : pip.getEndNode();
             Node startNode = pip.isReversed() ? pip.getEndNode() : pip.getStartNode();
 
-            ArrayList<PIP> rPips = endNodeToPips.computeIfAbsent(endNode, (n) -> new ArrayList<>());
+            ArrayList<PIP> rPips = reverseConns.computeIfAbsent(endNode, (n) -> new ArrayList<>());
             rPips.add(pip);
 
             fanout.merge(startNode, 1, Integer::sum);
@@ -1181,14 +1181,14 @@ public class DesignTools {
                     // This node is also used to connect another downstream pin, no more
                     // analysis necessary
                 } else {
-                    ArrayList<PIP> curr = endNodeToPips.get(sink);
+                    ArrayList<PIP> curr = reverseConns.get(sink);
                     while (curr != null && curr.size() == 1 && fanoutCount < 2) {
                         PIP pip = curr.get(0);
                         toRemove.add(pip);
                         updateFanout.add(pip.isReversed() ? pip.getEndNode() : pip.getStartNode());
                         sink = new Node(pip.getTile(), pip.isReversed() ? pip.getEndWireIndex() :
                                 pip.getStartWireIndex());
-                        curr = endNodeToPips.get(sink);
+                        curr = reverseConns.get(sink);
                         fanoutCount = fanout.getOrDefault(sink, 0);
                     }
                     if (curr == null && fanout.size() == 1 && !net.isStaticNet()) {

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -479,6 +479,44 @@ public class TestDesignTools {
         }
     }
 
+    @Test
+    public void testUnrouteSourcePinBidir() {
+        Design design = new Design("test", "xcvu19p-fsva3824-1-e");
+
+        Net net = createTestNet(design, "net", new String[]{
+                "INT_X193Y606/INT.LOGIC_OUTS_W27->INT_NODE_SDQ_87_INT_OUT0",
+                "INT_X193Y606/INT.INT_NODE_SDQ_87_INT_OUT0->>NN1_W_BEG6",
+                "INT_X193Y607/INT.NN1_W_END6->INT_NODE_SDQ_83_INT_OUT0",
+                "INT_X193Y607/INT.INT_NODE_SDQ_83_INT_OUT0->>WW1_W_BEG5",
+                "INT_X192Y607/INT.WW1_W_END5->INT_NODE_SDQ_34_INT_OUT0",
+                "INT_X192Y607/INT.INT_NODE_SDQ_34_INT_OUT0->>EE1_E_BEG5",
+                "INT_X193Y607/INT.EE1_E_END5->INT_NODE_SDQ_79_INT_OUT0",
+                "INT_X193Y607/INT.INT_NODE_SDQ_79_INT_OUT0->>SS1_W_BEG5",
+                "INT_X193Y606/INT.SS1_W_END5->>INT_NODE_IMUX_49_INT_OUT1",
+                "INT_X193Y606/INT.INT_NODE_IMUX_49_INT_OUT1->>BYPASS_W8",
+                "INT_X193Y606/INT.BYPASS_W8->>INT_NODE_IMUX_36_INT_OUT1",
+                "INT_X193Y606/INT.INT_NODE_IMUX_36_INT_OUT1->>BYPASS_W3",       // DX
+                "INT_X193Y606/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8",     // (reverse this PIP)
+                "INT_X193Y606/INT.INT_NODE_IMUX_37_INT_OUT0->>BYPASS_W7",       // D_I
+        });
+
+        for (PIP pip : net.getPIPs()) {
+            if (pip.toString().equals("INT_X193Y606/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8"))
+                pip.setIsReversed(true);
+        }
+
+        SiteInst si = design.createSiteInst(design.getDevice().getSite("SLICE_X369Y606"));
+        SitePinInst DQ2 = net.createPin("DQ2", si);
+        DQ2.setRouted(true);
+        SitePinInst DX = net.createPin("DX", si);
+        DX.setRouted(true);
+        SitePinInst D_I = net.createPin("D_I", si);
+        D_I.setRouted(true);
+
+        DesignTools.unrouteSourcePin(DQ2);
+        Assertions.assertTrue(net.getPIPs().isEmpty());
+    }
+
     public static void addPIPs(Net net, String[] pips) {
         Device device = net.getDesign().getDevice();
         for (String pip : pips) {

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -166,10 +166,12 @@ public class TestDesignTools {
         testCopyImplementationHelper(keepStaticRouting, numPIPs);
     }
 
-    @Test
-    public void testBatchRemoveSitePins() {
-        Path dcpPath = RapidWrightDCP.getPath("picoblaze_ooc_X10Y235.dcp");
-        Design design = Design.readCheckpoint(dcpPath);
+    @ParameterizedTest
+    @ValueSource(strings = {"picoblaze_ooc_X10Y235.dcp",
+                            "picoblaze_partial.dcp",        // contains a routed clock net, with (many) bidir PIPs
+    })
+    public void testBatchRemoveSitePins(String path) {
+        Design design = RapidWrightDCP.loadDCP(path);
 
         SiteInst si = design.getSiteInstFromSiteName("SLICE_X14Y238");
         Assertions.assertNotNull(si);

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -301,7 +301,7 @@ public class TestDesignTools {
         Net net = createTestNet(design, "net", new String[]{
                 "INT_X102Y428/INT.LOGIC_OUTS_W30->>INT_NODE_IMUX_60_INT_OUT1",  // EQ output
                 "INT_X102Y428/INT.INT_NODE_IMUX_60_INT_OUT1->>BYPASS_W14",
-                "INT_X102Y428/INT.INT_NODE_IMUX_50_INT_OUT0<<->>BYPASS_W14",    // (bidir PIP!)
+                "INT_X102Y428/INT.INT_NODE_IMUX_50_INT_OUT0<<->>BYPASS_W14",    // (reversed PIP)
                 "INT_X102Y428/INT.INT_NODE_IMUX_50_INT_OUT0->>BOUNCE_W_13_FT0",
                 "INT_X102Y429/INT.BOUNCE_W_BLN_13_FT1->>INT_NODE_IMUX_62_INT_OUT0",
                 "INT_X102Y429/INT.INT_NODE_IMUX_62_INT_OUT0->>BYPASS_W5",       // B_I input
@@ -310,6 +310,11 @@ public class TestDesignTools {
                 "INT_X102Y428/INT.LOGIC_OUTS_W30->>INODE_W_60_FT0",
                 "INT_X102Y429/INT.INODE_W_BLN_60_FT1->>IMUX_W2",                // E1 input
         });
+
+        for (PIP pip : net.getPIPs()) {
+            if (pip.toString().equals("INT_X102Y428/INT.INT_NODE_IMUX_50_INT_OUT0<<->>BYPASS_W14"))
+                pip.setIsReversed(true);
+        }
 
         SiteInst si = design.createSiteInst(design.getDevice().getSite("SLICE_X196Y428"));
         SitePinInst EQ = net.createPin("EQ", si);
@@ -362,9 +367,14 @@ public class TestDesignTools {
                 "INT_X127Y235/INT.INT_NODE_SDQ_78_INT_OUT0->>WW2_W_BEG5",
                 "INT_X126Y235/INT.WW2_W_END5->>INT_NODE_IMUX_49_INT_OUT1",
                 "INT_X126Y235/INT.INT_NODE_IMUX_49_INT_OUT1->>BYPASS_W8",       // EX input
-                "INT_X126Y235/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8",
+                "INT_X126Y235/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8",     // (reversed PIP)
                 "INT_X126Y235/INT.INT_NODE_IMUX_37_INT_OUT0->>BYPASS_W7"        // D_I input
         });
+
+        for (PIP pip : net.getPIPs()) {
+            if (pip.toString().equals("INT_X126Y235/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8"))
+                pip.setIsReversed(true);
+        }
 
         SiteInst si = design.createSiteInst(design.getDevice().getSite("SLICE_X242Y235"));
         SitePinInst DQ2 = net.createPin("DQ2", si);
@@ -496,7 +506,7 @@ public class TestDesignTools {
                 "INT_X193Y606/INT.INT_NODE_IMUX_49_INT_OUT1->>BYPASS_W8",
                 "INT_X193Y606/INT.BYPASS_W8->>INT_NODE_IMUX_36_INT_OUT1",
                 "INT_X193Y606/INT.INT_NODE_IMUX_36_INT_OUT1->>BYPASS_W3",       // DX
-                "INT_X193Y606/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8",     // (reverse this PIP)
+                "INT_X193Y606/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8",     // (reversed PIP)
                 "INT_X193Y606/INT.INT_NODE_IMUX_37_INT_OUT0->>BYPASS_W7",       // D_I
         });
 


### PR DESCRIPTION
Specifically rewriting: `DesignTools.getTrimmablePIPsFromPins()` and modifying `DesignTools.unrouteSourcePin()`.
Also removes unused private method `DesignTools.unroutePin()`

Since it wasn't handling the two new testcases with bidirectional PIPs.

In this rewrite, use `PIP.isReversed()` to get the correct driving/sink node.