### PR TITLE
DesignTools.createA1A6ToStaticNets() fixes

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2891,7 +2891,11 @@ public class DesignTools {
             }
             String belName = belPin.getBELName();
             if (LUTTools.isCellALUT(cell) &&
+                    // No cell placed in the 5LUT spot
+                    si.getCell(belName.replace('6', '5')) == null &&
+                    // No net originally present on input sitewire
                     netOnSiteWire != net &&
+                    // No net present on output sitewire
                     si.getNetFromSiteWire(belName.charAt(0) + "5LUT_O5") == null) {
                 // LUT input siteWire has no net attached, nor does the LUT output sitewire: no need for site pin
                 return;

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2878,10 +2878,8 @@ public class DesignTools {
         // SiteWire and SitePin Name are the same for LUT inputs
         String siteWireName = belPin.getSiteWireName();
         // VCC returned based on the site wire, site pins are not stored in dcp
-        Net net = si.getNetFromSiteWire(siteWireName);
-        if (net == null) {
-            net = si.getDesign().getVccNet();
-        }
+        Net netOnSiteWire = si.getNetFromSiteWire(siteWireName);
+        Net net = (netOnSiteWire != null) ? netOnSiteWire : si.getDesign().getVccNet();
         if (net.isStaticNet()) {
             // SRL16Es that have been transformed from SRLC32E require GND on their A6 pin
             if (cell.getType().equals("SRL16E") && siteWireName.endsWith("6")) {
@@ -2891,8 +2889,10 @@ public class DesignTools {
                 }
             }
             String belName = belPin.getBELName();
-            if (belPin.getBEL().isLUT() && si.getCell(belName.replace('6', '5')) == null) {
-                // Nothing is placed on the 5LUT BEL, no need for site pin
+            if (belPin.getBEL().isLUT() &&
+                    netOnSiteWire != net &&
+                    si.getNetFromSiteWire(belName.charAt(0) + "5LUT_O5") == null) {
+                // LUT input siteWire has no net attached, nor does the LUT output sitewire: no need for site pin
                 return;
             }
             SitePinInst pin = si.getSitePinInst(siteWireName);

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.xilinx.rapidwright.design.blocks.UtilizationType;
+import com.xilinx.rapidwright.design.tools.LUTTools;
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.BELClass;
 import com.xilinx.rapidwright.device.BELPin;
@@ -2889,7 +2890,7 @@ public class DesignTools {
                 }
             }
             String belName = belPin.getBELName();
-            if (belPin.getBEL().isLUT() &&
+            if (LUTTools.isCellALUT(cell) &&
                     netOnSiteWire != net &&
                     si.getNetFromSiteWire(belName.charAt(0) + "5LUT_O5") == null) {
                 // LUT input siteWire has no net attached, nor does the LUT output sitewire: no need for site pin

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -226,6 +226,40 @@ public class TestDesignTools {
     }
 
     @Test
+    public void testCreateA1A6ToStaticNets() {
+        String dcpPath = RapidWrightDCP.getString("bnn.dcp");
+        Design design = Design.readCheckpoint(dcpPath);
+        DesignTools.createA1A6ToStaticNets(design);
+
+        String[] pins = new String[]{
+                // 5LUT used as a static source
+                "SLICE_X79Y169/A6",
+                "SLICE_X73Y164/A6",
+                "SLICE_X82Y161/A6",
+                "SLICE_X79Y159/A6",
+                "SLICE_X76Y156/A6",
+                "SLICE_X73Y155/A6",
+                "SLICE_X83Y153/A6",
+                "SLICE_X77Y150/A6",
+                "SLICE_X79Y145/A6",
+                "SLICE_X78Y145/A6",
+
+                // Tied to VCC because RAMS32
+                "SLICE_X87Y203/H6",
+                "SLICE_X87Y202/H6"
+        };
+
+        Set<SitePinInst> vccPins = new HashSet<>(design.getVccNet().getPins());
+        for (String pin : pins) {
+            String[] split = pin.split("/");
+            SiteInst si = design.getSiteInstFromSiteName(split[0]);
+            SitePinInst spi = si.getSitePinInst(split[1]);
+            Assertions.assertNotNull(spi);
+            Assertions.assertTrue(vccPins.contains(spi));
+        }
+    }
+
+    @Test
     public void testBlackBoxCreation() {
         Design design = RapidWrightDCP.loadDCP("bnn.dcp");
         String hierCellName = "bd_0_i/hls_inst/inst/dmem_V_U";

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -226,40 +226,6 @@ public class TestDesignTools {
     }
 
     @Test
-    public void testCreateA1A6ToStaticNets() {
-        String dcpPath = RapidWrightDCP.getString("bnn.dcp");
-        Design design = Design.readCheckpoint(dcpPath);
-        DesignTools.createA1A6ToStaticNets(design);
-
-        String[] pins = new String[]{
-                // 5LUT used as a static source
-                "SLICE_X79Y169/A6",
-                "SLICE_X73Y164/A6",
-                "SLICE_X82Y161/A6",
-                "SLICE_X79Y159/A6",
-                "SLICE_X76Y156/A6",
-                "SLICE_X73Y155/A6",
-                "SLICE_X83Y153/A6",
-                "SLICE_X77Y150/A6",
-                "SLICE_X79Y145/A6",
-                "SLICE_X78Y145/A6",
-
-                // Tied to VCC because RAMS32
-                "SLICE_X87Y203/H6",
-                "SLICE_X87Y202/H6"
-        };
-
-        Set<SitePinInst> vccPins = new HashSet<>(design.getVccNet().getPins());
-        for (String pin : pins) {
-            String[] split = pin.split("/");
-            SiteInst si = design.getSiteInstFromSiteName(split[0]);
-            SitePinInst spi = si.getSitePinInst(split[1]);
-            Assertions.assertNotNull(spi);
-            Assertions.assertTrue(vccPins.contains(spi));
-        }
-    }
-
-    @Test
     public void testBlackBoxCreation() {
         Design design = RapidWrightDCP.loadDCP("bnn.dcp");
         String hierCellName = "bd_0_i/hls_inst/inst/dmem_V_U";
@@ -709,6 +675,40 @@ public class TestDesignTools {
             Assertions.assertEquals("[IN SLICE_X0Y0.A6]", design.getVccNet().getPins().toString());
         } else {
             Assertions.assertTrue(design.getVccNet().getPins().isEmpty());
+        }
+    }
+
+    @Test
+    public void testCreateA1A6ToStaticNetsVcc() {
+        String dcpPath = RapidWrightDCP.getString("bnn.dcp");
+        Design design = Design.readCheckpoint(dcpPath);
+        DesignTools.createA1A6ToStaticNets(design);
+
+        String[] pins = new String[]{
+                // 5LUT used as a static source
+                "SLICE_X79Y169/A6",
+                "SLICE_X73Y164/A6",
+                "SLICE_X82Y161/A6",
+                "SLICE_X79Y159/A6",
+                "SLICE_X76Y156/A6",
+                "SLICE_X73Y155/A6",
+                "SLICE_X83Y153/A6",
+                "SLICE_X77Y150/A6",
+                "SLICE_X79Y145/A6",
+                "SLICE_X78Y145/A6",
+
+                // Tied to VCC because RAMS32
+                "SLICE_X87Y203/H6",
+                "SLICE_X87Y202/H6"
+        };
+
+        Set<SitePinInst> vccPins = new HashSet<>(design.getVccNet().getPins());
+        for (String pin : pins) {
+            String[] split = pin.split("/");
+            SiteInst si = design.getSiteInstFromSiteName(split[0]);
+            SitePinInst spi = si.getSitePinInst(split[1]);
+            Assertions.assertNotNull(spi);
+            Assertions.assertTrue(vccPins.contains(spi));
         }
     }
 

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -713,6 +713,36 @@ public class TestDesignTools {
     }
 
     @Test
+    public void testCreateA1A6ToStaticNetsGnd() {
+        String dcpPath = RapidWrightDCP.getString("optical-flow.dcp");
+        Design design = Design.readCheckpoint(dcpPath);
+        DesignTools.createA1A6ToStaticNets(design);
+
+        String[] pins = new String[]{
+                // SRLC32E transformed to SRL16E
+                "SLICE_X68Y164/A6",
+                "SLICE_X68Y164/D6",
+                "SLICE_X68Y163/A6",
+                "SLICE_X68Y163/D6",
+                "SLICE_X68Y162/A6",
+                "SLICE_X68Y162/D6",
+                "SLICE_X68Y161/A6",
+                "SLICE_X68Y161/D6",
+                "SLICE_X68Y160/A6",
+                "SLICE_X68Y160/D6",
+        };
+
+        Set<SitePinInst> gndPins = new HashSet<>(design.getGndNet().getPins());
+        for (String pin : pins) {
+            String[] split = pin.split("/");
+            SiteInst si = design.getSiteInstFromSiteName(split[0]);
+            SitePinInst spi = si.getSitePinInst(split[1]);
+            Assertions.assertNotNull(spi);
+            Assertions.assertTrue(gndPins.contains(spi));
+        }
+    }
+
+    @Test
     public void testResolveNetNameFromSiteWireWithoutNetlist() {
         Design design = new Design(); // This constructor does not create a netlist
         design.setPartName(Device.KCU105);


### PR DESCRIPTION
Handle cases where:
* 5LUT is being used as a static source, necessitating the A6 input to be tied to VCC.
* RAMS32 is mapped onto a SLICEM LUT, also necessitating A6 to be tied to VCC
* SRL32CE was transformed into a SRL16E, requiring A6 to be tied to GND