### PR TITLE
Fix for #632 - Detect unsupported RWRoute devices

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -27,6 +27,7 @@ package com.xilinx.rapidwright.rwroute;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -157,12 +158,10 @@ public class RWRoute{
     /** A map storing routes from CLK_OUT to different INT tiles that connect to sink pins of a global clock net */
     protected Map<String, List<String>> routesToSinkINTTiles;
 
-    public static final Set<Series> SUPPORTED_SERIES;
+    public static final EnumSet<Series> SUPPORTED_SERIES;
 
     static {
-        SUPPORTED_SERIES = new HashSet<>();
-        SUPPORTED_SERIES.add(Series.UltraScale);
-        SUPPORTED_SERIES.add(Series.UltraScalePlus);
+        SUPPORTED_SERIES = EnumSet.of(Series.UltraScale, Series.UltraScalePlus);
     }
 
     public RWRoute(Design design, RWRouteConfig config) {

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -23,22 +23,27 @@
 
 package com.xilinx.rapidwright.rwroute;
 
-import com.xilinx.rapidwright.design.Design;
-import com.xilinx.rapidwright.design.Net;
-import com.xilinx.rapidwright.design.SiteInst;
-import com.xilinx.rapidwright.design.SitePinInst;
-import com.xilinx.rapidwright.device.Device;
-import com.xilinx.rapidwright.support.LargeTest;
-import com.xilinx.rapidwright.support.RapidWrightDCP;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.design.SitePinInst;
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Part;
+import com.xilinx.rapidwright.device.PartNameTools;
+import com.xilinx.rapidwright.device.Series;
+import com.xilinx.rapidwright.support.LargeTest;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
 
 public class TestRWRoute {
     private static void assertAllSinksRouted(List<SitePinInst> pins) {
@@ -217,5 +222,21 @@ public class TestRWRoute {
 
         Assertions.assertTrue(pinsToRoute.stream().allMatch(SitePinInst::isRouted));
         Assertions.assertTrue(Long.valueOf(System.getProperty("rapidwright.rwroute.nodesPopped")) <= nodesPoppedLimit);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Series.class)
+    public void testRWRouteDeviceSupport(Series series) {
+        for (Part part : PartNameTools.getAllParts(series)) {
+            Design design = new Design("test", part.getName());
+            if (!RWRoute.SUPPORTED_SERIES.contains(series)) {
+                RuntimeException e = Assertions.assertThrows(RuntimeException.class,
+                        () -> RWRoute.routeDesignFullNonTimingDriven(design),
+                        "Expected RuntimeException() but was not thrown.");
+                Assertions.assertTrue(e.getMessage().equals(RWRoute.getUnsupportedSeriesMessage(part)));
+            }
+            // Only test one part per series
+            break;
+        }
     }
 }


### PR DESCRIPTION
Address issue in #632 by detecting upfront if a targeted device is supported by RWRoute.