### PR TITLE
Make loading gzipped EDIF decompress in memory by default, on to disk by option

### DIFF
--- a/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
+++ b/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.xilinx.rapidwright.util.Params;
 import com.xilinx.rapidwright.util.StringPool;
 import com.xilinx.rapidwright.util.function.InputStreamSupplier;
 
@@ -91,7 +92,8 @@ public abstract class AbstractEDIFParserWorker {
     }
 
     public AbstractEDIFParserWorker(Path fileName, StringPool uniquifier, EDIFReadLegalNameCache cache) throws FileNotFoundException {
-        in = InputStreamSupplier.getInputStream(fileName);
+        in = InputStreamSupplier.getInputStream(fileName,
+                fileName.toString().endsWith(".gz") && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK);
         tokenizer = new EDIFTokenizer(fileName, in, uniquifier);
         this.cache = cache;
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -38,6 +38,7 @@ import java.util.Map;
 
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.FileTools;
+import com.xilinx.rapidwright.util.Params;
 import com.xilinx.rapidwright.util.StringPool;
 
 /**
@@ -130,7 +131,8 @@ public class EDIFParser extends AbstractEDIFParserWorker implements AutoCloseabl
         }
 
         Path fileName = tokenizer.getFileName();
-        if (fileName != null && fileName.toString().endsWith(".gz")) {
+        if (fileName != null && fileName.toString().endsWith(".gz")
+                && Params.RW_DECOMPRESS_GZIPPED_EDIF) {
             try {
                 Files.delete(
                         FileTools.getDecompressedGZIPFileName(tokenizer.getFileName()));

--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -132,7 +132,7 @@ public class EDIFParser extends AbstractEDIFParserWorker implements AutoCloseabl
 
         Path fileName = tokenizer.getFileName();
         if (fileName != null && fileName.toString().endsWith(".gz")
-                && Params.RW_DECOMPRESS_GZIPPED_EDIF) {
+                && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK) {
             try {
                 Files.delete(
                         FileTools.getDecompressedGZIPFileName(tokenizer.getFileName()));

--- a/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
@@ -42,6 +42,7 @@ import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.FileTools;
 import com.xilinx.rapidwright.util.ParallelismTools;
+import com.xilinx.rapidwright.util.Params;
 import com.xilinx.rapidwright.util.StringPool;
 import com.xilinx.rapidwright.util.function.InputStreamSupplier;
 
@@ -117,7 +118,8 @@ public class ParallelEDIFParser implements AutoCloseable{
 
     public EDIFNetlist parseEDIFNetlist() throws IOException {
         EDIFNetlist netlist = parseEDIFNetlist(CodePerfTracker.SILENT);
-        if (fileName.toString().endsWith(".gz")) {
+        if (fileName != null && fileName.toString().endsWith(".gz")
+                && Params.RW_DECOMPRESS_GZIPPED_EDIF) {
             Files.delete(FileTools.getDecompressedGZIPFileName(fileName));
         }
         return netlist;

--- a/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
@@ -83,7 +83,8 @@ public class ParallelEDIFParser implements AutoCloseable{
     }
 
     public ParallelEDIFParser(Path p, long fileSize) {
-        this(p, fileSize, InputStreamSupplier.fromPath(p));
+        this(p, fileSize, InputStreamSupplier.fromPath(p,
+                p.toString().endsWith(".gz") && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK));
     }
 
     public ParallelEDIFParser(Path p) throws IOException {
@@ -119,7 +120,7 @@ public class ParallelEDIFParser implements AutoCloseable{
     public EDIFNetlist parseEDIFNetlist() throws IOException {
         EDIFNetlist netlist = parseEDIFNetlist(CodePerfTracker.SILENT);
         if (fileName != null && fileName.toString().endsWith(".gz")
-                && Params.RW_DECOMPRESS_GZIPPED_EDIF) {
+                && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK) {
             Files.delete(FileTools.getDecompressedGZIPFileName(fileName));
         }
         return netlist;

--- a/src/com/xilinx/rapidwright/util/Params.java
+++ b/src/com/xilinx/rapidwright/util/Params.java
@@ -1,0 +1,43 @@
+package com.xilinx.rapidwright.util;
+
+/**
+ * Aims to be a centralized helper class to manage global RapidWright settings.
+ */
+public class Params {
+
+    /**
+     * Flag to have RapidWright decompress gzipped EDIF files to disk prior to
+     * parsing. This is a tradeoff where pre-decompression improves runtime of the
+     * default method which is to decompress in memory. The disadvantage is that
+     * this will temporarily consume ~18x more disk space than original gzipped EDIF
+     * file, but loading of the EDIF file will be ~2x faster.
+     */
+    public static boolean RW_DECOMPRESS_GZIPPED_EDIF = isParamSet("RW_DECOMPRESS_GZIPPED_EDIF");
+    
+    /**
+     * Checks if the named RapidWright parameter is set
+     * 
+     * @param key Name of the global RapidWright parameter
+     * @return True if the parameter is set (as defined by {@link #isSet(String)}),
+     *         false otherwise
+     */
+    public static boolean isParamSet(String key) {
+        return isSet(System.getenv(key)) || isSet(System.getProperty(key));
+    }
+
+    /**
+     * Checks if a parameter is set by examining the provided value.
+     * 
+     * @param value An environment variable or JVM parameter value
+     * @return True if (1) value is not null, (2) is not an empty string, (3) is not
+     *         0 and (4) is not false (case-insensitive).
+     */
+    public static boolean isSet(String value) {
+        return !( value == null 
+               || value.length() == 0 
+               || value.equals("0") 
+               || value.toLowerCase().equals("false")
+               );         
+    }
+    
+}

--- a/src/com/xilinx/rapidwright/util/Params.java
+++ b/src/com/xilinx/rapidwright/util/Params.java
@@ -1,9 +1,34 @@
+/*
+ *
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD AECG Research Labs.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.xilinx.rapidwright.util;
 
 /**
  * Aims to be a centralized helper class to manage global RapidWright settings.
  */
 public class Params {
+
+    public static String RW_DECOMPRESS_GZIPPED_EDIF_NAME = "RW_DECOMPRESS_GZIPPED_EDIF";
 
     /**
      * Flag to have RapidWright decompress gzipped EDIF files to disk prior to
@@ -12,10 +37,11 @@ public class Params {
      * this will temporarily consume ~18x more disk space than original gzipped EDIF
      * file, but loading of the EDIF file will be ~2x faster.
      */
-    public static boolean RW_DECOMPRESS_GZIPPED_EDIF = isParamSet("RW_DECOMPRESS_GZIPPED_EDIF");
+    public static boolean RW_DECOMPRESS_GZIPPED_EDIF = isParamSet(RW_DECOMPRESS_GZIPPED_EDIF_NAME);
     
     /**
-     * Checks if the named RapidWright parameter is set
+     * Checks if the named RapidWright parameter is set via an environment variable
+     * or by a JVM parameter of the same name.
      * 
      * @param key Name of the global RapidWright parameter
      * @return True if the parameter is set (as defined by {@link #isSet(String)}),

--- a/src/com/xilinx/rapidwright/util/Params.java
+++ b/src/com/xilinx/rapidwright/util/Params.java
@@ -28,7 +28,7 @@ package com.xilinx.rapidwright.util;
  */
 public class Params {
 
-    public static String RW_DECOMPRESS_GZIPPED_EDIF_NAME = "RW_DECOMPRESS_GZIPPED_EDIF";
+    public static String RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK_NAME = "RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK";
 
     /**
      * Flag to have RapidWright decompress gzipped EDIF files to disk prior to
@@ -37,7 +37,7 @@ public class Params {
      * this will temporarily consume ~18x more disk space than original gzipped EDIF
      * file, but loading of the EDIF file will be ~2x faster.
      */
-    public static boolean RW_DECOMPRESS_GZIPPED_EDIF = isParamSet(RW_DECOMPRESS_GZIPPED_EDIF_NAME);
+    public static boolean RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK = isParamSet(RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK_NAME);
     
     /**
      * Checks if the named RapidWright parameter is set via an environment variable

--- a/src/com/xilinx/rapidwright/util/Params.java
+++ b/src/com/xilinx/rapidwright/util/Params.java
@@ -32,7 +32,7 @@ public class Params {
 
     /**
      * Flag to have RapidWright decompress gzipped EDIF files to disk prior to
-     * parsing. This is a tradeoff where pre-decompression improves runtime of the
+     * parsing. This is a tradeoff where pre-decompression improves runtime over the
      * default method which is to decompress in memory. The disadvantage is that
      * this will temporarily consume ~18x more disk space than original gzipped EDIF
      * file, but loading of the EDIF file will be ~2x faster.

--- a/src/com/xilinx/rapidwright/util/function/InputStreamSupplier.java
+++ b/src/com/xilinx/rapidwright/util/function/InputStreamSupplier.java
@@ -56,7 +56,7 @@ public interface InputStreamSupplier extends IOSupplier<InputStream> {
     public static InputStream getInputStream(Path fileName, boolean decompressToDisk) {
         InputStream in = null;
         try {
-            if (decompressToDisk) {
+            if (fileName.toString().endsWith(".gz") && decompressToDisk) {
                 Path decompressed = FileTools.getDecompressedGZIPFileName(fileName);
                 synchronized (InputStreamSupplier.class) {
                     if (!decompressed.toFile().exists()) {

--- a/src/com/xilinx/rapidwright/util/function/InputStreamSupplier.java
+++ b/src/com/xilinx/rapidwright/util/function/InputStreamSupplier.java
@@ -34,11 +34,10 @@ import java.util.zip.GZIPInputStream;
 import org.apache.commons.io.function.IOSupplier;
 
 import com.xilinx.rapidwright.util.FileTools;
-import com.xilinx.rapidwright.util.Params;
 
 public interface InputStreamSupplier extends IOSupplier<InputStream> {
-    static InputStreamSupplier fromPath(Path p) {
-        return () -> getInputStream(p);
+    static InputStreamSupplier fromPath(Path p, boolean decompressToDisk) {
+        return () -> getInputStream(p, decompressToDisk);
     }
 
     /**
@@ -46,13 +45,18 @@ public interface InputStreamSupplier extends IOSupplier<InputStream> {
      * extension), it will decompress the file alongside the original with the '.gz'
      * extension removed.
      * 
-     * @param fileName Path to the file or gzipped file from which to get an InputStream.
-     * @return An InputStream of the file, or of a decompressed copy of a gzipped file.
+     * @param fileName         Path to the file or gzipped file from which to get an
+     *                         InputStream.
+     * @param decompressToDisk To make certain operations faster, decompress the
+     *                         file to disk first rather than to decompress through
+     *                         the InputStream.
+     * @return An InputStream of the file, or of a decompressed copy of a gzipped
+     *         file.
      */
-    public static InputStream getInputStream(Path fileName) {
+    public static InputStream getInputStream(Path fileName, boolean decompressToDisk) {
         InputStream in = null;
         try {
-            if (fileName.toString().endsWith(".gz") && Params.RW_DECOMPRESS_GZIPPED_EDIF) {
+            if (decompressToDisk) {
                 Path decompressed = FileTools.getDecompressedGZIPFileName(fileName);
                 synchronized (InputStreamSupplier.class) {
                     if (!decompressed.toFile().exists()) {

--- a/test/src/com/xilinx/rapidwright/edif/ParallelEDIFParserTestSpecificOffsets.java
+++ b/test/src/com/xilinx/rapidwright/edif/ParallelEDIFParserTestSpecificOffsets.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import com.xilinx.rapidwright.util.Params;
 import com.xilinx.rapidwright.util.StringPool;
 import com.xilinx.rapidwright.util.function.InputStreamSupplier;
 
@@ -44,7 +45,11 @@ public class ParallelEDIFParserTestSpecificOffsets extends ParallelEDIFParser{
     }
 
     ParallelEDIFParserTestSpecificOffsets(Path fileName, int maxTokenLength, List<ParseStart> startOffsets) throws IOException {
-        this(fileName, Files.size(fileName), InputStreamSupplier.fromPath(fileName), maxTokenLength, startOffsets);
+        this(fileName, Files.size(fileName),
+                InputStreamSupplier.fromPath(fileName,
+                        fileName.toString().endsWith(".gz")
+                                && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK),
+                maxTokenLength, startOffsets);
     }
 
     @Override

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
@@ -130,7 +130,7 @@ public class TestEDIFParser {
     public void testGZIPEDIFParsing(boolean decompressToDisk, @TempDir Path tempDir)
             throws IOException {
         if (decompressToDisk) {
-            System.setProperty(Params.RW_DECOMPRESS_GZIPPED_EDIF_NAME, "1");
+            System.setProperty(Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK_NAME, "1");
         }
 
         Path src = tempDir.resolve(input.getFileName());
@@ -149,7 +149,7 @@ public class TestEDIFParser {
     public void testGZIPEDIFParsingParallel(boolean decompressToDisk, @TempDir Path tempDir)
             throws IOException {
         if (decompressToDisk) {
-            System.setProperty(Params.RW_DECOMPRESS_GZIPPED_EDIF_NAME, "1");
+            System.setProperty(Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK_NAME, "1");
         }
 
         Path src = tempDir.resolve(input.getFileName());

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.FileTools;
+import com.xilinx.rapidwright.util.Params;
 
 public class TestEDIFParser {
     private static final Path input = RapidWrightDCP.getPath("edif_parsing_stress_test.edf");
@@ -129,7 +130,7 @@ public class TestEDIFParser {
     public void testGZIPEDIFParsing(boolean decompressToDisk, @TempDir Path tempDir)
             throws IOException {
         if (decompressToDisk) {
-            System.setProperty("RW_DECOMPRESS_GZIPPED_EDIF", "1");
+            System.setProperty(Params.RW_DECOMPRESS_GZIPPED_EDIF_NAME, "1");
         }
 
         Path src = tempDir.resolve(input.getFileName());
@@ -148,7 +149,7 @@ public class TestEDIFParser {
     public void testGZIPEDIFParsingParallel(boolean decompressToDisk, @TempDir Path tempDir)
             throws IOException {
         if (decompressToDisk) {
-            System.setProperty("RW_DECOMPRESS_GZIPPED_EDIF", "1");
+            System.setProperty(Params.RW_DECOMPRESS_GZIPPED_EDIF_NAME, "1");
         }
 
         Path src = tempDir.resolve(input.getFileName());

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
@@ -123,8 +124,14 @@ public class TestEDIFParser {
 
     }
 
-    @Test
-    public void testGZIPEDIFParsing(@TempDir Path tempDir) throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void testGZIPEDIFParsing(boolean decompressToDisk, @TempDir Path tempDir)
+            throws IOException {
+        if (decompressToDisk) {
+            System.setProperty("RW_DECOMPRESS_GZIPPED_EDIF", "1");
+        }
+
         Path src = tempDir.resolve(input.getFileName());
         Files.copy(input, src);
         Path compressed = FileTools.compressFileUsingGZIP(src);
@@ -136,8 +143,14 @@ public class TestEDIFParser {
         Assertions.assertFalse(src.toFile().exists());
     }
 
-    @Test
-    public void testGZIPEDIFParsingParallel(@TempDir Path tempDir) throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void testGZIPEDIFParsingParallel(boolean decompressToDisk, @TempDir Path tempDir)
+            throws IOException {
+        if (decompressToDisk) {
+            System.setProperty("RW_DECOMPRESS_GZIPPED_EDIF", "1");
+        }
+
         Path src = tempDir.resolve(input.getFileName());
         Files.copy(input, src);
         Path compressed = FileTools.compressFileUsingGZIP(src);


### PR DESCRIPTION
There is a tradeoff when using gzipped EDIF files that, because RapidWright has a very fast parallel parser, decompressing onto disk first is much faster (~2x or more).  However, this temporarily uses ~18x more disk space in order to do so.  This change makes the default method to decompress (more slowly) in memory in order to prevent out of disk space errors.  If users would like the additional parsing speed with gzipped EDIF, they can set the parameter `RW_DECOMPRESS_GZIPPED_EDIF=1` (either via an Environment Variable or through the jvm command line `-Dname=value` parameter).  