### PR TITLE
[Interchange] PhysNetlistReader to align with Vivado on SRST routing

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -797,7 +797,8 @@ public class PhysNetlistReader {
 
         if (series == Series.UltraScalePlus || series == Series.UltraScale) {
             // To be consistent with Vivado DCPs, remove all intra-site routing for
-            // SRST* pins tied to ground on these series of devices
+            // SRST* pins tied to ground on these series of devices.
+            // (Note: this condition is necessary for {@link DesignTools#createCeSrRstPinsToVCC()})
             for (SiteInst si : design.getSiteInsts()) {
                 if (!Utils.isSLICE(si)) {
                     continue;

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -799,18 +799,19 @@ public class PhysNetlistReader {
             // To be consistent with Vivado DCPs, remove all intra-site routing for
             // SRST* pins tied to ground on these series of devices.
             // (Note: this condition is necessary for {@link DesignTools#createCeSrRstPinsToVCC()})
+            String[] siteWires = new String[]{"RST_ABCDINV_OUT", "RST_EFGHINV_OUT"};
             for (SiteInst si : design.getSiteInsts()) {
                 if (!Utils.isSLICE(si)) {
                     continue;
                 }
-                for (String sw : new String[]{"RST_ABCDINV_OUT", "RST_EFGHINV_OUT"}) {
+                for (String sw : siteWires) {
                     Net net = si.getNetFromSiteWire(sw);
                     if (net != null && net.getType() == NetType.GND) {
                         BELPin belPin = si.getSiteWirePins(sw)[0];
-                        assert (belPin.isOutput());
+                        assert(belPin.isOutput());
                         BEL bel = belPin.getBEL();
-                        assert (bel.getBELClass() == BELClass.RBEL);
-                        assert (bel.getInvertingPin() == bel.getNonInvertingPin());
+                        assert(bel.getBELClass() == BELClass.RBEL);
+                        assert(bel.getInvertingPin() == bel.getNonInvertingPin());
                         SitePIP sp = si.getSitePIP(belPin);
                         Net inputNet = si.getNetFromSiteWire(sp.getInputPin().getSiteWireName());
                         assert(inputNet == null || inputNet.isStaticNet());


### PR DESCRIPTION
Imitate how Vivado represents `SLICE` `SRST*` connections by clearing out the intra site routing when connected to GND (i.e. no sensitivity to set or reset). This allows `DesignTools.createCeSrRstPinsToVcc()` to create the corresponding `SitePinInst` and attach to the VCC net, using the in-built inverter to achieved ground.