### PR TITLE
[EDIF] EDIFNetlist.collapseMacroUnisims() to not clobber cell

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -259,7 +259,7 @@ public class EDIFNetlist extends EDIFName {
         if (cell == null) {
             cell = Design.getUnisimCell(unisim);
         }
-        return lib.addCell(cell);
+        return new EDIFCell(lib, cell, unisim.name());
     }
 
     public EDIFLibrary getWorkLibrary() {

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -257,9 +257,9 @@ public class EDIFNetlist extends EDIFName {
         EDIFLibrary lib = getHDIPrimitivesLibrary();
         EDIFCell cell = lib.getCell(unisim.name());
         if (cell == null) {
-            cell = Design.getUnisimCell(unisim);
+            cell = new EDIFCell(lib, cell, unisim.name());
         }
-        return new EDIFCell(lib, cell, unisim.name());
+        return cell;
     }
 
     public EDIFLibrary getWorkLibrary() {

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -42,6 +42,7 @@ import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -1639,29 +1640,26 @@ public class EDIFNetlist extends EDIFName {
                                 throw new RuntimeException("failed to find cell macro "+cellName+", we are in "+lib.getName());
                             }
                             primsToRemoveOnCollapse.add(cellName);
-                            EDIFCell copy = new EDIFCell(netlistPrims, macro, cellName);
-                            if (copy.getCellInsts().size() > 0) {
-                                for (EDIFCellInst copyInst : copy.getCellInsts()) {
-                                    EDIFCell primCell = netlistPrims.getCell(copyInst.getCellType().getName());
-                                    if (primCell == null) {
-                                        primCell = new EDIFCell(netlistPrims, copyInst.getCellType());
-                                        primsToRemoveOnCollapse.add(copyInst.getCellType().getName());
-                                    }
-                                    copyInst.setCellType(primCell);
+                            newCell = new EDIFCell(netlistPrims, macro, cellName);
+                            for (EDIFCellInst childInst : newCell.getCellInsts()) {
+                                EDIFCell primCell = netlistPrims.getCell(childInst.getCellType().getName());
+                                if (primCell == null) {
+                                    primCell = new EDIFCell(netlistPrims, childInst.getCellType());
+                                    primsToRemoveOnCollapse.add(childInst.getCellType().getName());
                                 }
+                                childInst.setCellType(primCell);
                             }
-                            newCell = copy;
                         }
+                        assert(newCell == netlistPrims.getCell(cellName));
                         inst.setCellType(newCell);
-                        for (EDIFCellInst childInst : newCell.getCellInsts()) {
-                            // Check if we already have a copy
-                            EDIFCell existingCellType = netlistPrims.getCell(childInst.getCellName());
-                            if (existingCellType == null) {
-                                existingCellType = new EDIFCell(netlistPrims, childInst.getCellType());
-                                primsToRemoveOnCollapse.add(existingCellType.getName());
-                            }
-                            childInst.setCellType(existingCellType);
-                        }
+                    }
+                }
+            }
+            for (EDIFCell cell : lib.getCells()) {
+                for (EDIFNet net : cell.getNets()) {
+                    for (EDIFPortInst portInst : net.getPortInsts()) {
+                        EDIFCell parent = portInst.getPort().getParentCell();
+                        assert (parent.getLibrary().getCell(parent.getName()) == parent);
                     }
                 }
             }
