### PR TITLE
Ignore TestCheckOpenFilesInstalled.test if outside of gradle

### DIFF
--- a/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
+++ b/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Eddie Hung, Xilinx Research Labs.
@@ -32,13 +32,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.engine.config.JupiterConfiguration;
 
 /**
  * Check that a testcase does leak open files
@@ -137,10 +141,18 @@ public class CheckOpenFilesExtension implements BeforeTestExecutionCallback, Aft
         Assertions.assertNotNull(getBeforeList(extensionContext), "Open Files Checker Extension does not seem to be running");
     }
 
-    public static class CheckOpenFilesWorkingExtension implements AfterTestExecutionCallback {
+    public static class CheckOpenFilesWorkingExtension implements AfterTestExecutionCallback, ExecutionCondition {
         @Override
         public void afterTestExecution(ExtensionContext context) {
             assertExtensionInstalled(context);
+        }
+
+        @Override
+        public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+            Optional<String> extensions = context.getConfigurationParameter(JupiterConfiguration.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME);
+            if ("true".equals(extensions.orElse("false")))
+                return ConditionEvaluationResult.enabled(JupiterConfiguration.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME + " == true");
+            return ConditionEvaluationResult.disabled(JupiterConfiguration.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME + " != true");
         }
     }
 }

--- a/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
+++ b/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -140,6 +141,9 @@ public class CheckOpenFilesExtension implements BeforeTestExecutionCallback, Aft
     public static class CheckOpenFilesWorkingExtension implements AfterTestExecutionCallback {
         @Override
         public void afterTestExecution(ExtensionContext context) {
+            // if "gradle" not in command line ignore this test
+            boolean gradleStart = ManagementFactory.getRuntimeMXBean().getInputArguments().stream().anyMatch(n -> n.contains("gradle"));
+            Assumptions.assumeTrue(gradleStart);
             assertExtensionInstalled(context);
         }
     }

--- a/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
+++ b/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
@@ -149,6 +149,9 @@ public class CheckOpenFilesExtension implements BeforeTestExecutionCallback, Aft
 
         @Override
         public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+            // Only run this extension (used by TestCheckOpenFilesInstalled) when extensions
+            // are enabled which should be the case when invoked by through Gradle, but not
+            // necessarily through an IDE
             Optional<String> extensions = context.getConfigurationParameter(JupiterConfiguration.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME);
             if ("true".equals(extensions.orElse("false")))
                 return ConditionEvaluationResult.enabled(JupiterConfiguration.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME + " == true");

--- a/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
+++ b/test/shared/com/xilinx/rapidwright/support/CheckOpenFilesExtension.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -141,9 +140,6 @@ public class CheckOpenFilesExtension implements BeforeTestExecutionCallback, Aft
     public static class CheckOpenFilesWorkingExtension implements AfterTestExecutionCallback {
         @Override
         public void afterTestExecution(ExtensionContext context) {
-            // if "gradle" not in command line ignore this test
-            boolean gradleStart = ManagementFactory.getRuntimeMXBean().getInputArguments().stream().anyMatch(n -> n.contains("gradle"));
-            Assumptions.assumeTrue(gradleStart);
             assertExtensionInstalled(context);
         }
     }

--- a/test/src/com/xilinx/rapidwright/TestCheckOpenFilesInstalled.java
+++ b/test/src/com/xilinx/rapidwright/TestCheckOpenFilesInstalled.java
@@ -27,18 +27,12 @@ import java.io.IOException;
 
 import com.xilinx.rapidwright.support.CheckOpenFilesExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 public class TestCheckOpenFilesInstalled {
     @Test
-    @EnabledIf("runningInGradle")
     @ExtendWith(CheckOpenFilesExtension.CheckOpenFilesWorkingExtension.class)
     public void test() throws IOException {
         //Actual test is in extension
-    }
-
-    private boolean runningInGradle() {
-        return "true".equals(System.getProperty("junit.jupiter.extensions.autodetection.enabled"));
     }
 }

--- a/test/src/com/xilinx/rapidwright/TestCheckOpenFilesInstalled.java
+++ b/test/src/com/xilinx/rapidwright/TestCheckOpenFilesInstalled.java
@@ -27,12 +27,18 @@ import java.io.IOException;
 
 import com.xilinx.rapidwright.support.CheckOpenFilesExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 public class TestCheckOpenFilesInstalled {
     @Test
+    @EnabledIf("runningInGradle")
     @ExtendWith(CheckOpenFilesExtension.CheckOpenFilesWorkingExtension.class)
     public void test() throws IOException {
         //Actual test is in extension
+    }
+
+    private boolean runningInGradle() {
+        return System.getProperties().keySet().toString().contains("gradle");
     }
 }

--- a/test/src/com/xilinx/rapidwright/TestCheckOpenFilesInstalled.java
+++ b/test/src/com/xilinx/rapidwright/TestCheckOpenFilesInstalled.java
@@ -39,6 +39,6 @@ public class TestCheckOpenFilesInstalled {
     }
 
     private boolean runningInGradle() {
-        return System.getProperty("junit.jupiter.extensions.autodetection.enabled") != null;
+        return "true".equals(System.getProperty("junit.jupiter.extensions.autodetection.enabled"));
     }
 }

--- a/test/src/com/xilinx/rapidwright/TestCheckOpenFilesInstalled.java
+++ b/test/src/com/xilinx/rapidwright/TestCheckOpenFilesInstalled.java
@@ -39,6 +39,6 @@ public class TestCheckOpenFilesInstalled {
     }
 
     private boolean runningInGradle() {
-        return System.getProperties().keySet().toString().contains("gradle");
+        return System.getProperty("junit.jupiter.extensions.autodetection.enabled") != null;
     }
 }


### PR DESCRIPTION
PR #397 modified the gradle environment such that every testcase is automatically extended with methods to ensure the test closes all of the files it opens. However when run outside of gradle (e.g. in an IDE) the testcase that checks to see if this extension is running obviously fails. This commit adds a conditional to skip the test if run outside of gradle.