### PR TITLE
MainEntrypoint to print application list in columns

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -184,10 +184,7 @@ public class MainEntrypoint {
     }
 
     private static void listModes() {
-        for (String name : functionNames) {
-            System.err.print('\t');
-            System.err.println(name);
-        }
+        StringTools.printListInColumns(functionNames, System.err);
     }
 
     public static void main(String[] args) throws Throwable {

--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -184,7 +184,7 @@ public class MainEntrypoint {
     }
 
     private static void listModes() {
-        StringTools.printListInColumns(functionNames, System.err);
+        StringTools.printListInColumns(functionNames, System.err, 5);
     }
 
     public static void main(String[] args) throws Throwable {

--- a/src/com/xilinx/rapidwright/router/Router.java
+++ b/src/com/xilinx/rapidwright/router/Router.java
@@ -67,6 +67,7 @@ import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.MessageGenerator;
+import com.xilinx.rapidwright.util.StringTools;
 import com.xilinx.rapidwright.util.Utils;
 
 
@@ -449,7 +450,8 @@ public class Router extends AbstractRouter {
         if (debug) System.out.println(" SRC: " + end.getTile().getName());
         if (debug) System.out.println("SINK: " + snk.getTile().getName());
         while ((Math.abs(x) > LONG_LINE_THRESHOLD || Math.abs(y) > LONG_LINE_THRESHOLD) && watchDog > 0 && !longLineQueue.isEmpty()) {
-            if (debug) System.out.println(MessageGenerator.makeWhiteSpace(end.getLevel()) + end.toString());
+            if (debug)
+                System.out.println(StringTools.makeWhiteSpace(end.getLevel()) + end.toString());
             watchDog--;
 
             end = longLineQueue.remove();
@@ -464,7 +466,9 @@ public class Router extends AbstractRouter {
                 String wireName = wc.getWireName();
                 if (intNodeQuadLongs.contains(wireName) || allLongLines.contains(wireName)) {
                     tmp.setTileAndWire(wc);
-                    if (debug) System.out.println(MessageGenerator.makeWhiteSpace(end.getLevel()) +" -> "+ tmp.toString() +" "+ visited.contains(tmp) +" "+ usedNodes.contains(tmp));
+                    if (debug)
+                        System.out.println(StringTools.makeWhiteSpace(end.getLevel()) + " -> " + tmp.toString() + " "
+                                + visited.contains(tmp) + " " + usedNodes.contains(tmp));
                     if (visited.contains(tmp)) continue;
                     if (!canUseNode(tmp)) continue;
 
@@ -488,7 +492,9 @@ public class Router extends AbstractRouter {
                     visited.add(start);
                 }
             }
-            if (debug) System.out.println(MessageGenerator.makeWhiteSpace(end.getLevel()) + "NEXT: " + end.toString() + ": CLOSEST=" + closest.toString());
+            if (debug)
+                System.out.println(StringTools.makeWhiteSpace(end.getLevel()) + "NEXT: " + end.toString() + ": CLOSEST="
+                        + closest.toString());
             x = end.getTile().getTileXCoordinate() - snk.getTile().getTileXCoordinate();
             y = end.getTile().getTileYCoordinate() - snk.getTile().getTileYCoordinate();
         }
@@ -555,7 +561,9 @@ public class Router extends AbstractRouter {
                 return;
             }
             RouteNode currNode = queue.remove();
-            if (debug) System.out.println(MessageGenerator.makeWhiteSpace(currNode.getLevel()) + currNode.toString() + " " + currNode.getIntentCode() + " *DQ*");
+            if (debug)
+                System.out.println(StringTools.makeWhiteSpace(currNode.getLevel()) + currNode.toString() + " "
+                        + currNode.getIntentCode() + " *DQ*");
             nodesProcessed++;
             nextNode: for (Wire w : currNode.getConnections()) {
                 if (currNode.equals(currSink) || (w.getWireIndex() == this.currSink.getWire() && w.getTile().equals(currSink.getTile()))) {
@@ -683,7 +691,7 @@ public class Router extends AbstractRouter {
                             // This looks like a possible candidate for our next node, we'll add it
                             setCost(tmp, w.isRouteThru());
                             if (debug) {
-                                System.out.println(MessageGenerator.makeWhiteSpace(currNode.getLevel())
+                                System.out.println(StringTools.makeWhiteSpace(currNode.getLevel())
                                         + " -> " + tmp + " " + tmp.getIntentCode());
                             }
                             if (queue.isEmpty() || tmp.getCost() < (queue.peek().getCost() + ceilingCost)) {
@@ -1252,7 +1260,9 @@ public class Router extends AbstractRouter {
                         if (tmp.getConnections() != null && canUseNode(tmp)) {
                             setClkCostLevel(tmp);
                             visitedNodes.add(tmp);
-                            if (debug)System.out.println(MessageGenerator.makeWhiteSpace(currRouteNode.getLevel()) + " -> " + tmp + " " + tmp.getIntentCode());
+                            if (debug)
+                                System.out.println(StringTools.makeWhiteSpace(currRouteNode.getLevel()) + " -> " + tmp
+                                        + " " + tmp.getIntentCode());
                             queue.add(tmp);
                         }
                     }
@@ -1286,7 +1296,9 @@ public class Router extends AbstractRouter {
                         if (tmp.getConnections() != null && canUseNode(tmp)) {
                             setClkCostLevel(tmp);
                             visitedNodes.add(tmp);
-                            if (debug)System.out.println(MessageGenerator.makeWhiteSpace(currRouteNode.getLevel()) + " -> " + tmp + " " + tmp.getIntentCode());
+                            if (debug)
+                                System.out.println(StringTools.makeWhiteSpace(currRouteNode.getLevel()) + " -> " + tmp
+                                        + " " + tmp.getIntentCode());
                             queue.add(tmp);
                         }
                     }
@@ -1466,7 +1478,9 @@ public class Router extends AbstractRouter {
                                     }
                                 }
                         }
-                        if (debug) System.out.println(MessageGenerator.makeWhiteSpace(currNode.getLevel()) + " -> " + tmp + " " + tmp.getIntentCode());
+                        if (debug)
+                            System.out.println(StringTools.makeWhiteSpace(currNode.getLevel()) + " -> " + tmp + " "
+                                    + tmp.getIntentCode());
                         setClkCostDistance(tmp, currSink);
                         visitedNodes.add(tmp);
                         clockQueue.add(tmp);
@@ -1603,7 +1617,7 @@ public class Router extends AbstractRouter {
                     conflictNodes = new HashSet<RouteNode>();
                 }
                 while (currPathNode.getParent() != null) {
-                    if (debug) System.out.println("CL: " + MessageGenerator.makeWhiteSpace(currPathNode.getLevel()) + currPathNode.toString());
+                    if (debug) System.out.println("CL: " + StringTools.makeWhiteSpace(currPathNode.getLevel()) + currPathNode.toString());
                     if (allowWireOverlap) {
                         if (usedNodes.contains(currPathNode)) {
                             conflictNodes.add(currPathNode);

--- a/src/com/xilinx/rapidwright/util/DeviceTools.java
+++ b/src/com/xilinx/rapidwright/util/DeviceTools.java
@@ -51,7 +51,7 @@ public class DeviceTools {
         while (!q.isEmpty()) {
             RouteNode curr = q.poll();
             if (curr.getLevel() > depth) continue;
-            System.out.println(MessageGenerator.makeWhiteSpace(curr.getLevel()) + curr);
+            System.out.println(StringTools.makeWhiteSpace(curr.getLevel()) + curr);
             for (Wire w : curr.getConnections()) {
                 RouteNode next = new RouteNode(w.getTile(),w.getWireIndex(),curr,curr.getLevel()+1);
                 if (next.getConnections().isEmpty()) continue;

--- a/src/com/xilinx/rapidwright/util/MessageGenerator.java
+++ b/src/com/xilinx/rapidwright/util/MessageGenerator.java
@@ -117,8 +117,8 @@ public class MessageGenerator{
         String left;
         String right;
         double whiteSpace = (72 - s.length())/2.0;
-        left = MessageGenerator.makeWhiteSpace((int)(whiteSpace));
-        right = MessageGenerator.makeWhiteSpace((int)(whiteSpace+0.5));
+        left = StringTools.makeWhiteSpace((int) (whiteSpace));
+        right = StringTools.makeWhiteSpace((int) (whiteSpace + 0.5));
         System.out.println(bar);
         System.out.println("== "+ left + s + right +" ==");
         System.out.println(bar);
@@ -126,17 +126,13 @@ public class MessageGenerator{
 
     /**
      * Creates a whitespace string with length number of spaces.
+     * 
      * @param length Number of spaces in the string.
      * @return The newly created whitespace string.
+     * @deprecated to be removed in 2023.2.0
      */
     public static String makeWhiteSpace(int length) {
-        if (length < 1)
-            return "";
-        StringBuilder sb = new StringBuilder(length);
-        for (int i=0; i<length; i++) {
-            sb.append(" ");
-        }
-        return sb.toString();
+        return StringTools.makeWhiteSpace(length);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/util/StringTools.java
+++ b/src/com/xilinx/rapidwright/util/StringTools.java
@@ -257,9 +257,31 @@ public class StringTools {
         return length < 1 ? "" : new String(new char[length]).replace('\0', ' ');
     }
 
-    private static final int COLUMN_SPACING = 2;
+    /**
+     * Number of spaces between column prints in
+     * {@link #printListInColumns(List, PrintStream)}
+     */
+    public static final int COLUMN_SPACING = 2;
 
+    /**
+     * Prints a list of Strings in columns, based upon the terminal width.
+     * 
+     * @param items      The list of Strings to print
+     * @param ps         The stream to send the printed Strings to.
+     * @param maxColumns A maximum limit to the number columns to print
+     */
     public static void printListInColumns(List<String> items, PrintStream ps) {
+        printListInColumns(items, ps, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Prints a list of Strings in columns, based upon the terminal width.
+     * 
+     * @param items      The list of Strings to print
+     * @param ps         The stream to send the printed Strings to.
+     * @param maxColumns A maximum limit to the number columns to print
+     */
+    public static void printListInColumns(List<String> items, PrintStream ps, int maxColumns) {
         // Find the longest length of all the provided Strings
         int maxLength = items.stream().max(Comparator.comparingInt(String::length)).get().length();
 
@@ -267,11 +289,11 @@ public class StringTools {
         int termWidth = TerminalFactory.get().getWidth();
 
         int colWidth = maxLength + COLUMN_SPACING;
-        int maxColumns = (termWidth / 2) / colWidth;
-        int colHeight = (items.size() + maxColumns) / maxColumns;
+        int numCols = Integer.min(termWidth / colWidth, maxColumns);
+        int colHeight = (items.size() + numCols) / numCols;
         String fmt = makeWhiteSpace(COLUMN_SPACING) + "%-" + maxLength + "s";
         for (int i = 0; i < colHeight; i++) {
-            for (int col = 0; col < maxColumns; col++) {
+            for (int col = 0; col < numCols; col++) {
                 int idx = col * colHeight + i;
                 if (idx < items.size())
                     ps.printf(fmt, items.get(idx));

--- a/src/com/xilinx/rapidwright/util/StringTools.java
+++ b/src/com/xilinx/rapidwright/util/StringTools.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -26,10 +26,13 @@
 package com.xilinx.rapidwright.util;
 
 import java.io.File;
+import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+
+import org.python.jline.TerminalFactory;
 
 /**
  * A set of String utility methods.
@@ -241,6 +244,40 @@ public class StringTools {
             if (str.startsWith(prefix)) return prefix;
         }
         return null;
+    }
+
+    /**
+     * Creates a String of spaces of the specified length
+     * 
+     * @param length The number of spaces in the desired String
+     * @return A String containing spaces of the desired length. Any length less
+     *         than 1 will return a String of length 0.
+     */
+    public static String makeWhiteSpace(int length) {
+        return length < 1 ? "" : new String(new char[length]).replace('\0', ' ');
+    }
+
+    private static final int COLUMN_SPACING = 2;
+
+    public static void printListInColumns(List<String> items, PrintStream ps) {
+        // Find the longest length of all the provided Strings
+        int maxLength = items.stream().max(Comparator.comparingInt(String::length)).get().length();
+
+        // Get the width in characters of the current terminal
+        int termWidth = TerminalFactory.get().getWidth();
+
+        int colWidth = maxLength + COLUMN_SPACING;
+        int maxColumns = (termWidth / 2) / colWidth;
+        int colHeight = (items.size() + maxColumns) / maxColumns;
+        String fmt = makeWhiteSpace(COLUMN_SPACING) + "%-" + maxLength + "s";
+        for (int i = 0; i < colHeight; i++) {
+            for (int col = 0; col < maxColumns; col++) {
+                int idx = col * colHeight + i;
+                if (idx < items.size())
+                    ps.printf(fmt, items.get(idx));
+            }
+            ps.println();
+        }
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Adds a `StringTools` API to enable printing a list of Strings in columns and uses that in `MainEntrypoint` to print a list of applications using columns instead of a long list.  For example, the new output is:

```
Need one argument to determine the mode. Valid modes are (case-insensitive):
  AddSubGenerator               DeviceResourcesExample        IsolateLeafClkBuffer          PBlock                        ReportDevicePerformance     
  BlockCreator                  EDIFNetlist                   JobQueue                      PerformanceEvaluation         ReportTimingExample         
  BlockStitcher                 EDIFParser                    Lesson1                       PerformanceExplorer           Router                      
  BlockUpdater                  EDIFPropertyValue             LogicalNetlistExample         PhysicalNetlistExample        RouteThruHelper             
  BrowseDevice                  EDIFTools                     LUTTools                      PhysicalNetlistToDcp          RunSATRouterExample         
  CheckAccuracyUsingGnlDesigns  EnumerateCellBelMapping       MergeDesigns                  PicoBlazeArray                RWRoute                     
  CompareRouteStatusReports     ExampleNetlistCreation        MetadataParser                PinMapTester                  SLRCrosserGenerator         
  CopyMMCMCell                  FileTools                     ModuleOptimizer               PipelineGenerator             SmallestEnclosingCircle     
  CustomRouting                 GenerateInterchangeDevices    MultGenerator                 PipelineGeneratorWithRouting  StampPlacement              
  DecomposeLUT                  HandPlacer                    PartPrinter                   PolynomialGenerator           StringTools                 
  DesignImplementationDiff      ILAInserter                   PartTileBrowser               PrintEDIFInstances            TileColumnPattern           
  DesignInstrumentor            ImplGuide                     PartialRouter                 ProbeRouter                   Unzip                       
  DeviceBrowser                 IntentCode                    PBlockGenDebugger             PseudoPIPHelper               UpdateRoutingUsingSATRouter 
  DeviceLoader                  Interchange                   PBlockGenerator               RapidWright                 

```

Also deprecates `MessageGenerator.makeWhiteSpace()` and refactors it to `StringTools`.