### PR TITLE
Test for Cell-s and Net-s with backslashes in name

### DIFF
--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -259,8 +259,19 @@ public class TestDesign {
             "cell_with_backslash_double_2022.1.dcp,true",
             "cell_with_backslash_double_2022.2.dcp,true",
     })
-    public void testCellWithBackslash(String dcp, boolean doubleBackslash) {
+    public void testCellWithBackslash(String dcp, boolean doubleBackslash, @TempDir Path tempDir) {
         Design design = RapidWrightDCP.loadDCP(dcp);
+        testCellWithBackslashHelper(design, doubleBackslash);
+
+        if (dcp.endsWith("_2021.2.dcp") || dcp.endsWith("_2022.1.dcp")) {
+            final Path rapidWrightDcp = tempDir.resolve("rapidwright.dcp");
+            design.writeCheckpoint(rapidWrightDcp);
+            design = Design.readCheckpoint(rapidWrightDcp);
+            testCellWithBackslashHelper(design, doubleBackslash);
+        }
+    }
+
+    private static void testCellWithBackslashHelper(Design design, boolean doubleBackslash) {
         String cellName;
         if (doubleBackslash) {
             cellName = "this.is.an\\\\.escaped\\.identifier";

--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -247,4 +247,15 @@ public class TestDesign {
         Design d2 = new Design("test2", d.getPartName());
         Assertions.assertNotNull(d2.copyCell(orig, "copy"));
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "cell_with_backslash_2022.2.dcp",
+            "cell_with_backslash_2022.1.dcp",
+    })
+    public void testCellWithBackslash(String dcp) {
+        Design design = RapidWrightDCP.loadDCP(dcp);
+        Cell c = design.getCell("this.is.an\\.escaped\\.identifier");
+        Assertions.assertNotNull(c);
+        Assertions.assertNotNull(c.getEDIFHierCellInst());
+    }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -251,6 +251,22 @@ public class TestDesign {
         Assertions.assertNotNull(d2.copyCell(orig, "copy"));
     }
 
+    /**
+     * Input description: (synthesized out of context)
+     * module top(input a, b,
+     *            input \this.is.an\.escaped\.net\.identifier ,
+     *            output o);
+     *
+     * wire \this.is.another\\.escaped\$net\+&!identifier ;
+     *
+     * (* DONT_TOUCH="true" *)
+     * LUT2 \this.is.an\.escaped\.cell\.identifier (.O(\this.is.another\\.escaped\$net\+&!identifier ), .I0(\this.is.an\.escaped\.net\.identifier ), .I1(a));
+     *
+     * (* DONT_TOUCH="true" *)
+     * LUT2 \this.is.another\\.escaped\$cell\+&!identifier (.O(o), .I0(\this.is.another\\.escaped\$net\+&!identifier ), .I1(b));
+     *
+     * endmodule
+     */
     @ParameterizedTest
     @CsvSource({
             "design_with_backslash_2022.2.dcp",

--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -304,7 +304,7 @@ public class TestDesign {
             Assertions.assertNotNull(n);
             Assertions.assertEquals(ehn.getHierarchicalNetName(), n.getName());
         }
-        // 2 + {a, b, o, GLOBAL_USEDNET, GLOBAL_LOGIC0}
-        Assertions.assertEquals(design.getNets().size(), 2 + 5);
+        final int extraNets = 5; // {a, b, o, GLOBAL_USEDNET, GLOBAL_LOGIC0}
+        Assertions.assertEquals(design.getNets().size(), 2 + extraNets);
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -271,21 +271,24 @@ public class TestDesign {
 
     private static void testDesignWithBackslashHelper(Design design) {
         for (String cellName : Arrays.asList("this.is.an\\.escaped\\.cell\\.identifier",
-                "this.is.another\\\\.escaped\\.cell\\.identifier")) {
+                "this.is.another\\\\.escaped\\$cell\\+&!identifier")) {
             EDIFHierCellInst ehci = design.getNetlist().getHierCellInstFromName(cellName);
             Assertions.assertNotNull(ehci);
             Cell c = design.getCell(cellName);
             Assertions.assertNotNull(c);
             Assertions.assertEquals(ehci.getFullHierarchicalInstName(), c.getName());
         }
+        Assertions.assertEquals(design.getCells().size(), 2);
 
         for (String netName : Arrays.asList("this.is.an\\.escaped\\.net\\.identifier",
-                "this.is.another\\\\.escaped\\.net\\.identifier")) {
+                "this.is.another\\\\.escaped\\$net\\+&!identifier")) {
             EDIFHierNet ehn = design.getNetlist().getHierNetFromName(netName);
             Assertions.assertNotNull(ehn);
             Net n = design.getNet(netName);
             Assertions.assertNotNull(n);
             Assertions.assertEquals(ehn.getHierarchicalNetName(), n.getName());
         }
+        // 2 + {a, b, o, GLOBAL_USEDNET, GLOBAL_LOGIC0}
+        Assertions.assertEquals(design.getNets().size(), 2 + 5);
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -254,8 +255,11 @@ public class TestDesign {
     })
     public void testCellWithBackslash(String dcp) {
         Design design = RapidWrightDCP.loadDCP(dcp);
-        Cell c = design.getCell("this.is.an\\.escaped\\.identifier");
+        String cellName = "this.is.an\\.escaped\\.identifier";
+        EDIFHierCellInst ehci = design.getNetlist().getHierCellInstFromName(cellName);
+        Assertions.assertNotNull(ehci);
+        Cell c = design.getCell(cellName);
         Assertions.assertNotNull(c);
-        Assertions.assertNotNull(c.getEDIFHierCellInst());
+        Assertions.assertEquals(ehci.getFullHierarchicalInstName(), c.getName());
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.xilinx.rapidwright.device.BEL;
@@ -250,12 +251,22 @@ public class TestDesign {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "cell_with_backslash_2022.2.dcp",
-            "cell_with_backslash_2022.1.dcp",
+    @CsvSource({
+            "cell_with_backslash_2022.2.dcp,false",
+            "cell_with_backslash_2022.1.dcp,false",
+            "cell_with_backslash_2021.2.dcp,false",
+            "cell_with_backslash_double_2021.2.dcp,true",
+            "cell_with_backslash_double_2022.1.dcp,true",
+            "cell_with_backslash_double_2022.2.dcp,true",
     })
-    public void testCellWithBackslash(String dcp) {
+    public void testCellWithBackslash(String dcp, boolean doubleBackslash) {
         Design design = RapidWrightDCP.loadDCP(dcp);
-        String cellName = "this.is.an\\.escaped\\.identifier";
+        String cellName;
+        if (doubleBackslash) {
+            cellName = "this.is.an\\\\.escaped\\.identifier";
+        } else {
+            cellName = "this.is.an\\.escaped\\.identifier";
+        }
         EDIFHierCellInst ehci = design.getNetlist().getHierCellInstFromName(cellName);
         Assertions.assertNotNull(ehci);
         Cell c = design.getCell(cellName);


### PR DESCRIPTION
Works for 2022.2, fails on 2022.1 (expects `"this.is.an\\\\.escaped\\\\.identifier"` instead).

This was the input description:
```
module top(input a, b,
           input \this.is.an\.escaped\.net\.identifier ,
           output o);

wire \this.is.another\\.escaped\$net\+&!identifier ;

(* DONT_TOUCH="true" *)
LUT2 \this.is.an\.escaped\.cell\.identifier (.O(\this.is.another\\.escaped\$net\+&!identifier ), .I0(\this.is.an\.escaped\.net\.identifier ), .I1(a));

(* DONT_TOUCH="true" *)
LUT2 \this.is.another\\.escaped\$cell\+&!identifier (.O(o), .I0(\this.is.another\\.escaped\$net\+&!identifier ), .I1(b));

endmodule
```