### PR TITLE
Fix EDIFNetlist.cellInstIOStandardFallback

### DIFF
--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -333,6 +333,7 @@ class TestEDIFNetlist {
     @Test
     public void testGetIOStandard() {
         final EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+        netlist.setDevice(Device.getDevice(Device.AWS_F1));
 
         EDIFCell top = netlist.getTopCell();
         EDIFPort port = top.createPort("O", EDIFDirection.OUTPUT, 1);

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -362,6 +362,7 @@ class TestEDIFNetlist {
     })
     public void testExpandMacroUnisimsExceptionWithFallbackIOStandard(String standard, String cellType) {
         final EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+        netlist.setDevice(Device.getDevice(Device.AWS_F1));
 
         EDIFCell top = netlist.getTopCell();
         EDIFPort port = top.createPort("O", EDIFDirection.OUTPUT, 1);


### PR DESCRIPTION
Fix for https://github.com/Xilinx/RapidWright/pull/646 whereby if an `EDIFCellInst` inside of a macro is found, it is possible that this instantiation is not unique and may lead to a conflicting IOStandard error.

If inside a macro, use the outer macro's `EDIFCellInst` instead.