### PR TITLE
EDIF Improvements

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierNet.java
@@ -26,13 +26,14 @@
  */
 package com.xilinx.rapidwright.edif;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collection;
+import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -157,6 +158,33 @@ public class EDIFHierNet {
     }
 
     /**
+     * Gets the sorted ArrayList of EDIFHierPortInsts on this net as a collection.
+     * @return The collection of EDIFPortInsts on this net.
+     */
+    public Collection<EDIFHierPortInst> getPortInsts() {
+        Collection<EDIFPortInst> portInsts = net.getPortInsts();
+        Collection<EDIFHierPortInst> hierPortInsts = new ArrayList<>(portInsts.size());
+        for (EDIFPortInst portInst : portInsts) {
+            hierPortInsts.add(new EDIFHierPortInst(hierarchicalInst, portInst));
+        }
+        return hierPortInsts;
+    }
+
+    /**
+     * This returns all sources on the net, either output ports of the
+     * cell instances in the cell or the top level input ports.
+     * @return A list of EDIFHierPortInst sources.
+     */
+    public List<EDIFHierPortInst> getSourcePortInsts(boolean includeTopLevelPorts) {
+        List<EDIFPortInst> portInsts = net.getSourcePortInsts(includeTopLevelPorts);
+        List<EDIFHierPortInst> hierPortInsts = new ArrayList<>(portInsts.size());
+        for (EDIFPortInst portInst : portInsts) {
+            hierPortInsts.add(new EDIFHierPortInst(hierarchicalInst, portInst));
+        }
+        return hierPortInsts;
+    }
+
+    /**
      * Gets all connected leaf port instances on this hierarchical net and its aliases.
      * @return The list of all leaf cell port instances connected to this hierarchical net and its
      * aliases.
@@ -173,10 +201,22 @@ public class EDIFHierNet {
      * aliases.
      */
     public List<EDIFHierPortInst> getLeafHierPortInsts(boolean includeSourcePins) {
+        return getLeafHierPortInsts(includeSourcePins, new HashSet<>());
+    }
+
+    /**
+     * Gets all connected leaf port instances on this hierarchical net and its aliases.
+     * @param includeSourcePins A flag to include source pins in the result.  Setting this to false
+     * only returns the sinks.
+     * @param visited An initial set of EDIFHierNet-s that have already been visited and will not
+     * be visited again. Pre-populating this set can be useful for blocking traversal.
+     * @return The list of all leaf cell port instances connected to this hierarchical net and its
+     * aliases.
+     */
+    public List<EDIFHierPortInst> getLeafHierPortInsts(boolean includeSourcePins, Set<EDIFHierNet> visited) {
         List<EDIFHierPortInst> leafCellPins = new ArrayList<>();
         Queue<EDIFHierNet> queue = new ArrayDeque<>();
         queue.add(this);
-        HashSet<EDIFHierNet> visited = new HashSet<>();
 
         EDIFHierNet parentNet = null;
         while (!queue.isEmpty()) {

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -93,17 +93,19 @@ public class EDIFNet extends EDIFPropertyObject {
             parentCell.addInternalPortMapEntry(portInst.getName(), this);
         }
         portInst.setParentNet(this);
-        if (portInsts.add(portInst)) {
-            // Only consider tracking if it was successfully added
-            if (isParentCellNonNull) {
-                // This does not explicitly track the port instance index, in most cases the name should be sufficient.
-                trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
-            }
-        }
+        boolean portInstAdded;
         if (deferSort) {
+            // portInst will have been added (even with deferred sorting) if it doesn't already exist
+            portInstAdded = isParentCellNonNull && (portInsts.get(portInst.getCellInst(), portInst.getName()) == null);
             portInsts.deferSortAdd(portInst);
         } else {
-            portInsts.add(portInst);
+            portInstAdded = portInsts.add(portInst) && isParentCellNonNull;
+        }
+
+        // Only consider tracking if it was successfully added
+        if (portInstAdded) {
+            // This does not explicitly track the port instance index, in most cases the name should be sufficient.
+            trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
         }
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -93,9 +93,12 @@ public class EDIFNet extends EDIFPropertyObject {
             parentCell.addInternalPortMapEntry(portInst.getName(), this);
         }
         portInst.setParentNet(this);
-        if (isParentCellNonNull) {
-            // This does not explicitly track the port instance index, in most cases the name should be sufficient.
-            trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
+        if (portInsts.add(portInst)) {
+            // Only consider tracking if it was successfully added
+            if (isParentCellNonNull) {
+                // This does not explicitly track the port instance index, in most cases the name should be sufficient.
+                trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
+            }
         }
         if (deferSort) {
             portInsts.deferSortAdd(portInst);

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -93,19 +93,15 @@ public class EDIFNet extends EDIFPropertyObject {
             parentCell.addInternalPortMapEntry(portInst.getName(), this);
         }
         portInst.setParentNet(this);
-        boolean portInstAdded;
-        if (deferSort) {
-            // portInst will have been added (even with deferred sorting) if it doesn't already exist
-            portInstAdded = isParentCellNonNull && (portInsts.get(portInst.getCellInst(), portInst.getName()) == null);
-            portInsts.deferSortAdd(portInst);
-        } else {
-            portInstAdded = portInsts.add(portInst) && isParentCellNonNull;
-        }
-
-        // Only consider tracking if it was successfully added
-        if (portInstAdded) {
+        if (isParentCellNonNull) {
             // This does not explicitly track the port instance index, in most cases the name should be sufficient.
             trackChanges(EDIFChangeType.PORT_INST_ADD, inst, portInst.getName());
+        }
+        if (deferSort) {
+            portInsts.deferSortAdd(portInst);
+        } else {
+            boolean added = portInsts.add(portInst);
+            assert(added);
         }
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1199,7 +1199,7 @@ public class EDIFNetlist extends EDIFName {
                     // Moving up in hierarchy
                     if (!p.getHierarchicalInst().isTopLevelInst()) {
                         final EDIFHierPortInst upPort = p.getPortInParent();
-                        if (upPort != null) {
+                        if (upPort != null && upPort.getNet() != null) {
                             queue.add(upPort.getHierarchicalNet());
                         }
                     }
@@ -1331,7 +1331,7 @@ public class EDIFNetlist extends EDIFName {
                 // Checks if cell is primitive or black box
                 if (eci.getCellType().getCellInsts().size() == 0 && eci.getCellType().getNets().size() == 0) {
                     for (EDIFPortInst portInst : eci.getPortInsts()) {
-                        if (portInst.isOutput()) {
+                        if (portInst.isOutput() && portInst.getNet() != null) {
                             queue.add(new EDIFHierPortInst(currInst, portInst));
                         }
                     }
@@ -1342,6 +1342,7 @@ public class EDIFNetlist extends EDIFName {
         }
 
         for (EDIFHierPortInst pr : queue) {
+            assert(pr.getNet() != null);
             EDIFHierNet parentNetName = pr.getHierarchicalNet();
             for (EDIFHierNet alias : getNetAliases(parentNetName)) {
                 parentNetMap.put(alias, parentNetName);

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -154,7 +154,7 @@ public class EDIFTools {
     public static final boolean RW_ENABLE_EDIF_BINARY_CACHING =
             System.getenv("RW_ENABLE_EDIF_BINARY_CACHING") != null;
 
-    private static String getUniqueSuffix() {
+    public static String getUniqueSuffix() {
         return "_rw_created" + UNIQUE_COUNT++;
     }
 
@@ -467,11 +467,38 @@ public class EDIFTools {
         return Math.abs(left - right) + 1;
     }
 
-    private static EDIFNet createUniqueNet(EDIFCell parentCell, String netName) {
+    /**
+     * Create a unique net in the provided parent EDIFCell with the preferred provided
+     * name. If such a net already exists in this cell, append a unique suffix.
+     * @param parentCell EDIFCell in which new net is to be created.
+     * @param netName Preferred net name.
+     * @return Newly created EDIFNet.
+     */
+    public static EDIFNet createUniqueNet(EDIFCell parentCell, String netName) {
         if (parentCell.getNet(netName) != null) {
             netName += getUniqueSuffix();
         }
         return new EDIFNet(netName, parentCell);
+    }
+
+    /**
+     * Create a unique port in the provided parent EDIFCell with the preferred provided
+     * name. If such a port already exists in this cell, append a unique suffix.
+     * This method checks for the existence of the given name as well as for its root bus,
+     * e.g. for portName 'foo[9]', both this exact name and 'foo' will be checked.
+     * @param parentCell EDIFCell in which new port is to be created.
+     * @param portName Preferred port name.
+     * @param dir EDIFDirection.
+     * @param width Bit width.
+     * @return Newly created EDIFPort.
+     */
+    public static EDIFPort createUniquePort(EDIFCell parentCell, String portName, EDIFDirection dir, int width) {
+        String rootBusName = getRootBusName(portName);
+        if (parentCell.getPort(rootBusName) != null ||
+                (rootBusName != portName && parentCell.getPort(portName) != null)) {
+            portName += getUniqueSuffix();
+        }
+        return parentCell.createPort(portName, dir, width);
     }
 
     /**
@@ -522,11 +549,7 @@ public class EDIFTools {
                 } else {
                     // no port to the parent cell above exists, create one
                     EDIFCell cellType = hierParentInst.getCellType();
-                    String newPortName = newName;
-                    if (cellType.getPort(newPortName) != null) {
-                        newPortName += getUniqueSuffix();
-                    }
-                    EDIFPort port = cellType.createPort(newPortName,
+                    EDIFPort port = createUniquePort(cellType, newName,
                             hierPortInst == src ? EDIFDirection.OUTPUT : EDIFDirection.INPUT, 1);
 
                     currNet.createPortInst(port);
@@ -536,7 +559,7 @@ public class EDIFTools {
                         // We don't need to create another net, just connect to the src's net
                         currNet = finalSrc.getNet();
                     } else {
-                        currNet = createUniqueNet(hierParentInst.getCellType(), newName);
+                        currNet = createUniqueNet(hierParentInst.getCellType(), port.getName());
                     }
                     outerPortInst = currNet.createPortInst(port, prevInst);
                 }
@@ -565,6 +588,69 @@ public class EDIFTools {
         }
         // Make final connection in the common ancestor instance
         finalSrc.getNet().addPortInst(finalSnk.getPortInst());
+    }
+
+    /**
+     * Connects an existing logical net and logical port inst together by creating new ports and
+     * nets on all cells instantiated between their levels of hierarchy.  This is a helper method
+     * on top of {@link #connectPortInstsThruHier(EDIFHierPortInst,EDIFHierPortInst,String)}
+     * for identifying the correct source and sink pins to be provided to this, according to
+     * whether the provided pin argument is an input or output pin (and finding the appropriate
+     * pin from the provided net).
+     * @param net The logical net
+     * @param pin The logical port inst source or sink
+     * @param newName A unique name to be used in creating the ports and nets
+     */
+    public static void connectPortInstsThruHier(EDIFHierNet net, EDIFHierPortInst pin,
+                                                String newName) {
+        EDIFHierPortInst src;
+        EDIFHierPortInst snk;
+
+        EDIFHierCellInst netInst = net.getHierarchicalInst();
+        EDIFCell cellType = netInst.getCellType();
+
+        // FIXME: This method always punches a new port upwards
+        //  -- what if the src/snk was in a lower part of the hierarchy?
+
+        if (pin.isOutput()) {
+            src = pin;
+
+            // Find an input portInst to use
+            snk = null;
+            for (EDIFHierPortInst pi : net.getPortInsts()) {
+                if (pi.isInput()) {
+                    snk = pi;
+                    break;
+                }
+            }
+            if (snk == null) {
+                // Create one if one doesn't exist
+                EDIFPort port = createUniquePort(cellType, newName, EDIFDirection.INPUT, 1);
+                net.getNet().createPortInst(port);
+
+                // EDIFTools.connectPortInstsThruHier() does not support top-level portInsts;
+                // need to create a port inst in the parent cell too
+                EDIFNet upperNet = createUniqueNet(netInst.getParent().getCellType(), port.getName());
+                snk = new EDIFHierPortInst(netInst.getParent(), upperNet.createPortInst(port, netInst.getInst()));
+            }
+        } else {
+            List<EDIFHierPortInst> sources = net.getSourcePortInsts(false);
+            if (!sources.isEmpty()) {
+                src = sources.get(0);
+            } else {
+                EDIFPort port = createUniquePort(cellType, newName, EDIFDirection.OUTPUT, 1);
+                net.getNet().createPortInst(port);
+
+                // EDIFTools.connectPortInstsThruHier() does not support top-level portInsts;
+                // need to create a port inst in the parent cell too
+                EDIFNet upperNet = createUniqueNet(netInst.getParent().getCellType(), port.getName());
+                src = new EDIFHierPortInst(netInst.getParent(), upperNet.createPortInst(port, netInst.getInst()));
+            }
+
+            snk = pin;
+        }
+
+        connectPortInstsThruHier(src, snk, newName);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
@@ -143,7 +144,7 @@ public class EDIFTools {
 
     public static final String LOAD_TCL_SUFFIX = "_load.tcl";
 
-    public static int UNIQUE_COUNT = 0;
+    public static final AtomicInteger UNIQUE_COUNT = new AtomicInteger();
 
     /**
      * Flag to set a feature where any .edf file that is attempted to be loaded will check if an
@@ -155,7 +156,7 @@ public class EDIFTools {
             System.getenv("RW_ENABLE_EDIF_BINARY_CACHING") != null;
 
     public static String getUniqueSuffix() {
-        return "_rw_created" + UNIQUE_COUNT++;
+        return "_rw_created" + UNIQUE_COUNT.getAndIncrement();
     }
 
     /**

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFTools.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFTools.java
@@ -24,21 +24,19 @@
 
 package com.xilinx.rapidwright.edif;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
-import java.nio.charset.StandardCharsets;
-import java.util.regex.Pattern;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 public class TestEDIFTools {
 
@@ -50,8 +48,9 @@ public class TestEDIFTools {
     public static final String TEST_SNK = "u_ila_0/inst/PROBE_PIPE."
             + "shift_probes_reg[0][7]/D";
 
-    @Test
-    public void testConnectPortInstsThruHier() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testConnectPortInstsThruHier(boolean netToPin) {
         Design d = Design.readCheckpoint(RapidWrightDCP.getPath("microblazeAndILA_3pblocks.dcp"), true);
         EDIFNetlist netlist = d.getNetlist();
 
@@ -61,7 +60,11 @@ public class TestEDIFTools {
         // Disconnect sink in anticipation of connecting to another net
         snkPortInst.getNet().removePortInst(snkPortInst.getPortInst());
 
-        EDIFTools.connectPortInstsThruHier(srcPortInst, snkPortInst, UNIQUE_SUFFIX);
+        if (netToPin) {
+            EDIFTools.connectPortInstsThruHier(srcPortInst.getHierarchicalNet(), snkPortInst, UNIQUE_SUFFIX);
+        } else {
+            EDIFTools.connectPortInstsThruHier(srcPortInst, snkPortInst, UNIQUE_SUFFIX);
+        }
 
         netlist.resetParentNetMap();
 


### PR DESCRIPTION
* Add `EDIFHierNet.getPortInsts()` -- helper for returning `EDIFHierPortInst`-s built from the result of `EDIFNet.getPortInsts()`
* Add `EDIFHierNet.getSourcePortInsts()` -- helper for returning `EDIFHierPortInst`-s built from the result of `EDIFNet.getSourcePortInsts()`
* Add `EDIFTools.createUniquePort()`
* Add `EDIFTools.connectPortInstsThruHier(EDIFHierNet, EDIFHierPortInst, String)` overload
* Miscellaneous null checks