### PR TITLE
[EDIF] More expanded macros to be deep copied from prim library

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1599,7 +1599,8 @@ public class EDIFNetlist extends EDIFName {
                 toAdd = Design.getUnisimCell(Unisim.valueOf(cellName));
             }
             // Add copy to prim library to avoid destructive changes when collapsed
-            new EDIFCell(netlistPrims, toAdd);
+            // Needs to be a deep copy because it may have child instances that will get updated
+            new EDIFCell(netlistPrims, toAdd, cellName);
         }
 
         // Update all cell references to macro versions

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -150,9 +150,6 @@ class TestEDIFNetlist {
         EDIFCell macroCell = macroLibrary.getCell("DSP48E2");
         Assertions.assertNotSame(macroCell, cell);
         Assertions.assertEquals(8, macroCell.getCellInsts().size());
-        for (EDIFCellInst eci : macroCell.getCellInsts()) {
-            Assertions.assertSame(primLibrary, eci.getCellType().getLibrary());
-        }
 
         testNetlist.expandMacroUnisims(part.getSeries());
 
@@ -169,7 +166,7 @@ class TestEDIFNetlist {
 
         // Check that original macro cell wasn't inadvertently modified
         for (EDIFCellInst eci : macroCell.getCellInsts()) {
-            Assertions.assertSame(primLibrary, eci.getCellType().getLibrary());
+            Assertions.assertNotSame(netlistPrimLibrary, eci.getCellType().getLibrary());
         }
 
         testNetlist.collapseMacroUnisims(part.getSeries());

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -178,7 +178,7 @@ class TestEDIFNetlist {
         // Check original macro cell wasn't affected
         Assertions.assertEquals(8, macroCell.getCellInsts().size());
         for (EDIFCellInst eci : macroCell.getCellInsts()) {
-            Assertions.assertSame(primLibrary, eci.getCellType().getLibrary());
+            Assertions.assertNotSame(netlistPrimLibrary, eci.getCellType().getLibrary());
         }
     }
 

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -132,6 +132,60 @@ class TestEDIFNetlist {
     }
 
     @Test
+    void testMacroExpansionInstanceTypes() {
+        final Part part = PartNameTools.getPart(Device.AWS_F1);
+        Design testDesign = createSamplePrimitiveDesign("DSP48E2", part);
+        EDIFNetlist testNetlist = testDesign.getNetlist();
+        EDIFLibrary netlistPrimLibrary = testNetlist.getHDIPrimitivesLibrary();
+
+        EDIFCell cell = netlistPrimLibrary.getCell("DSP48E2");
+        Assertions.assertTrue(cell.getCellInsts().isEmpty());
+
+        // Singleton libraries
+        EDIFLibrary macroLibrary = Design.getMacroPrimitives(part.getSeries());
+        EDIFLibrary primLibrary = Design.getPrimitivesLibrary();
+        // Netlist should have its own copy of the singleton library
+        Assertions.assertNotSame(netlistPrimLibrary, primLibrary);
+
+        EDIFCell macroCell = macroLibrary.getCell("DSP48E2");
+        Assertions.assertNotSame(macroCell, cell);
+        Assertions.assertEquals(8, macroCell.getCellInsts().size());
+        for (EDIFCellInst eci : macroCell.getCellInsts()) {
+            Assertions.assertSame(primLibrary, eci.getCellType().getLibrary());
+        }
+
+        testNetlist.expandMacroUnisims(part.getSeries());
+
+        // Expanded cell must not be the same cell as before, and be a copy
+        // of the macro library's cell
+        EDIFCell expandedCell = netlistPrimLibrary.getCell("DSP48E2");
+        Assertions.assertNotSame(expandedCell, cell);
+        Assertions.assertNotSame(expandedCell, macroCell);
+        Assertions.assertEquals(8, expandedCell.getCellInsts().size());
+        for (EDIFCellInst eci : expandedCell.getCellInsts()) {
+            // Its instances should also refer to netlist's primitive library copy
+            Assertions.assertSame(netlistPrimLibrary, eci.getCellType().getLibrary());
+        }
+
+        // Check that original macro cell wasn't inadvertently modified
+        for (EDIFCellInst eci : macroCell.getCellInsts()) {
+            Assertions.assertSame(primLibrary, eci.getCellType().getLibrary());
+        }
+
+        testNetlist.collapseMacroUnisims(part.getSeries());
+
+        EDIFCell collapsedCell = netlistPrimLibrary.getCell("DSP48E2");
+        Assertions.assertNotSame(collapsedCell, cell);
+        Assertions.assertTrue(collapsedCell.getCellInsts().isEmpty());
+
+        // Check original macro cell wasn't affected
+        Assertions.assertEquals(8, macroCell.getCellInsts().size());
+        for (EDIFCellInst eci : macroCell.getCellInsts()) {
+            Assertions.assertSame(primLibrary, eci.getCellType().getLibrary());
+        }
+    }
+
+    @Test
     public void testTrackChanges() {
         Design d = Design.readCheckpoint(RapidWrightDCP.getPath("microblazeAndILA_3pblocks.dcp"), true);
         EDIFNetlist netlist = d.getNetlist();

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -134,11 +134,12 @@ class TestEDIFNetlist {
     @Test
     void testMacroExpansionInstanceTypes() {
         final Part part = PartNameTools.getPart(Device.AWS_F1);
-        Design testDesign = createSamplePrimitiveDesign("DSP48E2", part);
+        String macroName = "DSP48E2";
+        Design testDesign = createSamplePrimitiveDesign(macroName, part);
         EDIFNetlist testNetlist = testDesign.getNetlist();
         EDIFLibrary netlistPrimLibrary = testNetlist.getHDIPrimitivesLibrary();
 
-        EDIFCell cell = netlistPrimLibrary.getCell("DSP48E2");
+        EDIFCell cell = netlistPrimLibrary.getCell(macroName);
         Assertions.assertTrue(cell.getCellInsts().isEmpty());
 
         // Singleton libraries
@@ -147,7 +148,7 @@ class TestEDIFNetlist {
         // Netlist should have its own copy of the singleton library
         Assertions.assertNotSame(netlistPrimLibrary, primLibrary);
 
-        EDIFCell macroCell = macroLibrary.getCell("DSP48E2");
+        EDIFCell macroCell = macroLibrary.getCell(macroName);
         Assertions.assertNotSame(macroCell, cell);
         Assertions.assertEquals(8, macroCell.getCellInsts().size());
 
@@ -155,7 +156,7 @@ class TestEDIFNetlist {
 
         // Expanded cell must not be the same cell as before, and be a copy
         // of the macro library's cell
-        EDIFCell expandedCell = netlistPrimLibrary.getCell("DSP48E2");
+        EDIFCell expandedCell = netlistPrimLibrary.getCell(macroName);
         Assertions.assertNotSame(expandedCell, cell);
         Assertions.assertNotSame(expandedCell, macroCell);
         Assertions.assertEquals(8, expandedCell.getCellInsts().size());
@@ -171,7 +172,7 @@ class TestEDIFNetlist {
 
         testNetlist.collapseMacroUnisims(part.getSeries());
 
-        EDIFCell collapsedCell = netlistPrimLibrary.getCell("DSP48E2");
+        EDIFCell collapsedCell = netlistPrimLibrary.getCell(macroName);
         Assertions.assertNotSame(collapsedCell, cell);
         Assertions.assertTrue(collapsedCell.getCellInsts().isEmpty());
 


### PR DESCRIPTION
Before this, a macro cell in the global/singleton macro library was only shallow-copied into a netlist's private primitive library.

As part of macro expansion, the child instances of a macro are also updated to instantiate cells in the netlist's private library. However, because the instance list was only shallow copied, this ended up modifying the global macro's instance list too.

The end result was that the global macro library now holds a reference to a particular user netlist, which blocks it from being garbage collected.