### PR TITLE
DesignTools.createCeSrRstPinsToVCC() to detect gnd to invert

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2854,8 +2854,6 @@ public class DesignTools {
         for (Cell cell : design.getCells()) {
             if (isUnisimFlipFlopType(cell.getType())) {
                 SiteInst si = cell.getSiteInst();
-                if (si.getSiteName().equals("SLICE_X58Y149"))
-                    System.err.print("");
                 BEL bel = cell.getBEL();
                 Pair<String, String> sitePinNames = belSitePinNameMapping.get(bel.getBELType());
                 String[] pins = new String[] {"CE", "SR"};

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
+import com.xilinx.rapidwright.design.tools.LUTTools;
 import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.device.SitePIP;
 import org.capnproto.MessageReader;
@@ -117,8 +118,6 @@ public class PhysNetlistReader {
         readRouting(physNetlist, design, allStrings);
 
         readDesignProperties(physNetlist, design, allStrings);
-
-        postProcess(design);
 
         return design;
     }
@@ -797,36 +796,6 @@ public class PhysNetlistReader {
                     }
                 }
 
-            }
-        }
-    }
-
-    private static void postProcess(Design design) {
-        final Series series = design.getDevice().getSeries();
-
-        if (series == Series.UltraScalePlus || series == Series.UltraScale) {
-            // To be consistent with Vivado DCPs, remove all intra-site routing for
-            // SRST* pins tied to ground on these series of devices.
-            // (Note: this condition is necessary for {@link DesignTools#createCeSrRstPinsToVCC()})
-            String[] siteWires = new String[]{"RST_ABCDINV_OUT", "RST_EFGHINV_OUT"};
-            for (SiteInst si : design.getSiteInsts()) {
-                if (!Utils.isSLICE(si)) {
-                    continue;
-                }
-                for (String sw : siteWires) {
-                    Net net = si.getNetFromSiteWire(sw);
-                    if (net != null && net.getType() == NetType.GND) {
-                        BELPin belPin = si.getSiteWirePins(sw)[0];
-                        assert(belPin.isOutput());
-                        BEL bel = belPin.getBEL();
-                        assert(bel.getBELClass() == BELClass.RBEL);
-                        assert(bel.getInvertingPin() == bel.getNonInvertingPin());
-                        SitePIP sp = si.getSitePIP(belPin);
-                        Net inputNet = si.getNetFromSiteWire(sp.getInputPin().getSiteWireName());
-                        assert(inputNet == null || inputNet.isStaticNet());
-                        si.unrouteIntraSiteNet(sp.getInputPin(), sp.getOutputPin());
-                    }
-                }
             }
         }
     }

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -35,7 +35,6 @@ import java.util.Set;
 
 import com.xilinx.rapidwright.design.tools.LUTTools;
 import com.xilinx.rapidwright.device.Series;
-import com.xilinx.rapidwright.device.SitePIP;
 import org.capnproto.MessageReader;
 import org.capnproto.PrimitiveList;
 import org.capnproto.ReaderOptions;

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -33,8 +33,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import com.xilinx.rapidwright.design.tools.LUTTools;
-import com.xilinx.rapidwright.device.Series;
 import org.capnproto.MessageReader;
 import org.capnproto.PrimitiveList;
 import org.capnproto.ReaderOptions;

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.


### PR DESCRIPTION
`DesignTools.createCeSrRstPinsToVCC()` to now create a `SRST[12]` site pin connected to the VCC net if the FF cell's sitewire is empty or connected to the GND net.

Also revert the `postProcess()` method of https://github.com/Xilinx/RapidWright/pull/636 which wrongly created the environment for triggering the old behaviour for adding this site pin.

Add support for UltraScale parts too.