### PR TITLE
ModuleInst.connect() to move SitePinInst-s from old Net to new

### DIFF
--- a/src/com/xilinx/rapidwright/design/ModuleInst.java
+++ b/src/com/xilinx/rapidwright/design/ModuleInst.java
@@ -698,6 +698,10 @@ public class ModuleInst extends AbstractModuleInst<Module, Site, ModuleInst>{
         }
 
         for (SitePinInst inPin : modInst.getCorrespondingPins(inPort)) {
+            Net oldPhysicalNet = inPin.getNet();
+            if (oldPhysicalNet != null) {
+                oldPhysicalNet.removePin(inPin, true);
+            }
             physicalNet.addPin(inPin);
         }
     }


### PR DESCRIPTION
Without this, any `SitePinInst`-s associated with the `ModuleInst` which were previously on an old net will remain there, while the pin is also inserted into the new net.