### PR TITLE
EDIFNetlist.getIOStandard() to inherit IOStandard from EDIFNet

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -125,7 +125,7 @@ public class EDIFNetlist extends EDIFName {
 
     public static final String IOSTANDARD_PROP = "IOStandard";
 
-    private static final EDIFPropertyValue DEFAULT_PROP_VALUE = new EDIFPropertyValue(IOStandard.DEFAULT.name(), EDIFValueType.STRING);
+    public static final EDIFPropertyValue DEFAULT_PROP_VALUE = new EDIFPropertyValue(IOStandard.DEFAULT.name(), EDIFValueType.STRING);
 
     static {
         EnumSet<IOStandard> obufExpansion = EnumSet.of(

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -183,7 +183,8 @@ public class EDIFNetlist extends EDIFName {
      * Map that stores EDIFCellInst to EDIFPropertyValue for non-default IOStandard
      * values propagated from other parts of the netlist.
      * Anecdotally, it's been observed that Vivado propagates the IOStandard property
-     * from the EDIFNet feeding an output port to its driving EDIFCellInst I/O buffer.
+     * from the EDIFNet feeding a top-level output port to its driving EDIFCellInst
+     * I/O buffer.
      */
     Map<EDIFCellInst,EDIFPropertyValue> cellInstIOStandardFallback;
 

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -19,9 +19,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- */
-/**
  *
  */
 package com.xilinx.rapidwright.edif;

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1485,4 +1485,25 @@ public class EDIFTools {
         }
         return collection.entrySet().stream().sorted(Entry.comparingByKey())::iterator;
     }
+
+    /**
+     * Helper method to get the IOStandard property from an EDIFPropertyObject,
+     * with consideration for upper-case.
+     * @param epo EDIFPropertyObject
+     * @return EDIFPropertyValue containing IOStandard. Returns
+     *         EDIFNetlist.DEFAULT_PROP_VALUE if no value found.
+     */
+    public static EDIFPropertyValue getIoStandard(EDIFPropertyObject epo) {
+        EDIFPropertyValue value = epo.getProperty(EDIFNetlist.IOSTANDARD_PROP);
+        if (value != null) {
+            return value;
+        }
+
+        value = epo.getProperty(EDIFNetlist.IOSTANDARD_PROP.toUpperCase());
+        if (value != null) {
+            return value;
+        }
+
+        return EDIFNetlist.DEFAULT_PROP_VALUE;
+    }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1493,7 +1493,7 @@ public class EDIFTools {
      * @return EDIFPropertyValue containing IOStandard. Returns
      *         EDIFNetlist.DEFAULT_PROP_VALUE if no value found.
      */
-    public static EDIFPropertyValue getIoStandard(EDIFPropertyObject epo) {
+    public static EDIFPropertyValue getIOStandard(EDIFPropertyObject epo) {
         EDIFPropertyValue value = epo.getProperty(EDIFNetlist.IOSTANDARD_PROP);
         if (value != null) {
             return value;

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -29,10 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.xilinx.rapidwright.device.Series;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.xilinx.rapidwright.design.Design;
@@ -326,5 +328,51 @@ class TestEDIFNetlist {
         Assertions.assertEquals(port0.getWidth(), testPort0.getWidth());
         EDIFPort testPort1 = testTopCell.getNet(net1.getName()).getPortInst(null, portName + "[0]").getPort();
         Assertions.assertEquals(port1.getWidth(), testPort1.getWidth());
+    }
+
+    @Test
+    public void testGetIOStandard() {
+        final EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+
+        EDIFCell top = netlist.getTopCell();
+        EDIFPort port = top.createPort("O", EDIFDirection.OUTPUT, 1);
+        EDIFCellInst obufds = top.createChildCellInst("obuf", Design.getPrimitivesLibrary().getCell("OBUFDS"));
+        EDIFNet net = top.createNet("O");
+        new EDIFPortInst(port, net);
+        new EDIFPortInst(obufds.getPort("O"), net, obufds);
+        Assertions.assertEquals(EDIFNetlist.DEFAULT_PROP_VALUE, netlist.getIOStandard(obufds));
+
+        netlist.cellInstIOStandardFallback = null;
+
+        // Test that top-level-port's connected net property is propagated
+        net.addProperty(EDIFNetlist.IOSTANDARD_PROP, "LVDS");
+        Assertions.assertEquals("LVDS", netlist.getIOStandard(obufds).getValue());
+
+        // Test that cell inst takes priority
+        obufds.addProperty(EDIFNetlist.IOSTANDARD_PROP, "DIFF_SSTL12_DCI");
+        Assertions.assertEquals("DIFF_SSTL12_DCI", netlist.getIOStandard(obufds).getValue());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "LVDS,OBUFDS",
+            "BLVDS_25,OBUFDS_DUAL_BUF"
+    })
+    public void testExpandMacroUnisimsExceptionWithFallbackIOStandard(String standard, String cellType) {
+        final EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+
+        EDIFCell top = netlist.getTopCell();
+        EDIFPort port = top.createPort("O", EDIFDirection.OUTPUT, 1);
+        EDIFCellInst obufds = top.createChildCellInst("obuf", Design.getPrimitivesLibrary().getCell("OBUFDS"));
+        netlist.getHDIPrimitivesLibrary().addCell(obufds.getCellType());
+        EDIFNet net = top.createNet("O");
+        new EDIFPortInst(port, net);
+        new EDIFPortInst(obufds.getPort("O"), net, obufds);
+
+        // Set IOStandard only on top-level-port's connected net
+        net.addProperty(EDIFNetlist.IOSTANDARD_PROP, standard);
+
+        netlist.expandMacroUnisims(Series.UltraScalePlus);
+        Assertions.assertEquals(cellType, obufds.getCellType().getName());
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFTools.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFTools.java
@@ -1,7 +1,6 @@
-
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Jakob Wenzel, Xilinx Research Labs.
@@ -210,5 +209,21 @@ public class TestEDIFTools {
         Assertions.assertNotEquals(newPort2, slicedPortName);
         Assertions.assertNotEquals(newPort2, newPort1);
         Assertions.assertTrue(newPort2.matches(Pattern.quote(slicedPortName) + "_rw_created\\d+"));
+    }
+
+    @Test
+    public void testGetIoStandard() {
+        final EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+
+        EDIFCell top = netlist.getTopCell();
+        EDIFPort port = top.createPort("O", EDIFDirection.OUTPUT, 1);
+        EDIFCellInst obufds = top.createChildCellInst("obuf", Design.getPrimitivesLibrary().getCell("OBUFDS"));
+        EDIFNet net = top.createNet("O");
+        new EDIFPortInst(port, net);
+        new EDIFPortInst(obufds.getPort("O"), net, obufds);
+        Assertions.assertEquals(EDIFNetlist.DEFAULT_PROP_VALUE, EDIFTools.getIOStandard(obufds));
+
+        obufds.addProperty(EDIFNetlist.IOSTANDARD_PROP, "LVDS");
+        Assertions.assertEquals("LVDS", EDIFTools.getIOStandard(obufds).getValue());
     }
 }


### PR DESCRIPTION
Anecdotally, it's been observed that Vivado propagates the `IOStandard` property from the `EDIFNet` feeding a top-level output port to its driving `EDIFCellInst` I/O buffer. Do so here too, with `EDIFNetlist.getIOStandard()` which backs onto the `EDIFTools.getIOStandard()` static helper.

This `IOStandard` turns out to be important for determining whether certain macros should be expanded (see https://github.com/Xilinx/RapidWright/pull/505).