### PR TITLE
Enables large FPGA Interchange devices for placement

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesExample.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesExample.java
@@ -23,7 +23,6 @@
 
 package com.xilinx.rapidwright.interchange;
 
-import java.io.File;
 import java.io.IOException;
 
 import com.xilinx.rapidwright.device.Device;
@@ -31,11 +30,18 @@ import com.xilinx.rapidwright.tests.CodePerfTracker;
 
 public class DeviceResourcesExample {
 
+    public static final String SKIP_ROUTE_RESOURCES_OPTION = "--skip_route_resources";
+
     public static void main(String[] args) throws IOException {
-        if (args.length != 1) {
-            System.out.println("USAGE: <device name>");
+        if (args.length != 1 && args.length != 2) {
+            System.out.println("USAGE: <device name> [" + SKIP_ROUTE_RESOURCES_OPTION + "]");
             System.out.println("   Example dump of device information for interchange format.");
             return;
+        }
+
+        boolean skipRouteResources = false;
+        if (args.length == 2 && args[1].equals(SKIP_ROUTE_RESOURCES_OPTION)) {
+            skipRouteResources = true;
         }
 
         CodePerfTracker t = new CodePerfTracker("Device Resources Dump: " + args[0]);
@@ -43,15 +49,12 @@ public class DeviceResourcesExample {
 
         // Create device resource file if it doesn't exist
         String capnProtoFileName = args[0] + ".device";
-        //if (!new File(capnProtoFileName).exists()) {
-            //MessageGenerator.waitOnAnyKey();
-            t.start("Load Device");
-            Device device = Device.getDevice(args[0]);
-            t.stop();
-            // Write Netlist to Cap'n Proto Serialization file
-            DeviceResourcesWriter.writeDeviceResourcesFile(args[0], device, t, capnProtoFileName);
-            Device.releaseDeviceReferences();
-        //}
+        t.start("Load Device");
+        Device device = Device.getDevice(args[0]);
+        t.stop();
+        // Write Netlist to Cap'n Proto Serialization file
+        DeviceResourcesWriter.writeDeviceResourcesFile(args[0], device, t, capnProtoFileName, skipRouteResources);
+        Device.releaseDeviceReferences();
 
         t.start("Verify file");
         // Verify device resources

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -141,7 +141,7 @@ public class DeviceResourcesVerifier {
         design.setPartName(deviceName);
 
         DeviceResources.Device.Reader dReader = null;
-        ReaderOptions readerOptions = new ReaderOptions(1024L*1024L*1024L*16L, 64);
+        ReaderOptions readerOptions = new ReaderOptions(1024L * 1024L * 1024L * 64L, 64);
         MessageReader readMsg = null;
         readMsg = Interchange.readInterchangeFile(devResFileName, readerOptions);
 


### PR DESCRIPTION
This adds an option (`--skip_route_resources`) to `DeviceResourcesExample` that will skip adding wires and nodes to the device model FPGA Interchange file.  Currently there are a couple of issues (#410, also see https://github.com/Xilinx/RapidWright/issues/176#issuecomment-1030410003) that would prevent large designs from being written out with routing.  

This also fixes a performance bug that caused the `Cell <-> BEL pin map:` phase to take almost 20 minutes, with this change it now takes about 2 minutes.

The output from a run with the following parameters:

`java -Xmx32000m com.xilinx.rapidwright.interchange.DeviceResourcesExample xcvu19p --skip_route_resources`

```
            Prims&Macros:     0.812s     65.209MBs          |   1652.207MBs (peak)
    Cell <-> BEL pin map:   140.047s      0.565MBs          |   5249.344MBs (peak)
                Packages:     0.032s      0.179MBs          |   5253.449MBs (peak)
               Constants:    73.127s   2530.729MBs          |   8781.207MBs (peak)
              Wire Types:     0.011s     -0.373MBs          |   8781.207MBs (peak)
                 Strings:     0.699s     94.670MBs          |   8781.207MBs (peak)
              Write File:     5.147s      0.010MBs          |   8781.207MBs (peak)
             Verify file:   779.180s   3381.796MBs          |  24665.059MBs (peak)
------------------------------------------------------------------------------
                 *Total*:  1004.774s   6878.560MBs          |  24665.059MBs (peak)
```