### PR TITLE
[RouteNode] Combines the prev reference into children 

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -666,19 +666,20 @@ public class RWRoute{
     private void estimateDelayOfConnections() {
         for (Connection connection : indirectConnections) {
             RouteNode source = connection.getSourceRnode();
-            if (source.getChildren().length == 0) {
+            if (source.getChildrenCount() == 0) {
                 // output pin is blocked
                 swapOutputPin(connection);
                 source = connection.getSourceRnode();
             }
             short estDelay = (short) 10000;
-            for (RouteNode child : source.getChildren()) {
+            RouteNode[] childrenArray = source.getChildren();
+            for (int i=source.getChildrenStartIdx(); i < childrenArray.length; i++) {
+                RouteNode child = source.getChildren()[i];
                 short tmpDelay = 113;
                 tmpDelay += child.getDelay();
                 if (tmpDelay < estDelay) {
                     estDelay = tmpDelay;
                 }
-
             }
             estDelay += source.getDelay();
             connection.setTimingEdgesDelay(estDelay);
@@ -1367,7 +1368,9 @@ public class RWRoute{
                                   float rnodeDelayWeight, float rnodeEstDlyWeight) {
         PriorityQueue<RouteNode> queue = this.queue.get();
         boolean longParent = config.isTimingDriven() && DelayEstimatorBase.isLong(rnode.getNode());
-        for (RouteNode childRNode:rnode.getChildren()) {
+        RouteNode[] childrenArray = rnode.getChildren();
+        for (int i=rnode.getChildrenStartIdx(); i < childrenArray.length; i++) {
+            RouteNode childRNode = childrenArray[i];
             // Targets that are visited more than once must be overused
             assert(!childRNode.isTarget() || !childRNode.isVisited() || childRNode.willOverUse(connection.getNetWrapper()));
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -430,7 +430,7 @@ public class RouteNodeGraph {
     public int averageChildren() {
         int sum = 0;
         for (RouteNode rnode : getRnodes()) {
-            sum += rnode.everExpanded() ? rnode.getChildren().length : 0;
+            sum += rnode.everExpanded() ? rnode.getChildrenCount() : 0;
         }
         return Math.round((float) sum / numNodes());
     }


### PR DESCRIPTION
In order to reduce the cost of the `RouteNode` object, this change stores the `prev` reference at the 0th index of the `children` array.  This change does increase route time ~7%:

Baseline:
```
Route design:                          302.50s
?? Initialization:                      14.05s
?  ?? determine route targets:          13.08s
?? Routing:                            288.44s
   ?? route clock:                       0.00s
   ?? route static nets:                 0.00s
   ?? route wire nets:                 276.56s
   ?  ?? rnodes creation:               43.62s
   ?  ?? route connections:            212.65s
   ?  ?? update timing:                  0.00s
   ?  ?? update congestion costs:       20.29s
   ?? finalize routes:                  11.88s
```

With this PR:
```
Route design:                          325.20s
?? Initialization:                      14.31s
?  ?? determine route targets:          13.28s
?? Routing:                            310.88s
   ?? route clock:                       0.00s
   ?? route static nets:                 0.00s
   ?? route wire nets:                 299.34s
   ?  ?? rnodes creation:               62.82s
   ?  ?? route connections:            215.09s
   ?  ?? update timing:                  0.00s
   ?  ?? update congestion costs:       21.44s
   ?? finalize routes:                  11.54s
```