### PR TITLE
DesignTools.createMissingSitePinInsts() to handle logical -> multiple phys pins

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2891,7 +2891,11 @@ public class DesignTools {
             }
             String belName = belPin.getBELName();
             if (LUTTools.isCellALUT(cell) &&
+                    // No cell placed in the 5LUT spot
+                    si.getCell(belName.replace('6', '5')) == null &&
+                    // No net originally present on input sitewire
                     netOnSiteWire != net &&
+                    // No net present on output sitewire
                     si.getNetFromSiteWire(belName.charAt(0) + "5LUT_O5") == null) {
                 // LUT input siteWire has no net attached, nor does the LUT output sitewire: no need for site pin
                 return;

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1820,37 +1820,14 @@ public class DesignTools {
             Cell c = design.getCell(p.getFullHierarchicalInstName());
             if (c == null || c.getBEL() == null) continue;
             String logicalPinName = p.getPortInst().getName();
-            String sitePinName = getRoutedSitePin(c, net, logicalPinName);
-            if (sitePinName == null) continue;
-            //TODO NOTE: The following if clause adds some unexpected pins to GND, e.g. SLICE.CIN
-            /*if (sitePinName == null) {
-                if (net.equals(design.getGndNet())) {
-                    sitePinName = c.getCorrespondingSitePinName(logicalPinName);
-                }
-                if (sitePinName == null) {
-                    continue;
-                }
-                if (c.getPhysicalPinMapping(logicalPinName) == null) {
-                    String physPinMapping = c.getDefaultPinMapping(logicalPinName);
-                    if (physPinMapping != null) {
-                        c.addPinMapping(physPinMapping, logicalPinName);
-                    }
-                }
-            }*/
-            SiteInst si = c.getSiteInst();
-            SitePinInst newPin = si.getSitePinInst(sitePinName);
-            if (newPin != null) continue;
-            newPin = net.createPin(sitePinName, c.getSiteInst());
-            if (newPin != null) newPins.add(newPin);
             Set<String> physPinMappings = c.getAllPhysicalPinMappings(logicalPinName);
             // BRAMs can have two (or more) physical pin mappings for a logical pin
-            String existing = c.getPhysicalPinMapping(logicalPinName);
-            if (physPinMappings != null && physPinMappings.size() > 1) {
+            if (physPinMappings != null) {
+                SiteInst si = c.getSiteInst();
                 for (String physPin : physPinMappings) {
-                    if (existing.equals(physPin)) continue;
-                    sitePinName = getRoutedSitePinFromPhysicalPin(c, net, physPin);
+                    String sitePinName = getRoutedSitePinFromPhysicalPin(c, net, physPin);
                     if (sitePinName == null) continue;
-                    newPin = si.getSitePinInst(sitePinName);
+                    SitePinInst newPin = si.getSitePinInst(sitePinName);
                     if (newPin != null) continue;
                     newPin = net.createPin(sitePinName, c.getSiteInst());
                     if (newPin != null) newPins.add(newPin);

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2878,10 +2878,8 @@ public class DesignTools {
         // SiteWire and SitePin Name are the same for LUT inputs
         String siteWireName = belPin.getSiteWireName();
         // VCC returned based on the site wire, site pins are not stored in dcp
-        Net net = si.getNetFromSiteWire(siteWireName);
-        if (net == null) {
-            net = si.getDesign().getVccNet();
-        }
+        Net netOnSiteWire = si.getNetFromSiteWire(siteWireName);
+        Net net = (netOnSiteWire != null) ? netOnSiteWire : si.getDesign().getVccNet();
         if (net.isStaticNet()) {
             // SRL16Es that have been transformed from SRLC32E require GND on their A6 pin
             if (cell.getType().equals("SRL16E") && siteWireName.endsWith("6")) {
@@ -2891,8 +2889,10 @@ public class DesignTools {
                 }
             }
             String belName = belPin.getBELName();
-            if (belPin.getBEL().isLUT() && si.getCell(belName.replace('6', '5')) == null) {
-                // Nothing is placed on the 5LUT BEL, no need for site pin
+            if (belPin.getBEL().isLUT() &&
+                    netOnSiteWire != net &&
+                    si.getNetFromSiteWire(belName.charAt(0) + "5LUT_O5") == null) {
+                // LUT input siteWire has no net attached, nor does the LUT output sitewire: no need for site pin
                 return;
             }
             SitePinInst pin = si.getSitePinInst(siteWireName);

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.xilinx.rapidwright.design.blocks.UtilizationType;
+import com.xilinx.rapidwright.design.tools.LUTTools;
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.BELClass;
 import com.xilinx.rapidwright.device.BELPin;
@@ -2889,7 +2890,7 @@ public class DesignTools {
                 }
             }
             String belName = belPin.getBELName();
-            if (belPin.getBEL().isLUT() &&
+            if (LUTTools.isCellALUT(cell) &&
                     netOnSiteWire != net &&
                     si.getNetFromSiteWire(belName.charAt(0) + "5LUT_O5") == null) {
                 // LUT input siteWire has no net attached, nor does the LUT output sitewire: no need for site pin

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -226,6 +226,40 @@ public class TestDesignTools {
     }
 
     @Test
+    public void testCreateA1A6ToStaticNets() {
+        String dcpPath = RapidWrightDCP.getString("bnn.dcp");
+        Design design = Design.readCheckpoint(dcpPath);
+        DesignTools.createA1A6ToStaticNets(design);
+
+        String[] pins = new String[]{
+                // 5LUT used as a static source
+                "SLICE_X79Y169/A6",
+                "SLICE_X73Y164/A6",
+                "SLICE_X82Y161/A6",
+                "SLICE_X79Y159/A6",
+                "SLICE_X76Y156/A6",
+                "SLICE_X73Y155/A6",
+                "SLICE_X83Y153/A6",
+                "SLICE_X77Y150/A6",
+                "SLICE_X79Y145/A6",
+                "SLICE_X78Y145/A6",
+
+                // Tied to VCC because RAMS32
+                "SLICE_X87Y203/H6",
+                "SLICE_X87Y202/H6"
+        };
+
+        Set<SitePinInst> vccPins = new HashSet<>(design.getVccNet().getPins());
+        for (String pin : pins) {
+            String[] split = pin.split("/");
+            SiteInst si = design.getSiteInstFromSiteName(split[0]);
+            SitePinInst spi = si.getSitePinInst(split[1]);
+            Assertions.assertNotNull(spi);
+            Assertions.assertTrue(vccPins.contains(spi));
+        }
+    }
+
+    @Test
     public void testBlackBoxCreation() {
         Design design = RapidWrightDCP.loadDCP("bnn.dcp");
         String hierCellName = "bd_0_i/hls_inst/inst/dmem_V_U";

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -226,40 +226,6 @@ public class TestDesignTools {
     }
 
     @Test
-    public void testCreateA1A6ToStaticNets() {
-        String dcpPath = RapidWrightDCP.getString("bnn.dcp");
-        Design design = Design.readCheckpoint(dcpPath);
-        DesignTools.createA1A6ToStaticNets(design);
-
-        String[] pins = new String[]{
-                // 5LUT used as a static source
-                "SLICE_X79Y169/A6",
-                "SLICE_X73Y164/A6",
-                "SLICE_X82Y161/A6",
-                "SLICE_X79Y159/A6",
-                "SLICE_X76Y156/A6",
-                "SLICE_X73Y155/A6",
-                "SLICE_X83Y153/A6",
-                "SLICE_X77Y150/A6",
-                "SLICE_X79Y145/A6",
-                "SLICE_X78Y145/A6",
-
-                // Tied to VCC because RAMS32
-                "SLICE_X87Y203/H6",
-                "SLICE_X87Y202/H6"
-        };
-
-        Set<SitePinInst> vccPins = new HashSet<>(design.getVccNet().getPins());
-        for (String pin : pins) {
-            String[] split = pin.split("/");
-            SiteInst si = design.getSiteInstFromSiteName(split[0]);
-            SitePinInst spi = si.getSitePinInst(split[1]);
-            Assertions.assertNotNull(spi);
-            Assertions.assertTrue(vccPins.contains(spi));
-        }
-    }
-
-    @Test
     public void testBlackBoxCreation() {
         Design design = RapidWrightDCP.loadDCP("bnn.dcp");
         String hierCellName = "bd_0_i/hls_inst/inst/dmem_V_U";
@@ -709,6 +675,40 @@ public class TestDesignTools {
             Assertions.assertEquals("[IN SLICE_X0Y0.A6]", design.getVccNet().getPins().toString());
         } else {
             Assertions.assertTrue(design.getVccNet().getPins().isEmpty());
+        }
+    }
+
+    @Test
+    public void testCreateA1A6ToStaticNetsVcc() {
+        String dcpPath = RapidWrightDCP.getString("bnn.dcp");
+        Design design = Design.readCheckpoint(dcpPath);
+        DesignTools.createA1A6ToStaticNets(design);
+
+        String[] pins = new String[]{
+                // 5LUT used as a static source
+                "SLICE_X79Y169/A6",
+                "SLICE_X73Y164/A6",
+                "SLICE_X82Y161/A6",
+                "SLICE_X79Y159/A6",
+                "SLICE_X76Y156/A6",
+                "SLICE_X73Y155/A6",
+                "SLICE_X83Y153/A6",
+                "SLICE_X77Y150/A6",
+                "SLICE_X79Y145/A6",
+                "SLICE_X78Y145/A6",
+
+                // Tied to VCC because RAMS32
+                "SLICE_X87Y203/H6",
+                "SLICE_X87Y202/H6"
+        };
+
+        Set<SitePinInst> vccPins = new HashSet<>(design.getVccNet().getPins());
+        for (String pin : pins) {
+            String[] split = pin.split("/");
+            SiteInst si = design.getSiteInstFromSiteName(split[0]);
+            SitePinInst spi = si.getSitePinInst(split[1]);
+            Assertions.assertNotNull(spi);
+            Assertions.assertTrue(vccPins.contains(spi));
         }
     }
 

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -713,6 +713,36 @@ public class TestDesignTools {
     }
 
     @Test
+    public void testCreateA1A6ToStaticNetsGnd() {
+        String dcpPath = RapidWrightDCP.getString("optical-flow.dcp");
+        Design design = Design.readCheckpoint(dcpPath);
+        DesignTools.createA1A6ToStaticNets(design);
+
+        String[] pins = new String[]{
+                // SRLC32E transformed to SRL16E
+                "SLICE_X68Y164/A6",
+                "SLICE_X68Y164/D6",
+                "SLICE_X68Y163/A6",
+                "SLICE_X68Y163/D6",
+                "SLICE_X68Y162/A6",
+                "SLICE_X68Y162/D6",
+                "SLICE_X68Y161/A6",
+                "SLICE_X68Y161/D6",
+                "SLICE_X68Y160/A6",
+                "SLICE_X68Y160/D6",
+        };
+
+        Set<SitePinInst> gndPins = new HashSet<>(design.getGndNet().getPins());
+        for (String pin : pins) {
+            String[] split = pin.split("/");
+            SiteInst si = design.getSiteInstFromSiteName(split[0]);
+            SitePinInst spi = si.getSitePinInst(split[1]);
+            Assertions.assertNotNull(spi);
+            Assertions.assertTrue(gndPins.contains(spi));
+        }
+    }
+
+    @Test
     public void testResolveNetNameFromSiteWireWithoutNetlist() {
         Design design = new Design(); // This constructor does not create a netlist
         design.setPartName(Device.KCU105);

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -226,6 +226,37 @@ public class TestDesignTools {
     }
 
     @Test
+    public void testCreateMissingSitePinInstsMultiPinMap() {
+        String dcpPath = RapidWrightDCP.getString("bnn.dcp");
+        Design design = Design.readCheckpoint(dcpPath);
+        DesignTools.createMissingSitePinInsts(design);
+
+        Net net = design.getNet("bd_0_i/hls_inst/inst/grp_bin_conv_fu_485/grp_process_word_fu_2716/grp_conv_word_fu_523/conv_out_buffer_V_address0[1]");
+        // Net connects to logical pins that map onto more than one physical pin
+        // (H2 and [^H]2); make sure those non H2 pins are present
+        String[] pins = new String[]{
+                "SLICE_X81Y218/A2",
+                "SLICE_X81Y218/B2",
+                "SLICE_X81Y218/C2",
+                "SLICE_X81Y218/D2",
+                "SLICE_X81Y218/E2",
+                "SLICE_X81Y218/F2",
+                "SLICE_X81Y218/G2",
+
+                "SLICE_X81Y218/H2"
+        };
+
+        Set<SitePinInst> netPins = new HashSet<>(net.getPins());
+        for (String pin : pins) {
+            String[] split = pin.split("/");
+            SiteInst si = design.getSiteInstFromSiteName(split[0]);
+            SitePinInst spi = si.getSitePinInst(split[1]);
+            Assertions.assertNotNull(spi);
+            Assertions.assertTrue(netPins.contains(spi));
+        }
+    }
+
+    @Test
     public void testBlackBoxCreation() {
         Design design = RapidWrightDCP.loadDCP("bnn.dcp");
         String hierCellName = "bd_0_i/hls_inst/inst/dmem_V_U";


### PR DESCRIPTION
As occurring for single-ported distributed RAM block, where the read and write addresses are identical. Thus, a pins on the logical "read/write address" is mapped onto both the `WAx` (write) and `Ax` (read) physical pins. Since the write address site pin is shared between all RAMs in the SLICEM, make sure that the read address site pin is also identified correctly.