### PR TITLE
[CodePerfTracker] Don't +1 in computing maxSegmentNameSize

### DIFF
--- a/src/com/xilinx/rapidwright/tests/CodePerfTracker.java
+++ b/src/com/xilinx/rapidwright/tests/CodePerfTracker.java
@@ -334,8 +334,10 @@ public class CodePerfTracker {
         for (int i=0; i < runtimes.size(); i++) {
             totalRuntime += runtimes.get(i);
             totalUsage += memUsages.get(i);
-            int len = segmentNames.get(i).length() + 1;
-            if (len > maxSegmentNameSize) maxSegmentNameSize = len;
+            if (!printProgress) {
+                int len = segmentNames.get(i).length();
+                if (len > maxSegmentNameSize) maxSegmentNameSize = len;
+            }
         }
         runtimes.add(totalRuntime);
         memUsages.add(totalUsage);
@@ -344,7 +346,9 @@ public class CodePerfTracker {
         if (linuxProcID != null) {
             totalOSMemUsages.add(getTotalOSMemUsage());
         }
-        if (maxSegmentNameSize < totalName.length()) maxSegmentNameSize = totalName.length();
+        if (!printProgress && maxSegmentNameSize < totalName.length()) {
+            maxSegmentNameSize = totalName.length();
+        }
     }
 
     private void removeTotalEntry() {


### PR DESCRIPTION
Also, only update maxSegmentNameSize if !printProgress.

Means that we get this output now:
```
==============================================================================
==                                 Example                                  ==
==============================================================================
 XML Parse & Device Load:     1.106s              |    632.809MBs (peak)
            (EDIF Parse):            (    0.446s) |    772.668MBs (peak)
    (Read PhysDB Caches):            (    0.075s) |    791.926MBs (peak)
   (Read PhysDB Routing):            (    0.082s) |    827.535MBs (peak)
 (Read PhysDB Placement):            (    0.088s) |    827.551MBs (peak)
(Read PhysDB Finalizing):            (    0.006s) |    827.551MBs (peak)
   Read Netlist & PhysDB:     0.624s              |    827.551MBs (peak)
------------------------------------------------------------------------------
         [No GC] *Total*:     1.729s              |    827.645MBs (peak)
123456789012345678901234:     0.000s              |    827.648MBs (peak)
------------------------------------------------------------------------------
         [No GC] *Total*:     1.729s              |    827.914MBs (peak)
```
rather than the last few lines being:
```
123456789012345678901234:     0.000s              |    849.086MBs (peak)
------------------------------------------------------------------------------
          [No GC] *Total*:     1.680s              |    849.086MBs (peak)
```
when a segment name exists that is exactly `maxSegmentNameSize` (24 here).