### PR TITLE
Handle EDIF export bussed port name collision with identically named bit ports

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -260,7 +260,12 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
         os.write(EXPORT_CONST_INDENT);
         os.write(EXPORT_CONST_PORT_BEGIN);
         if (width > 1) os.write(EXPORT_CONST_ARRAY_BEGIN);
-        exportEDIFName(os, cache);
+        if (isBus()) {
+            exportEDIFBusName(os, cache);
+        } else {
+            exportEDIFName(os, cache);
+        }
+
         if (width > 1) {
             os.write(' ');
             os.write(Integer.toString(width).getBytes(StandardCharsets.UTF_8));
@@ -276,6 +281,17 @@ public class EDIFPort extends EDIFPropertyObject implements EDIFEnumerable {
         }
         os.write(')');
         os.write('\n');
+    }
+
+    /**
+     * Writes out valid EDIF syntax the name and/or rename of this port to the
+     * provided output writer.
+     * 
+     * @param os The stream to export the EDIF syntax to.
+     * @throws IOException
+     */
+    public void exportEDIFBusName(OutputStream os, EDIFWriteLegalNameCache<?> cache) throws IOException {
+        exportSomeEDIFName(os, getName(), cache.getEDIFRename(busName));
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -278,7 +278,7 @@ public class EDIFPortInst implements Comparable<EDIFPortInst> {
         }
         else {
             os.write(EXPORT_CONST_MEMBER);
-            os.write(cache.getLegalEDIFName(getPort().getName()));
+            os.write(cache.getLegalEDIFName(getPort().getBusName(true)));
             os.write(' ');
             os.write(Integer.toString(index).getBytes(StandardCharsets.UTF_8));
             os.write(')');

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -310,7 +310,7 @@ class TestEDIFNetlist {
         net1.createPortInst(port1, 1);
         net1.createPortInst("R", ff);
 
-        Path tempFile = Path.of("test.edf");// path.resolve("test.edf");
+        Path tempFile = path.resolve("test.edf");
         origNetlist.exportEDIF(tempFile);
 
         EDIFNetlist testNetlist = EDIFTools.readEdifFile(tempFile);


### PR DESCRIPTION
This fixes an issue when RapidWright writes out an EDIF netlist that contains a cell with two ports, one bussed and the other a single bit that have the same root name, for example:
```
my_port
my_port[1:0]
```
This is a legal set of ports, but when the EDIF is exported from RapidWright, the EDIF rename collides on port instance references.  This PR resolves the issue by explicitly using the `busName` of the `EDIFPort` for any bussed ports which contains a trailing `[` character that then gets translated to an `_` when it is legalized for EDIF.  This differentiates it from its single bit counterpart.