### PR TITLE
[RWRoute] Static net router + RouteNode enhancements

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.function.Function;
 
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
@@ -279,15 +279,21 @@ public class GlobalSignalRouting {
         return device.getClockRegion(center.y, center.x);
     }
 
+    public enum NodeStatus {
+        AVAILABLE,
+        UNAVAILABLE,
+        INUSE
+    }
+
     /**
      * Routes a static net (GND or VCC).
      * @param currNet The current static net to be routed.
-     * @param isNodeUnavailable A Predicate lambda to check if node is unavailable for use.
+     * @param getNodeState Lambda to get a node's status (available, unavailable, already in-use).
      * @param design The {@link Design} instance to use.
      * @param routeThruHelper The {@link RouteThruHelper} instance to use.
      */
     public static void routeStaticNet(Net currNet,
-                                      Predicate<Node> isNodeUnavailable,
+                                      Function<Node,NodeStatus> getNodeState,
                                       Design design, RouteThruHelper routeThruHelper) {
         NetType netType = currNet.getType();
         Set<PIP> netPIPs = new HashSet<>();
@@ -349,7 +355,7 @@ public class GlobalSignalRouting {
                 for (Node uphillNode : routingNode.getNode().getAllUphillNodes()) {
                     if (routeThruHelper.isRouteThru(uphillNode, routingNode.getNode())) continue;
                     LightweightRouteNode nParent = RouterHelper.createRoutingNode(uphillNode, createdRoutingNodes);
-                    if (!pruneNode(nParent, isNodeUnavailable, visitedRoutingNodes)) {
+                    if (!pruneNode(nParent, getNodeState, visitedRoutingNodes, usedRoutingNodes)) {
                         nParent.setPrev(routingNode);
                         q.add(nParent);
                     }
@@ -377,8 +383,9 @@ public class GlobalSignalRouting {
      * @return true, if the RoutingNode instance should not be considered as an available resource.
      */
     private static boolean pruneNode(LightweightRouteNode routingNode,
-                                     Predicate<Node> isNodeUnavailable,
-                                     Set<LightweightRouteNode> visitedRoutingNodes) {
+                                     Function<Node,NodeStatus> isNodeUnavailable,
+                                     Set<LightweightRouteNode> visitedRoutingNodes,
+                                     Set<LightweightRouteNode> usedRoutingNodes) {
         Node node = routingNode.getNode();
         IntentCode ic = node.getTile().getWireIntentCode(node.getWire());
         switch(ic) {
@@ -393,7 +400,15 @@ public class GlobalSignalRouting {
                 return true;
             default:
         }
-        if (isNodeUnavailable.test(node)) return true;
+        NodeStatus status = isNodeUnavailable.apply(node);
+        if (status == NodeStatus.UNAVAILABLE) {
+            return true;
+        }
+        if (status == NodeStatus.INUSE) {
+            assert(!visitedRoutingNodes.contains(routingNode));
+            usedRoutingNodes.add(routingNode);
+            return false;
+        }
         return visitedRoutingNodes.contains(routingNode);
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -279,12 +279,6 @@ public class GlobalSignalRouting {
         return device.getClockRegion(center.y, center.x);
     }
 
-    public enum NodeStatus {
-        AVAILABLE,
-        UNAVAILABLE,
-        INUSE
-    }
-
     /**
      * Routes a static net (GND or VCC).
      * @param currNet The current static net to be routed.

--- a/src/com/xilinx/rapidwright/rwroute/NodeStatus.java
+++ b/src/com/xilinx/rapidwright/rwroute/NodeStatus.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Eddie Hung, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.rwroute;
+
+/**
+ * Enumeration designating the routing status of a Node.
+ */
+public enum NodeStatus {
+    AVAILABLE,
+    UNAVAILABLE,
+    INUSE
+}

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -420,13 +420,13 @@ public class RWRoute{
                         if (preservedNet != null) {
                             // If one is present, it is unavailable only if it isn't carrying
                             // the net undergoing routing
-                            return preservedNet == net ? GlobalSignalRouting.NodeStatus.INUSE
-                                    : GlobalSignalRouting.NodeStatus.UNAVAILABLE;
+                            return preservedNet == net ? NodeStatus.INUSE
+                                    : NodeStatus.UNAVAILABLE;
                         }
                         // A RouteNode will only be created if the net is necessary for
                         // a to-be-routed connection
-                        return routingGraph.getNode(node) == null ? GlobalSignalRouting.NodeStatus.AVAILABLE
-                                : GlobalSignalRouting.NodeStatus.UNAVAILABLE;
+                        return routingGraph.getNode(node) == null ? NodeStatus.AVAILABLE
+                                : NodeStatus.UNAVAILABLE;
                     },
                     design, routethruHelper);
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -371,7 +371,7 @@ public class RWRoute{
      * @param staticNet The static net in question, i.e. VCC or GND.
      */
     protected void addStaticNetRoutingTargets(Net staticNet) {
-        preserveNet(staticNet, false);
+        assert(!staticNet.hasPIPs());
 
         List<SitePinInst> sinks = staticNet.getSinkPins();
         if (sinks.size() > 0) {
@@ -394,7 +394,7 @@ public class RWRoute{
 
         for (List<SitePinInst> netRouteTargetPins : staticNetAndRoutingTargets.values()) {
             for (SitePinInst sink : netRouteTargetPins) {
-                routingGraph.unpreserve(sink.getConnectedNode());
+                assert(!routingGraph.isPreserved(sink.getConnectedNode()));
             }
         }
 
@@ -413,17 +413,20 @@ public class RWRoute{
             List<SitePinInst> pins = e.getValue();
             System.out.println("INFO: Route " + pins.size() + " pins of " + net);
             GlobalSignalRouting.routeStaticNet(net,
-                    // Predicate to determine whether a node is unavailable for global routing
+                    // Lambda to determine whether a node is (a) available for use,
+                    // (b) already in used for this static net, (c) unavailable
                     (node) -> {
                         Net preservedNet = routingGraph.getPreservedNet(node);
                         if (preservedNet != null) {
                             // If one is present, it is unavailable only if it isn't carrying
                             // the net undergoing routing
-                            return preservedNet != net;
+                            return preservedNet == net ? GlobalSignalRouting.NodeStatus.INUSE
+                                    : GlobalSignalRouting.NodeStatus.UNAVAILABLE;
                         }
                         // A RouteNode will only be created if the net is necessary for
                         // a to-be-routed connection
-                        return routingGraph.getNode(node) != null;
+                        return routingGraph.getNode(node) == null ? GlobalSignalRouting.NodeStatus.AVAILABLE
+                                : GlobalSignalRouting.NodeStatus.UNAVAILABLE;
                     },
                     design, routethruHelper);
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -533,7 +533,7 @@ abstract public class RouteNode implements Comparable<RouteNode> {
                         this.type = RouteNodeType.SUPER_LONG_LINE;
                     } else {
                         // U-turn node at the boundary of the device
-                        assert(length == 0);
+                        assert(nodeInfo.length == 0);
                         assert(this.type == RouteNodeType.WIRE);
                     }
                     break;

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -349,7 +349,7 @@ abstract public class RouteNode implements Comparable<RouteNode> {
 
     public short getBeginTileXCoordinate() {
         // For US+ Laguna tiles, use end tile coordinate as that's already been corrected
-        // (see setEndTileXYCoordinates())
+        // (see RouteNodeInfo.getEndTileXCoordinate())
         Tile tile = node.getTile();
         return (tile.getTileTypeEnum() == TileTypeEnum.LAG_LAG) ? getEndTileXCoordinate()
                 : (short) tile.getTileXCoordinate();

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -305,7 +305,7 @@ abstract public class RouteNode implements Comparable<RouteNode> {
         return getNodeInfo(node).length;
     }
 
-    public void setLength(NodeInfo nodeInfo) {
+    private void setLength(NodeInfo nodeInfo) {
         length = nodeInfo.length;
 
         TileTypeEnum tileType = node.getTile().getTileTypeEnum();

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -166,20 +166,25 @@ abstract public class RouteNode implements Comparable<RouteNode> {
                 switch(ic) {
                     case NODE_OUTPUT:       // LUT route-thru
                     case NODE_CLE_OUTPUT:
+                    case NODE_LAGUNA_OUTPUT:
+                    case NODE_LAGUNA_DATA:  // US+: U-turn SLL at the boundary of the device
                         assert(length == 0);
                         break;
                     case NODE_LOCAL:
                     case INTENT_DEFAULT:
-                    case NODE_LAGUNA_OUTPUT:
                         assert(length <= 1);
                         break;
                     case NODE_SINGLE:
                         assert(length <= 2);
-                        if (length > 1) baseCost *= length;
+                        if (length == 2) baseCost *= length;
                         break;
                     case NODE_DOUBLE:
                         if (endTileXCoordinate != node.getTile().getTileXCoordinate()) {
-                            baseCost = 0.4f * length;
+                            assert(length == 1);
+                        } else {
+                            // Typically, length = 2 except for horizontal U-turns (length = 0)
+                            // or vertical U-turns (length = 1)
+                            assert(length <= 2);
                         }
                         break;
                     case NODE_HQUAD:
@@ -196,10 +201,6 @@ abstract public class RouteNode implements Comparable<RouteNode> {
                         break;
                     case NODE_VLONG:
                         baseCost = 0.7f;
-                        break;
-                    case NODE_LAGUNA_DATA:
-                        // US+: U-turn SLL at the boundary of the device
-                        assert(length == 0);
                         break;
                     default:
                         throw new RuntimeException(ic.toString());

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -180,11 +180,15 @@ abstract public class RouteNode implements Comparable<RouteNode> {
                         break;
                     case NODE_DOUBLE:
                         if (endTileXCoordinate != node.getTile().getTileXCoordinate()) {
-                            assert(length == 1);
+                            assert(length <= 2);
+                            // Typically, length = 1 (since tile X is not equal)
+                            // In US, have seen length = 2, e.g. VU440's INT_X171Y827/EE2_E_BEG7.
+                            if (length == 2) baseCost *= length;
                         } else {
                             // Typically, length = 2 except for horizontal U-turns (length = 0)
-                            // or vertical U-turns (length = 1)
-                            assert(length <= 2);
+                            // or vertical U-turns (length = 1).
+                            // In US, have seen length = 3, e.g. VU440's INT_X171Y827/NN2_E_BEG7.
+                            assert(length <= 3);
                         }
                         break;
                     case NODE_HQUAD:

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -338,12 +338,14 @@ abstract public class RouteNode implements Comparable<RouteNode> {
         if (tileType == TileTypeEnum.LAG_LAG) { // UltraScale+ only
             // Correct the X coordinate of all Laguna nodes since they are accessed by the INT
             // tile to its right, yet the LAG tile has a tile X coordinate one less than this.
-            if (tile.getTileXCoordinate() == endTileXCoordinate) {
+            // Do not apply this correction for NODE_LAGUNA_OUTPUT nodes (which the fanin and
+            // fanout nodes of the SLL are marked as) unless it is a fanin (LAGUNA_I)
+            // (i.e. do not apply it to the fanout nodes).
+            // Nor apply it to VCC_WIREs since their end tiles are INT tiles.
+            if ((node.getIntentCode() != IntentCode.NODE_LAGUNA_OUTPUT || type == RouteNodeType.LAGUNA_I) &&
+                !node.isTiedToVcc()) {
                 assert(tile.getTileXCoordinate() == endTileXCoordinate);
                 endTileXCoordinate++;
-            } else {
-                assert(type == RouteNodeType.WIRE);
-                assert(tile.getTileXCoordinate() + 1 == endTileXCoordinate);
             }
         } else if (tileType == TileTypeEnum.LAGUNA_TILE) { // UltraScale only
             // In UltraScale, Laguna tiles have the same X as the base INT tile

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -88,6 +88,9 @@ public class RouteNodeInfo {
                 + Math.abs(endTileYCoordinate - baseTile.getTileYCoordinate()));
         switch (baseTile.getTileTypeEnum()) {
             case LAG_LAG:
+                // Since only the endTile's X coordinate of LAG_LAG tiles would have been corrected
+                // by getEndTileXCoordinate(), but not the baseTile, revert this correction for the
+                // purpose of computing the node's length
                 length--;
                 // Fall through
             case LAGUNA_TILE:

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -104,6 +104,7 @@ public class RouteNodeInfo {
                 if (type == RouteNodeType.LAGUNA_I) {
                     assert(length == 0);
                 }
+                break;
         }
         return length;
     }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -84,16 +84,16 @@ public class RouteNodeInfo {
     }
 
     private static short getLength(Tile baseTile, RouteNodeType type, short endTileXCoordinate, short endTileYCoordinate) {
-        short length = (short) (Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate())
-                + Math.abs(endTileYCoordinate - baseTile.getTileYCoordinate()));
-        switch (baseTile.getTileTypeEnum()) {
+        TileTypeEnum tileType = baseTile.getTileTypeEnum();
+        short length = (short) Math.abs(endTileYCoordinate - baseTile.getTileYCoordinate());
+        if (tileType == TileTypeEnum.LAG_LAG) {
+            // Nodes in LAGUNA tiles have no X distance
+            assert(baseTile.getTileXCoordinate() == endTileXCoordinate - 1);
+        } else {
+            length += Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate());
+        }
+        switch (tileType) {
             case LAG_LAG:
-                // Since only the endTile's X coordinate of LAG_LAG tiles would have been corrected
-                // by getEndTileXCoordinate(), but not the baseTile, revert this correction for the
-                // purpose of computing the node's length
-                assert(Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate()) == 1);
-                length--;
-                // Fall through
             case LAGUNA_TILE:
                 if (type == RouteNodeType.SUPER_LONG_LINE) {
                     assert(length == RouteNodeGraph.SUPER_LONG_LINE_LENGTH_IN_TILES);

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -126,7 +126,7 @@ public class RouteNodeInfo {
                     assert(baseTile.getTileXCoordinate() == endTileXCoordinate);
                     endTileXCoordinate++;
                 }
-            break;
+                break;
             case LAGUNA_TILE: // UltraScale only
                 // In UltraScale, Laguna tiles have the same X as the base INT tile
                 assert(baseTile.getTileXCoordinate() == endTileXCoordinate);

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Eddie Hung, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.rwroute;
+
+import com.xilinx.rapidwright.device.IntentCode;
+import com.xilinx.rapidwright.device.Node;
+import com.xilinx.rapidwright.device.Tile;
+import com.xilinx.rapidwright.device.TileTypeEnum;
+import com.xilinx.rapidwright.device.Wire;
+import com.xilinx.rapidwright.util.Utils;
+
+public class RouteNodeInfo {
+    public final RouteNodeType type;
+    public final short endTileXCoordinate;
+    public final short endTileYCoordinate;
+    public final short length;
+
+    private RouteNodeInfo(RouteNodeType type,
+                          short endTileXCoordinate,
+                          short endTileYCoordinate,
+                          short length) {
+        this.type = type;
+        this.endTileXCoordinate = endTileXCoordinate;
+        this.endTileYCoordinate = endTileYCoordinate;
+        this.length = length;
+    }
+
+    public static RouteNodeInfo get(Node node) {
+        Wire[] wires = node.getAllWiresInNode();
+        Tile baseTile = node.getTile();
+        TileTypeEnum baseType = baseTile.getTileTypeEnum();
+        Tile endTile = null;
+        boolean pinfeedIntoLaguna = false;
+        for (Wire w : wires) {
+            Tile tile = w.getTile();
+            TileTypeEnum tileType = tile.getTileTypeEnum();
+            boolean lagunaTile = false;
+            if (tileType == TileTypeEnum.INT ||
+                    (lagunaTile = Utils.isLaguna(tileType))) {
+                if (!lagunaTile ||
+                        // Only consider a Laguna tile as an end tile if base tile is Laguna too
+                        // (otherwise it's a PINFEED into a Laguna)
+                        Utils.isLaguna(baseType)) {
+                    boolean endTileWasNotNull = (endTile != null);
+                    endTile = tile;
+                    // Break if this is the second INT tile
+                    if (endTileWasNotNull) break;
+                } else {
+                    assert(!Utils.isLaguna(baseType));
+                    pinfeedIntoLaguna = (node.getIntentCode() == IntentCode.NODE_PINFEED);
+                }
+            }
+        }
+        if (endTile == null) {
+            endTile = node.getTile();
+        }
+
+        RouteNodeType type = getType(node, endTile, pinfeedIntoLaguna);
+        short endTileXCoordinate = getEndTileXCoordinate(node, type, (short) endTile.getTileXCoordinate());
+        short endTileYCoordinate = (short) endTile.getTileYCoordinate();
+        short length = getLength(baseTile, type, endTileXCoordinate, endTileYCoordinate);
+
+        return new RouteNodeInfo(type, endTileXCoordinate, endTileYCoordinate, length);
+    }
+
+    private static short getLength(Tile baseTile, RouteNodeType type, short endTileXCoordinate, short endTileYCoordinate) {
+        short length = (short) (Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate())
+                + Math.abs(endTileYCoordinate - baseTile.getTileYCoordinate()));
+        switch (baseTile.getTileTypeEnum()) {
+            case LAG_LAG:
+                length--;
+                // Fall through
+            case LAGUNA_TILE:
+                if (type == RouteNodeType.SUPER_LONG_LINE) {
+                    assert(length == RouteNodeGraph.SUPER_LONG_LINE_LENGTH_IN_TILES);
+                } else {
+                    assert(length == 0);
+                }
+                break;
+            case INT:
+                if (type == RouteNodeType.LAGUNA_I) {
+                    assert(length == 0);
+                }
+        }
+        return length;
+    }
+
+    private static short getEndTileXCoordinate(Node node, RouteNodeType type, short endTileXCoordinate) {
+        Tile baseTile = node.getTile();
+        TileTypeEnum baseType = baseTile.getTileTypeEnum();
+        switch (baseType) {
+            case LAG_LAG: // UltraScale+ only
+                // Correct the X coordinate of all Laguna nodes since they are accessed by the INT
+                // tile to its right, yet the LAG tile has a tile X coordinate one less than this.
+                // Do not apply this correction for NODE_LAGUNA_OUTPUT nodes (which the fanin and
+                // fanout nodes of the SLL are marked as) unless it is a fanin (LAGUNA_I)
+                // (i.e. do not apply it to the fanout nodes).
+                // Nor apply it to VCC_WIREs since their end tiles are INT tiles.
+                if ((node.getIntentCode() != IntentCode.NODE_LAGUNA_OUTPUT || type == RouteNodeType.LAGUNA_I) &&
+                        !node.isTiedToVcc()) {
+                    assert(baseTile.getTileXCoordinate() == endTileXCoordinate);
+                    endTileXCoordinate++;
+                }
+            break;
+            case LAGUNA_TILE: // UltraScale only
+                // In UltraScale, Laguna tiles have the same X as the base INT tile
+                assert(baseTile.getTileXCoordinate() == endTileXCoordinate);
+                break;
+        }
+        return endTileXCoordinate;
+    }
+
+    private static RouteNodeType getType(Node node, Tile endTile, boolean pinfeedIntoLaguna) {
+        // NOTE: IntentCode is device-dependent
+        IntentCode ic = node.getIntentCode();
+        switch (ic) {
+            case NODE_PINBOUNCE:
+                return RouteNodeType.PINBOUNCE;
+
+            case NODE_PINFEED:
+                return pinfeedIntoLaguna ? RouteNodeType.LAGUNA_I : RouteNodeType.PINFEED_I;
+
+            case NODE_LAGUNA_OUTPUT: // UltraScale+ only
+                assert(node.getTile().getTileTypeEnum() == TileTypeEnum.LAG_LAG);
+                if (node.getWireName().endsWith("_TXOUT")) {
+                    return RouteNodeType.LAGUNA_I;
+                }
+                break;
+
+            case NODE_LAGUNA_DATA: // UltraScale+ only
+                assert(node.getTile().getTileTypeEnum() == TileTypeEnum.LAG_LAG);
+                if (node.getTile() != endTile) {
+                    return RouteNodeType.SUPER_LONG_LINE;
+                }
+
+                // U-turn node at the boundary of the device
+                break;
+
+            case INTENT_DEFAULT:
+                if (node.getTile().getTileTypeEnum() == TileTypeEnum.LAGUNA_TILE) { // UltraScale only
+                    String wireName = node.getWireName();
+                    if (wireName.startsWith("UBUMP")) {
+                        assert(node.getTile() != endTile);
+                        return RouteNodeType.SUPER_LONG_LINE;
+                    } else if (wireName.endsWith("_TXOUT")) {
+                        // This is the inner LAGUNA_I, mark it so it gets a base cost discount
+                        return RouteNodeType.LAGUNA_I;
+                    }
+                }
+                break;
+        }
+
+        return RouteNodeType.WIRE;
+    }
+}

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -91,6 +91,7 @@ public class RouteNodeInfo {
                 // Since only the endTile's X coordinate of LAG_LAG tiles would have been corrected
                 // by getEndTileXCoordinate(), but not the baseTile, revert this correction for the
                 // purpose of computing the node's length
+                assert(Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate()) == 1);
                 length--;
                 // Fall through
             case LAGUNA_TILE:

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -87,7 +87,7 @@ public class RouteNodeInfo {
         TileTypeEnum tileType = baseTile.getTileTypeEnum();
         short length = (short) Math.abs(endTileYCoordinate - baseTile.getTileYCoordinate());
         if (tileType == TileTypeEnum.LAG_LAG) {
-            // Nodes in LAGUNA tiles have no X distance
+            // Nodes in LAGUNA tiles must have no X distance
             assert(baseTile.getTileXCoordinate() == endTileXCoordinate - 1);
         } else {
             length += Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate());


### PR DESCRIPTION
Static net router to now reuse existing used resources when performing partial routing.

Refactor `RouteNode` functionality into `RouteNodeInfo`, fixing coordinate and wirelength computations as well as improving clarity and robustness.