### PR TITLE
DesignTools.getPortInstsFromSitePinInst() to cope with LUT RTs

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2140,13 +2140,17 @@ public class DesignTools {
      * @param sitePin The site pin to query.
      * @return A list of hierarchical port instances that connect to the site pin.
      */
-    public static ArrayList<EDIFHierPortInst> getPortInstsFromSitePinInst(SitePinInst sitePin) {
+    public static List<EDIFHierPortInst> getPortInstsFromSitePinInst(SitePinInst sitePin) {
         SiteInst siteInst = sitePin.getSiteInst();
         BELPin[] belPins = siteInst.getSiteWirePins(sitePin.getName());
-        ArrayList<EDIFHierPortInst> portInsts = new ArrayList<EDIFHierPortInst>();
-        for (BELPin belPin : belPins) {
+        List<EDIFHierPortInst> portInsts = new ArrayList<>();
+        Queue<BELPin> queue = new LinkedList<>();
+        queue.addAll(Arrays.asList(belPins));
+        while (!queue.isEmpty()) {
+            BELPin belPin = queue.remove();
             if (belPin.isOutput() == sitePin.isOutPin()) {
-                if (belPin.getBEL().getBELClass() == BELClass.RBEL) {
+                BEL bel = belPin.getBEL();
+                if (bel.getBELClass() == BELClass.RBEL) {
                     // Routing BEL, lets look ahead/behind it
                     SitePIP sitePIP = siteInst.getUsedSitePIP(belPin);
                     if (sitePIP != null) {
@@ -2158,8 +2162,15 @@ public class DesignTools {
                         }
                     }
                 } else {
-                    EDIFHierPortInst portInst = getPortInstFromBELPin(siteInst, belPin);
-                    if (portInst != null) portInsts.add(portInst);
+                    Cell lut = bel.isLUT() ? siteInst.getCell(bel) : null;
+                    if (lut != null && lut.isRoutethru() && lut.getLogicalPinMapping(belPin.getName()) != null) {
+                        BELPin opin = bel.getPin("O" + bel.getName().charAt(1));
+                        belPins = siteInst.getSiteWirePins(opin.getSiteWireName());
+                        queue.addAll(Arrays.asList(belPins));
+                    } else {
+                        EDIFHierPortInst portInst = getPortInstFromBELPin(siteInst, belPin);
+                        if (portInst != null) portInsts.add(portInst);
+                    }
                 }
             }
         }

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -23,6 +23,23 @@
 
 package com.xilinx.rapidwright.design;
 
+import com.xilinx.rapidwright.device.BELPin;
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.PIP;
+import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.tests.CodePerfTracker;
+import com.xilinx.rapidwright.util.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,24 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import com.xilinx.rapidwright.edif.EDIFPortInst;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
-
-import com.xilinx.rapidwright.device.BELPin;
-import com.xilinx.rapidwright.device.Device;
-import com.xilinx.rapidwright.device.PIP;
-import com.xilinx.rapidwright.device.Site;
-import com.xilinx.rapidwright.edif.EDIFHierCellInst;
-import com.xilinx.rapidwright.edif.EDIFNetlist;
-import com.xilinx.rapidwright.edif.EDIFTools;
-import com.xilinx.rapidwright.support.RapidWrightDCP;
-import com.xilinx.rapidwright.tests.CodePerfTracker;
-import com.xilinx.rapidwright.util.Pair;
 
 public class TestDesignTools {
 


### PR DESCRIPTION
Currently, if a LUT routethru services more than one cell (e.g. LUT output fans to two FFs) then only one `EDIFHierPortInst` will be returned.

Fix this here.