### PR TITLE
More compact data file, all family coverage with comprehensive test

### DIFF
--- a/src/com/xilinx/rapidwright/util/DataVersions.java
+++ b/src/com/xilinx/rapidwright/util/DataVersions.java
@@ -326,6 +326,6 @@ public class DataVersions {
         dataVersionMap.put("data/devices/zynquplusrfsoc/xqzu49dr_db.dat", new Pair<>("xqzu49dr-db-dat", "df942c4f499805206466b4d89813c235"));
         dataVersionMap.put("data/partdump.csv", new Pair<>("partdump-csv", "f0417647e80cb1de13c65f0a8973df17"));
         dataVersionMap.put("data/parts.db", new Pair<>("parts-db", "b728320ae4d94f28402e03343363b6e8"));
-        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "70faaac529fd20e64a0acaa4827a885e"));
+        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "10d1c6e79b176e329019d7bc752ca301"));
     }
 }

--- a/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
+++ b/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
@@ -35,6 +35,10 @@ import com.xilinx.rapidwright.edif.EDIFCell;
 
 public class TestUnisimPlacements {
 
+    /**
+     * Set of unsupported unisim families (for now) in 2022.2.3. Hopefully will add
+     * support in 2023.1.0.
+     */
     private static Set<FamilyType> unsupportedTypes = null;
 
     static {

--- a/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
+++ b/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
@@ -24,7 +24,7 @@ package com.xilinx.rapidwright.device;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
@@ -33,10 +33,10 @@ import com.xilinx.rapidwright.edif.EDIFCell;
 public class TestUnisimPlacements {
 
     @ParameterizedTest
-    @ValueSource(strings = { "VERSALPREMIUM", "ARTIX7", "ZYNQ", "ZYNQUPLUS", "VIRTEXU" })
-    public void testUnisimPlacements(String familyType) {
+    @EnumSource(FamilyType.class)
+    public void testUnisimPlacements(FamilyType familyType) {
         for (Part part : PartNameTools.getParts()) {
-            if (!part.getFamily().toString().equals(familyType))
+            if (part.getFamily() != familyType)
                 continue;
             Design des = new Design("top", part.getName());
             EDIFCell cell = Design.getPrimitivesLibrary(des.getDevice().getName()).getCell("FDRE");

--- a/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
+++ b/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
@@ -22,6 +22,9 @@
 
 package com.xilinx.rapidwright.device;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -32,9 +35,24 @@ import com.xilinx.rapidwright.edif.EDIFCell;
 
 public class TestUnisimPlacements {
 
+    private static Set<FamilyType> unsupportedTypes = null;
+
+    static {
+        unsupportedTypes = new HashSet<>();
+        unsupportedTypes.add(FamilyType.ZYNQUPLUSRFSOC);
+        unsupportedTypes.add(FamilyType.QVIRTEXUPLUSHBM);
+        unsupportedTypes.add(FamilyType.QZYNQUPLUSRFSOC);
+        unsupportedTypes.add(FamilyType.VIRTEXUPLUSHBMES1);
+        unsupportedTypes.add(FamilyType.VIRTEXUPLUSHBM);
+        unsupportedTypes.add(FamilyType.VIRTEXUPLUS58G);
+    }
+
     @ParameterizedTest
     @EnumSource(FamilyType.class)
     public void testUnisimPlacements(FamilyType familyType) {
+        if (unsupportedTypes.contains(familyType)) {
+            return;
+        }
         for (Part part : PartNameTools.getParts()) {
             if (part.getFamily() != familyType)
                 continue;


### PR DESCRIPTION
In a new release, all family unisim placement data will be aliased by architecture upon load of the `unisim_data.dat` file.  This will minimize the needed size of the file and provide broader coverage automatically.  