### PR TITLE
Memory Reduction for RWRoute

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
@@ -52,6 +52,7 @@ public enum RouteNodeType {
      * Denotes other wiring {@link RouteNode} Objects
      * that are created for routing {@link Connection} Objects.
      */
-    WIRE
+    WIRE;
 
+    public static final RouteNodeType[] values = values();
 }


### PR DESCRIPTION
RouteNode memory reduction: 
1) Set HashMap init size to 1; 
2) Removes baseCost (compute on-the-fly); 
3) Combine isTarget flag and RouteNodeType into a single variable