### PR TITLE
Add support to parse gzipped EDIF files

### DIFF
--- a/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
+++ b/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
@@ -24,15 +24,13 @@
 package com.xilinx.rapidwright.edif;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.xilinx.rapidwright.util.StringPool;
+import com.xilinx.rapidwright.util.function.InputStreamSupplier;
 
 public abstract class AbstractEDIFParserWorker {
 
@@ -93,15 +91,9 @@ public abstract class AbstractEDIFParserWorker {
     }
 
     public AbstractEDIFParserWorker(Path fileName, StringPool uniquifier, EDIFReadLegalNameCache cache) throws FileNotFoundException {
-        try {
-            in = Files.newInputStream(fileName);
-            tokenizer = new EDIFTokenizer(fileName, in, uniquifier);
-            this.cache = cache;
-        } catch (FileNotFoundException e) {
-            throw e;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        in = InputStreamSupplier.getInputStream(fileName);
+        tokenizer = new EDIFTokenizer(fileName, in, uniquifier);
+        this.cache = cache;
     }
 
     private static <T> T requireToken(T t) {

--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -129,7 +129,8 @@ public class EDIFParser extends AbstractEDIFParserWorker implements AutoCloseabl
             throw new EDIFParseException(token, "Expected EOF but found "+token);
         }
 
-        if (tokenizer.getFileName().toString().endsWith(".gz")) {
+        Path fileName = tokenizer.getFileName();
+        if (fileName != null && fileName.toString().endsWith(".gz")) {
             try {
                 Files.delete(
                         FileTools.getDecompressedGZIPFileName(tokenizer.getFileName()));

--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -29,12 +29,15 @@ package com.xilinx.rapidwright.edif;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.xilinx.rapidwright.tests.CodePerfTracker;
+import com.xilinx.rapidwright.util.FileTools;
 import com.xilinx.rapidwright.util.StringPool;
 
 /**
@@ -124,6 +127,15 @@ public class EDIFParser extends AbstractEDIFParserWorker implements AutoCloseabl
         final EDIFToken token = tokenizer.getOptionalNextToken(true);
         if (token != null) {
             throw new EDIFParseException(token, "Expected EOF but found "+token);
+        }
+
+        if (tokenizer.getFileName().toString().endsWith(".gz")) {
+            try {
+                Files.delete(
+                        FileTools.getDecompressedGZIPFileName(tokenizer.getFileName()));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
 
         return currNetlist;

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -755,7 +755,7 @@ public class EDIFTools {
     public static EDIFNetlist loadEDIFFile(Path fileName, int maxThreads) {
         try {
             final long size = Files.size(fileName);
-            if (ParallelEDIFParser.calcThreads(size, maxThreads) > 1) {
+            if (ParallelEDIFParser.calcThreads(size, maxThreads, fileName.toString().endsWith(".gz")) > 1) {
                 try (ParallelEDIFParser p = new ParallelEDIFParser(fileName)) {
                     return p.parseEDIFNetlist();
                 }

--- a/src/com/xilinx/rapidwright/util/FileTools.java
+++ b/src/com/xilinx/rapidwright/util/FileTools.java
@@ -1851,8 +1851,6 @@ public class FileTools {
         // Using a larger buffer size for GZIPInputStream improved runtime 5-10%
         try (GZIPInputStream gis = new GZIPInputStream(new FileInputStream(fileNameStr), 65536)) {
             Files.copy(gis, target, StandardCopyOption.REPLACE_EXISTING);
-        } catch (FileNotFoundException e) {
-            throw new UncheckedIOException(e);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1868,8 +1866,6 @@ public class FileTools {
         Path compressedFile = Paths.get(uncompressedFile.toString() + ".gz");
         try (GZIPOutputStream gos = new GZIPOutputStream(new FileOutputStream(compressedFile.toFile()), 65536)) {
             Files.copy(uncompressedFile, gos);
-        } catch (FileNotFoundException e) {
-            throw new UncheckedIOException(e);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/com/xilinx/rapidwright/util/function/InputStreamSupplier.java
+++ b/src/com/xilinx/rapidwright/util/function/InputStreamSupplier.java
@@ -23,14 +23,39 @@
 
 package com.xilinx.rapidwright.util.function;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.nio.file.Files;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 
 import org.apache.commons.io.function.IOSupplier;
 
+import com.xilinx.rapidwright.util.FileTools;
+
 public interface InputStreamSupplier extends IOSupplier<InputStream> {
     static InputStreamSupplier fromPath(Path p) {
-        return () -> Files.newInputStream(p);
+        return () -> getInputStream(p);
+    }
+
+    /**
+     * Gets the InputStream for the provided file path. If the file is gzipped (*.gz
+     * extension), it will decompress the file alongside the original with the '.gz'
+     * extension removed.
+     * 
+     * @param fileName Path to the file or gzipped file from which to get an InputStream.
+     * @return An InputStream of the file, or of a decompressed copy of a gzipped file.
+     */
+    public static InputStream getInputStream(Path fileName) {
+        InputStream in = null;
+        try {
+            if (fileName.toString().endsWith(".gz")) {
+                fileName = FileTools.decompressGZIPFile(fileName);
+            }
+            in = new FileInputStream(fileName.toString());
+        } catch (FileNotFoundException e) {
+            throw new UncheckedIOException("ERROR: Could not find file: " + fileName, e);
+        }
+        return in;
     }
 }

--- a/src/com/xilinx/rapidwright/util/function/InputStreamSupplier.java
+++ b/src/com/xilinx/rapidwright/util/function/InputStreamSupplier.java
@@ -31,7 +31,6 @@ import java.nio.file.Path;
 
 import org.apache.commons.io.function.IOSupplier;
 
-import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.FileTools;
 
 public interface InputStreamSupplier extends IOSupplier<InputStream> {
@@ -54,11 +53,7 @@ public interface InputStreamSupplier extends IOSupplier<InputStream> {
                 Path decompressed = FileTools.getDecompressedGZIPFileName(fileName);
                 synchronized (InputStreamSupplier.class) {
                     if (!decompressed.toFile().exists()) {
-                        System.out.println("Decompress");
-                        CodePerfTracker t = new CodePerfTracker("decompress");
-                        t.start("Decompress");
                         fileName = FileTools.decompressGZIPFile(fileName);
-                        t.stop().printSummary();
                     } else {
                         fileName = decompressed;
                     }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
@@ -131,7 +131,8 @@ public class TestEDIFParser {
         Assertions.assertTrue(compressed.toString().endsWith(".gz"));
         Assertions.assertTrue(src.toFile().exists());
         Files.delete(src);
-        EDIFTools.loadEDIFFile(compressed);
+        Assertions.assertFalse(src.toFile().exists());
+        Assertions.assertNotNull(EDIFTools.loadEDIFFile(compressed));
         Assertions.assertFalse(src.toFile().exists());
     }
 
@@ -143,8 +144,9 @@ public class TestEDIFParser {
         Assertions.assertTrue(compressed.toString().endsWith(".gz"));
         Assertions.assertTrue(src.toFile().exists());
         Files.delete(src);
+        Assertions.assertFalse(src.toFile().exists());
         try (ParallelEDIFParser p = new ParallelEDIFParser(compressed)) {
-            p.parseEDIFNetlist();
+            Assertions.assertNotNull(p.parseEDIFNetlist());
         }
         Assertions.assertFalse(src.toFile().exists());
     }


### PR DESCRIPTION
This will allow the EDIF Parser (both serial and parallel) to accept gzipped EDIF files for parsing.  It adds this capability by checking the file extension, if it ends with `.gz`, it is assumed gzip compressed and will temporarily decompress it in the same directory as the original file and parse it.  Once parsing is completed, the temporary decompressed EDIF file is deleted.  This will overwrite an existing EDIF file if the provided `.edf.gz` file is given for parsing.