### PR TITLE
[EDIF] Fix for skipping past EOF, improve tests

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
@@ -443,9 +443,18 @@ public class EDIFTokenizer implements AutoCloseable {
         }
         long actual = 0;
         while (actual < i) {
-            actual += in.skip(i-actual);
+            long skipped = in.skip(i-actual);
+            if (skipped == 0) {
+                if (in.read() == -1) {
+                    // EOF reached
+                    break;
+                }
+                // One byte was successfully read
+                skipped = 1;
+            }
+            actual += skipped;
         }
-        byteOffset += i;
+        byteOffset += actual;
     }
 
     /**


### PR DESCRIPTION
When parsing a gzipped EDIF, we can only estimate its uncompressed size in order to decide where each worker thread should start parsing. The possibility exists that estimate is so incorrect, and when there are enough workers, that one worker is asked to start at an offset that is past the end of the uncompressed file.

Handle this situation, and improve the tests to catch this.