### PR TITLE
DesignTools.makePhysNetNamesConsistent() to move SitePinInst-s too

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2721,6 +2721,13 @@ public class DesignTools {
         }
     }
 
+    /**
+     * Make all of a Design's physical Net objects consistent with its logical (EDIF) netlist.
+     * Specifically, merge all sitewire and SitePinInst-s associated with physical Net-s that
+     * are not the parent/canonical logical net into the parent Net, and delete all
+     * non-parent Net-s.
+     * @param design Design object to be modified in-place.
+     */
     public static void makePhysNetNamesConsistent(Design design) {
         Map<EDIFHierNet, EDIFHierNet> netParentMap = design.getNetlist().getParentNetMap();
         EDIFNetlist netlist = design.getNetlist();
@@ -2749,7 +2756,7 @@ public class DesignTools {
                             si.routeIntraSiteNet(parentPhysNet, pins[0], pins[0]);
                         }
                     }
-                    design.removeNet(net);
+                    design.movePinsToNewNetDeleteOldNet(net, parentPhysNet, true);
                 } else if (!net.rename(parentHierNet.getHierarchicalNetName())) {
                     System.out.println("WARNING: Failed to adjust physical net name " + net.getName());
                 }

--- a/src/com/xilinx/rapidwright/examples/SLRCrosserGenerator.java
+++ b/src/com/xilinx/rapidwright/examples/SLRCrosserGenerator.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.ConstraintGroup;
@@ -390,7 +391,8 @@ public class SLRCrosserGenerator {
         UltraScaleClockRouting.routeDistributionToLCBs(clk, distLines, lcbMappings.keySet());
 
         // Route from each LCB to laguna sites
-        UltraScaleClockRouting.routeLCBsToSinks(clk, lcbMappings);
+        Predicate<Node> isPreservedNode = (node) -> false;
+        UltraScaleClockRouting.routeLCBsToSinks(clk, lcbMappings, isPreservedNode);
 
         // Update clocking delays to improve SLR crossing hold issues
         clk.improveSLRClockingDelay(txClkWire, rxClkWire);

--- a/src/com/xilinx/rapidwright/router/UltraScaleClockRouting.java
+++ b/src/com/xilinx/rapidwright/router/UltraScaleClockRouting.java
@@ -414,6 +414,7 @@ public class UltraScaleClockRouting {
     /**
      * @param clk
      * @param lcbMappings
+     * @param isPreservedNode Predicate lambda for indicating whether a Node is preserved and cannot be used.
      */
     public static void routeLCBsToSinks(Net clk, Map<RouteNode, ArrayList<SitePinInst>> lcbMappings, Predicate<Node> isPreservedNode) {
         Set<Wire> used = new HashSet<>();

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -170,23 +170,23 @@ public class GlobalSignalRouting {
     public static void symmetricClkRouting(Net clk, Device device) {
         List<ClockRegion> clockRegions = getClockRegionsOfNet(clk);
         ClockRegion centroid = findCentroid(clk, device);
-        RouteNode clkRoutingLine = UltraScaleClockRouting.routeBUFGToNearestRoutingTrack(clk);// first HROUTE
-
-        RouteNode centroidHRouteNode = UltraScaleClockRouting.routeToCentroid(clk, clkRoutingLine, centroid, true, true);
-
-        RouteNode vrouteUp = null;
-        RouteNode vrouteDown;
-        // Two VROUTEs going up and down
-        ClockRegion aboveCentroid = centroid.getNeighborClockRegion(1, 0);
-        if (aboveCentroid != null) {
-            vrouteUp = UltraScaleClockRouting.routeToCentroid(clk, centroidHRouteNode, aboveCentroid, true, false);
-        }
-        vrouteDown = UltraScaleClockRouting.routeToCentroid(clk, centroidHRouteNode, centroid.getNeighborClockRegion(0, 0), true, false);
 
         List<ClockRegion> upClockRegions = new ArrayList<>();
         List<ClockRegion> downClockRegions = new ArrayList<>();
         // divides clock regions into two groups
         divideClockRegions(clockRegions, centroid, upClockRegions, downClockRegions);
+
+        RouteNode clkRoutingLine = UltraScaleClockRouting.routeBUFGToNearestRoutingTrack(clk);// first HROUTE
+        RouteNode centroidHRouteNode = UltraScaleClockRouting.routeToCentroid(clk, clkRoutingLine, centroid, true, true);
+
+        RouteNode vrouteUp = null;
+        RouteNode vrouteDown;
+        // Two VROUTEs going up and down
+        ClockRegion aboveCentroid = upClockRegions.isEmpty() ? null : centroid.getNeighborClockRegion(1, 0);
+        if (aboveCentroid != null) {
+            vrouteUp = UltraScaleClockRouting.routeToCentroid(clk, centroidHRouteNode, aboveCentroid, true, false);
+        }
+        vrouteDown = UltraScaleClockRouting.routeToCentroid(clk, centroidHRouteNode, centroid.getNeighborClockRegion(0, 0), true, false);
 
         List<RouteNode> upDownDistLines = new ArrayList<>();
         if (aboveCentroid != null) {

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -76,6 +76,7 @@ public class GlobalSignalRouting {
      * @param routesToSinkINTTiles A map storing routes from CLK_OUT to different INT tiles that
      * connect to sink pins of a global clock net.
      * @param device The target device needed to get routing path representation with nodes from names.
+     * @param isPreservedNode Predicate lambda for indicating whether a Node is preserved and cannot be used.
      */
     public static void routeClkWithPartialRoutes(Net clk,
                                                  Map<String, List<String>> routesToSinkINTTiles,
@@ -170,6 +171,7 @@ public class GlobalSignalRouting {
      * Routes a clock net by dividing the target clock regions into two groups and routes to the two groups with different centroid nodes.
      * @param clk The clock to be routed.
      * @param device The design device.
+     * @param isPreservedNode Predicate lambda for indicating whether a Node is preserved and cannot be used.
      */
     public static void symmetricClkRouting(Net clk, Device device, Predicate<Node> isPreservedNode) {
         List<ClockRegion> clockRegions = getClockRegionsOfNet(clk);

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -34,6 +34,7 @@ import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
@@ -76,7 +77,10 @@ public class GlobalSignalRouting {
      * connect to sink pins of a global clock net.
      * @param device The target device needed to get routing path representation with nodes from names.
      */
-    public static void routeClkWithPartialRoutes(Net clk, Map<String, List<String>> routesToSinkINTTiles, Device device) {
+    public static void routeClkWithPartialRoutes(Net clk,
+                                                 Map<String, List<String>> routesToSinkINTTiles,
+                                                 Device device,
+                                                 Predicate<Node> isPreservedNode) {
         Map<String, List<Node>> dstINTtilePaths = getListOfNodesFromRoutes(device, routesToSinkINTTiles);
         // Not import path after HDSTR
         Set<PIP> clkPIPs = new HashSet<>();
@@ -96,7 +100,7 @@ public class GlobalSignalRouting {
         UltraScaleClockRouting.routeToLCBs(clk, getStartingPoint(horDistributionLines, device), lcbMappings.keySet());
 
         // route LCBs to sink pins
-        UltraScaleClockRouting.routeLCBsToSinks(clk, lcbMappings);
+        UltraScaleClockRouting.routeLCBsToSinks(clk, lcbMappings, isPreservedNode);
 
         Set<PIP> clkPIPsWithoutDuplication = new HashSet<>(clk.getPIPs());
         clk.setPIPs(clkPIPsWithoutDuplication);
@@ -167,7 +171,7 @@ public class GlobalSignalRouting {
      * @param clk The clock to be routed.
      * @param device The design device.
      */
-    public static void symmetricClkRouting(Net clk, Device device) {
+    public static void symmetricClkRouting(Net clk, Device device, Predicate<Node> isPreservedNode) {
         List<ClockRegion> clockRegions = getClockRegionsOfNet(clk);
         ClockRegion centroid = findCentroid(clk, device);
 
@@ -200,7 +204,7 @@ public class GlobalSignalRouting {
         Map<RouteNode, ArrayList<SitePinInst>> lcbMappings = getLCBPinMappings(clk);
         UltraScaleClockRouting.routeDistributionToLCBs(clk, upDownDistLines, lcbMappings.keySet());
 
-        UltraScaleClockRouting.routeLCBsToSinks(clk, lcbMappings);
+        UltraScaleClockRouting.routeLCBsToSinks(clk, lcbMappings, isPreservedNode);
 
         Set<PIP> clkPIPsWithoutDuplication = new HashSet<>(clk.getPIPs());
         clk.setPIPs(clkPIPsWithoutDuplication);

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -570,6 +570,7 @@ public class PartialRouter extends RWRoute {
      * @param args An array of string arguments, can be null.
      * If null, the design will be routed in the full timing-driven routing mode with default a {@link RWRouteConfig} instance.
      * For more options of the configuration, please refer to the {@link RWRouteConfig} class.
+     * @param softPreserve Allow routed nets to be unrouted and subsequently rerouted in order to improve routability.
      * @return Routed design.
      */
     public static Design routeDesignWithUserDefinedArguments(Design design, String[] args, boolean softPreserve) {
@@ -595,6 +596,7 @@ public class PartialRouter extends RWRoute {
      * Routes a design in the partial non-timing-driven routing mode.
      * @param design The {@link Design} instance to be routed.
      * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed.
+     * @param softPreserve Allow routed nets to be unrouted and subsequently rerouted in order to improve routability.
      */
     public static Design routeDesignPartialNonTimingDriven(Design design, Collection<SitePinInst> pinsToRoute, boolean softPreserve) {
         return routeDesign(design, new RWRouteConfig(new String[] {
@@ -612,6 +614,7 @@ public class PartialRouter extends RWRoute {
      * Routes a design in the partial timing-driven routing mode.
      * @param design The {@link Design} instance to be routed.
      * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed.
+     * @param softPreserve Allow routed nets to be unrouted and subsequently rerouted in order to improve routability.
      */
     public static Design routeDesignPartialTimingDriven(Design design, Collection<SitePinInst> pinsToRoute, boolean softPreserve) {
         return routeDesign(design, new RWRouteConfig(new String[] {

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -492,6 +492,11 @@ public class RWRoute{
             } else {
                 Node sinkINTNode = nodes.get(0);
                 indirectConnections.add(connection);
+                Net oldNet = routingGraph.getPreservedNet(sinkINTNode);
+                if (oldNet != null) {
+                    throw new RuntimeException("ERROR: Sink node " + sinkINTNode + " of net '" + net.getName() + "' is "
+                            + " preserved by net '" + oldNet.getName() + "'");
+                }
                 connection.setSinkRnode(getOrCreateRouteNode(sinkINTNode, RouteNodeType.PINFEED_I));
                 if (sourceINTRnode == null) {
                     Node sourceINTNode = RouterHelper.projectOutputPinToINTNode(source);

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -493,7 +493,7 @@ public class RWRoute{
                 Node sinkINTNode = nodes.get(0);
                 indirectConnections.add(connection);
                 Net oldNet = routingGraph.getPreservedNet(sinkINTNode);
-                if (oldNet != null) {
+                if (oldNet != null && oldNet != net) {
                     throw new RuntimeException("ERROR: Sink node " + sinkINTNode + " of net '" + net.getName() + "' is "
                             + " preserved by net '" + oldNet.getName() + "'");
                 }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -557,11 +557,18 @@ abstract public class RouteNode implements Comparable<RouteNode> {
 
     /**
      * Sets the parent RouteNode instance for routing a connection.
-     * @param prev The driving RouteNode instance to set.
+     * @param prev The driving RouteNode instance to set. Cannot be null.
      */
     public void setPrev(RouteNode prev) {
         assert(prev != null);
         this.prev = prev;
+    }
+
+    /**
+     * Clears the parent RouteNode instance.
+     */
+    public void clearPrev() {
+        this.prev = null;
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -217,6 +217,7 @@ public class RouteNodeGraph {
         // No need to synchronize access to 'nets' since collisions are not expected
         Net[] nets = preservedMap.computeIfAbsent(tile, (t) -> new Net[t.getWireCount()]);
         Net oldNet = nets[wireIndex];
+        // Do not clobber the old value
         if (oldNet == null) {
             nets[wireIndex] = net;
         }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -217,7 +217,9 @@ public class RouteNodeGraph {
         // No need to synchronize access to 'nets' since collisions are not expected
         Net[] nets = preservedMap.computeIfAbsent(tile, (t) -> new Net[t.getWireCount()]);
         Net oldNet = nets[wireIndex];
-        nets[wireIndex] = net;
+        if (oldNet == null) {
+            nets[wireIndex] = net;
+        }
         return oldNet;
     }
 

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -212,7 +212,8 @@ public class TestRWRoute {
 
         List<SitePinInst> pinsToRoute = new ArrayList<>();
         pinsToRoute.add(dstSpi);
-        PartialRouter.routeDesignPartialNonTimingDriven(design, pinsToRoute);
+        boolean softPreserve = false;
+        PartialRouter.routeDesignPartialNonTimingDriven(design, pinsToRoute, softPreserve);
 
         Assertions.assertTrue(pinsToRoute.stream().allMatch(SitePinInst::isRouted));
         Assertions.assertTrue(Long.valueOf(System.getProperty("rapidwright.rwroute.nodesPopped")) <= nodesPoppedLimit);


### PR DESCRIPTION
Instead of just removing the non-parent physical `Net` after moving over all sitewires, move all of its `SitePinInst`-s too.

Built on top of https://github.com/Xilinx/RapidWright/pull/655