@@ -1679,15 +1677,41 @@ public class EDIFNetlist extends EDIFName {
         ArrayList<EDIFCell> reinsert = new ArrayList<EDIFCell>();
         Map<String, Pair<String, EnumSet<IOStandard>>> seriesMacroCollapseExceptionMap =
                 macroCollapseExceptionMap.getOrDefault(series, Collections.emptyMap());
+        Map<EDIFCell, EDIFCell> updateCellTypes = new IdentityHashMap<>();
         for (EDIFCell cell : prims.getCells()) {
             if (macros.containsCell(cell.getName())) {
                 cell.makePrimitive();
-                if (seriesMacroCollapseExceptionMap.containsKey(cell.getName())) {
-                    cell.rename(seriesMacroCollapseExceptionMap.get(cell.getName()).getFirst());
-                    reinsert.add(cell);
+                Pair<String, EnumSet<IOStandard>> exception = seriesMacroCollapseExceptionMap.get(cell.getName());
+                if (exception != null) {
+                    EDIFCell existingCell = prims.getCell(exception.getFirst());
+                    if (existingCell != null) {
+                        // Existing cell (e.g. OBUFDS) already exists/used in primitives library
+                        // thus cannot simply rename it (e.g. from OBUFDS_DUAL_BUF)
+                        updateCellTypes.put(cell, existingCell);
+                    } else {
+                        cell.rename(exception.getFirst());
+                        reinsert.add(cell);
+                    }
                 }
             }
         }
+
+        if (!updateCellTypes.isEmpty()) {
+            // Update all cell references
+            for (EDIFLibrary lib : getLibraries()) {
+                if (lib.isHDIPrimitivesLibrary())
+                    continue;
+                for (EDIFCell cell : new ArrayList<>(lib.getCells())) {
+                    for (EDIFCellInst inst : cell.getCellInsts()) {
+                        EDIFCell newCellType = updateCellTypes.get(inst.getCellType());
+                        if (newCellType != null) {
+                            inst.setCellType(newCellType);
+                        }
+                    }
+                }
+            }
+        }
+
         for (EDIFCell cell : reinsert) {
             prims.removeCell(cell);
             prims.addCell(cell);

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -257,7 +257,7 @@ public class EDIFNetlist extends EDIFName {
         EDIFLibrary lib = getHDIPrimitivesLibrary();
         EDIFCell cell = lib.getCell(unisim.name());
         if (cell == null) {
-            cell = new EDIFCell(lib, cell, unisim.name());
+            cell = new EDIFCell(lib, Design.getUnisimCell(unisim), unisim.name());
         }
         return cell;
     }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -487,7 +487,7 @@ class TestEDIFNetlist {
 
         EDIFCell top = netlist.getTopCell();
         EDIFPort port = top.createPort("O", EDIFDirection.OUTPUT, 1);
-        EDIFCellInst obufds = top.createChildCellInst("obuf", Design.getPrimitivesLibrary().getCell("OBUFDS"));
+        EDIFCellInst obufds = top.createChildCellInst("obuf", netlist.getHDIPrimitive(Unisim.OBUFDS));
         netlist.getHDIPrimitivesLibrary().addCell(obufds.getCellType());
         EDIFNet net = top.createNet("O");
         new EDIFPortInst(port, net);

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.device.Series;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -91,17 +92,57 @@ class TestEDIFNetlist {
         Design loadAgain = Design.readCheckpoint(outputDCP);
         Assertions.assertTrue(loadAgain.getNetlist().getHDIPrimitivesLibrary().containsCell("OBUFTDS"));
 
-        final Part part2 = PartNameTools.getPart(Device.KCU105);
-        Design testDesign2 = createSamplePrimitiveDesign("OBUFDS", part2);
-        testDesign2.getNetlist().expandMacroUnisims(part.getSeries());
-        Assertions.assertTrue(testDesign2.getNetlist().getHDIPrimitivesLibrary().containsCell("OBUFDS_DUAL_BUF"));
-        testDesign2.getNetlist().collapseMacroUnisims(part.getSeries());
-        Assertions.assertTrue(testDesign2.getNetlist().getHDIPrimitivesLibrary().containsCell("OBUFDS"));
-        Assertions.assertFalse(testDesign2.getNetlist().getHDIPrimitivesLibrary().containsCell("OBUFDS_DUAL_BUF"));
+        Design testDesign2 = createSamplePrimitiveDesign("OBUFDS", part);
+        EDIFNetlist testNetlist2 = testDesign2.getNetlist();
+
+        testNetlist2.expandMacroUnisims(part.getSeries());
+
+        Assertions.assertTrue(testNetlist2.getHDIPrimitivesLibrary().containsCell("OBUFDS_DUAL_BUF"));
+
+        testNetlist2.collapseMacroUnisims(part.getSeries());
+
+        Assertions.assertTrue(testNetlist2.getHDIPrimitivesLibrary().containsCell("OBUFDS"));
+        Assertions.assertFalse(testNetlist2.getHDIPrimitivesLibrary().containsCell("OBUFDS_DUAL_BUF"));
         testDesign2.getTopEDIFCell().getCellInst("testOBUFDS").addProperty("IOStandard", IOStandard.LVCMOS12.name());
-        testDesign2.getNetlist().expandMacroUnisims(part.getSeries());
-        Assertions.assertTrue(testDesign2.getNetlist().getHDIPrimitivesLibrary().containsCell("OBUFDS"));
-        Assertions.assertFalse(testDesign2.getNetlist().getHDIPrimitivesLibrary().containsCell("OBUFDS_DUAL_BUF"));
+
+        testNetlist2.expandMacroUnisims(part.getSeries());
+
+        Assertions.assertTrue(testNetlist2.getHDIPrimitivesLibrary().containsCell("OBUFDS"));
+        Assertions.assertFalse(testNetlist2.getHDIPrimitivesLibrary().containsCell("OBUFDS_DUAL_BUF"));
+    }
+
+    @Test
+    void testMacroExpansionWithAndWithoutException() {
+        final Part part = PartNameTools.getPart(PART_NAME);
+        Design testDesign = createSamplePrimitiveDesign("OBUFDS", part);
+
+        EDIFNetlist testNetlist = testDesign.getNetlist();
+        testNetlist.setDevice(testDesign.getDevice());
+
+        EDIFCellInst wontBeExpanded = testDesign.getTopEDIFCell().getCellInst("testOBUFDS");
+        wontBeExpanded.addProperty("IOStandard", IOStandard.LVCMOS12.name());
+        EDIFCellInst willBeExpanded = testNetlist.getTopCell().createChildCellInst("willBeExpanded", testNetlist.getHDIPrimitive(Unisim.OBUFDS));
+
+        testNetlist.expandMacroUnisims(part.getSeries());
+
+        EDIFCell obufdsCell = testNetlist.getHDIPrimitivesLibrary().getCell("OBUFDS");
+        EDIFCell obufdsDualBufCell = testNetlist.getHDIPrimitivesLibrary().getCell("OBUFDS_DUAL_BUF");
+
+        Assertions.assertSame(obufdsCell, wontBeExpanded.getCellType());
+        Assertions.assertSame(obufdsDualBufCell, willBeExpanded.getCellType());
+
+        testNetlist.collapseMacroUnisims(part.getSeries());
+
+        Assertions.assertSame(obufdsCell, testNetlist.getHDIPrimitivesLibrary().getCell("OBUFDS"));
+        Assertions.assertFalse(testNetlist.getHDIPrimitivesLibrary().containsCell("OBUFDS_DUAL_BUF"));
+
+        Assertions.assertSame(obufdsCell, wontBeExpanded.getCellType());
+        Assertions.assertSame(obufdsCell, willBeExpanded.getCellType());
+
+        testNetlist.expandMacroUnisims(part.getSeries());
+
+        Assertions.assertNotSame(obufdsCell, testNetlist.getHDIPrimitivesLibrary().getCell("OBUFDS"));
+        Assertions.assertNotSame(obufdsDualBufCell, testNetlist.getHDIPrimitivesLibrary().getCell("OBUFDS_DUAL_BUF"));
     }
 
     @Test


### PR DESCRIPTION
.. plus optimize `expandMacroUnisims()`.

Currently, the following scenario is not considered:
* Design has `OBUFDS` cell instantiations
* Only some of those `OBUFDS` cells are expanded into `OBUFDS_DUAL_BUF`
* Collapsing causes the `OBUFDS_DUAL_BUF` cell to be renamed to `OBUFDS`, without awareness that `OBUFDS` already exists.
* Now there are two `OBUFDS` cells being instantiated in the netlist, but only one in the library.



