### PR TITLE
Clear out PipelineGeneratorWithRouting static members

### DIFF
--- a/src/com/xilinx/rapidwright/examples/PipelineGeneratorWithRouting.java
+++ b/src/com/xilinx/rapidwright/examples/PipelineGeneratorWithRouting.java
@@ -539,11 +539,17 @@ public class PipelineGeneratorWithRouting {
                 }
                 result.addAll(tmpG.getPIPs());
             }
-
-            return result;
         } else {
-            return null;
+            result = null;
         }
+
+        queue = null;
+        visited = null;
+        delayCostTable = null;
+        prevG = null;
+        currG = null;
+
+        return result;
     }
 
 


### PR DESCRIPTION
Consequence of https://github.com/Xilinx/RapidWright/pull/615 which can cause `OutOfMemoryError`.