### PR TITLE
Add missing Versal Premium unisim placements

### DIFF
--- a/src/com/xilinx/rapidwright/util/DataVersions.java
+++ b/src/com/xilinx/rapidwright/util/DataVersions.java
@@ -326,6 +326,6 @@ public class DataVersions {
         dataVersionMap.put("data/devices/zynquplusrfsoc/xqzu49dr_db.dat", new Pair<>("xqzu49dr-db-dat", "df942c4f499805206466b4d89813c235"));
         dataVersionMap.put("data/partdump.csv", new Pair<>("partdump-csv", "f0417647e80cb1de13c65f0a8973df17"));
         dataVersionMap.put("data/parts.db", new Pair<>("parts-db", "b728320ae4d94f28402e03343363b6e8"));
-        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "b5a8968bd41a3b6095d5af6180a7a658"));
+        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "70faaac529fd20e64a0acaa4827a885e"));
     }
 }

--- a/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
+++ b/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.device;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.xilinx.rapidwright.design.Cell;
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.edif.EDIFCell;
+
+public class TestUnisimPlacements {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "VERSALPREMIUM", "ARTIX7", "ZYNQ", "ZYNQUPLUS", "VIRTEXU" })
+    public void testUnisimPlacements(String familyType) {
+        for (Part part : PartNameTools.getParts()) {
+            if (!part.getFamily().toString().equals(familyType))
+                continue;
+            Design des = new Design("top", part.getName());
+            EDIFCell cell = Design.getPrimitivesLibrary(des.getDevice().getName()).getCell("FDRE");
+            Cell c = des.createCell("inst", cell);
+            Assertions.assertTrue(c.getCompatiblePlacements().size() > 1);
+            break;
+        }
+    }
+}


### PR DESCRIPTION
This is to address the issue found in #631, points to an updated unisim data file with Versal Premium unisim placement information added.