### PR TITLE
Add symlink to rapidwright wrapper in bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 /.gradle/
 .pydevproject
 /.settings/
-/bin/
+/bin/com
+/bin/rapidwright_classpath.sh
 .idea
 *.iml
 /designs/

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ TMP_HEADER = TMP_HEADER_TXT
 .PHONY: compile update_jars ensure_headers check_headers pre_commit enable_pre_commit_hook
 compile: $(CLASSES)
 $(CLASSES): $(SOURCES) $(JARFILES)
-	rm -rf $(BIN)
-	mkdir -p $(BIN)
+	rm -rf $(BIN)/com
 	javac -source 8 -target 8 $(SOURCES) -d $(BIN) -cp $(CLASSPATH)
 	echo "export CLASSPATH=`pwd`/bin:$(shell echo `pwd`/jars/*.jar | tr ' ' ':')" > $(BIN)/rapidwright_classpath.sh
 

--- a/bin/rapidwright
+++ b/bin/rapidwright
@@ -1,0 +1,1 @@
+../rapidwright


### PR DESCRIPTION
This is to allow users to add `$RAPIDWRIGHT_PATH/bin` to their `PATH` so they can run RapidWright from any directory.