### PR TITLE
[RWRoute] Fix routeStaticNets() to not use other nets' nodes

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -437,7 +437,7 @@ public class RWRoute{
             }
         }
 
-        // Annotate all static pins with the net they're associated with to ensure that one
+        // Annotate all static pin nodes with the net they're associated with to ensure that one
         // net cannot unknowingly use a node needed by the other net
         Map<Node,Net> preservedStaticNodes = new HashMap<>();
         for (Map.Entry<Net,List<SitePinInst>> e : staticNetAndRoutingTargets.entrySet()) {
@@ -449,7 +449,7 @@ public class RWRoute{
             }
         }
 
-        // Iterate through both static nets in a stable order (not guaranteed by IdentityHashMap())
+        // Iterate through both static nets in a stable order (not guaranteed by IdentityHashMap)
         for (Net staticNet : Arrays.asList(design.getGndNet(), design.getVccNet())) {
             List<SitePinInst> pins = staticNetAndRoutingTargets.get(staticNet);
             if (pins == null) {

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -443,8 +443,9 @@ public class RWRoute{
         for (Map.Entry<Net,List<SitePinInst>> e : staticNetAndRoutingTargets.entrySet()) {
             Net staticNet = e.getKey();
             for (SitePinInst sink : e.getValue()) {
-                preservedStaticNode.put(sink.getConnectedNode(), staticNet);
-                assert(!routingGraph.isPreserved(sink.getConnectedNode()));
+                Node node = sink.getConnectedNode();
+                preservedStaticNode.put(node, staticNet);
+                assert(!routingGraph.isPreserved(node));
             }
         }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -439,11 +439,12 @@ public class RWRoute{
 
         // Annotate all static pins with the net they're associated with to ensure that one
         // net cannot unknowingly use a node needed by the other net
-        Map<Node,Net> pin2net = new HashMap<>();
+        Map<Node,Net> preservedStaticNode = new HashMap<>();
         for (Map.Entry<Net,List<SitePinInst>> e : staticNetAndRoutingTargets.entrySet()) {
             Net staticNet = e.getKey();
             for (SitePinInst sink : e.getValue()) {
-                pin2net.put(sink.getConnectedNode(), staticNet);
+                preservedStaticNode.put(sink.getConnectedNode(), staticNet);
+                assert(!routingGraph.isPreserved(sink.getConnectedNode()));
             }
         }
 
@@ -467,7 +468,7 @@ public class RWRoute{
                         }
 
                         // Check that this node is not needed by the other static net
-                        preservedNet = pin2net.get(node);
+                        preservedNet = preservedStaticNode.get(node);
                         if (preservedNet != null && preservedNet != staticNet) {
                             return NodeStatus.UNAVAILABLE;
                         }

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -439,12 +439,12 @@ public class RWRoute{
 
         // Annotate all static pins with the net they're associated with to ensure that one
         // net cannot unknowingly use a node needed by the other net
-        Map<Node,Net> preservedStaticNode = new HashMap<>();
+        Map<Node,Net> preservedStaticNodes = new HashMap<>();
         for (Map.Entry<Net,List<SitePinInst>> e : staticNetAndRoutingTargets.entrySet()) {
             Net staticNet = e.getKey();
             for (SitePinInst sink : e.getValue()) {
                 Node node = sink.getConnectedNode();
-                preservedStaticNode.put(node, staticNet);
+                preservedStaticNodes.put(node, staticNet);
                 assert(!routingGraph.isPreserved(node));
             }
         }
@@ -469,7 +469,7 @@ public class RWRoute{
                         }
 
                         // Check that this node is not needed by the other static net
-                        preservedNet = preservedStaticNode.get(node);
+                        preservedNet = preservedStaticNodes.get(node);
                         if (preservedNet != null && preservedNet != staticNet) {
                             return NodeStatus.UNAVAILABLE;
                         }

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -455,7 +455,7 @@ public class RWRoute{
             if (pins == null) {
                 continue;
             }
-            System.out.println("INFO: Route " + pins.size() + " pins of " + staticNet);
+            System.out.println("INFO: Routing " + pins.size() + " pins of " + staticNet);
             GlobalSignalRouting.routeStaticNet(staticNet,
                     // Lambda to determine whether a node is (a) available for use,
                     // (b) already in use for this static net, (c) unavailable

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -427,12 +427,6 @@ public class RWRoute{
         if (staticNetAndRoutingTargets.isEmpty())
             return;
 
-        for (List<SitePinInst> netRouteTargetPins : staticNetAndRoutingTargets.values()) {
-            for (SitePinInst sink : netRouteTargetPins) {
-                assert(!routingGraph.isPreserved(sink.getConnectedNode()));
-            }
-        }
-
         List<SitePinInst> gndPins = staticNetAndRoutingTargets.get(design.getGndNet());
         if (gndPins != null) {
             Set<SitePinInst> newVccPins = RouterHelper.invertPossibleGndPinsToVccPins(design, gndPins);
@@ -443,29 +437,49 @@ public class RWRoute{
             }
         }
 
+        // Annotate all static pins with the net they're associated with to ensure that one
+        // net cannot unknowingly use a node needed by the other net
+        Map<Node,Net> pin2net = new HashMap<>();
         for (Map.Entry<Net,List<SitePinInst>> e : staticNetAndRoutingTargets.entrySet()) {
-            Net net = e.getKey();
-            List<SitePinInst> pins = e.getValue();
-            System.out.println("INFO: Route " + pins.size() + " pins of " + net);
-            GlobalSignalRouting.routeStaticNet(net,
+            Net staticNet = e.getKey();
+            for (SitePinInst sink : e.getValue()) {
+                pin2net.put(sink.getConnectedNode(), staticNet);
+            }
+        }
+
+        // Iterate through both static nets in a stable order (not guaranteed by IdentityHashMap())
+        for (Net staticNet : Arrays.asList(design.getGndNet(), design.getVccNet())) {
+            List<SitePinInst> pins = staticNetAndRoutingTargets.get(staticNet);
+            if (pins == null) {
+                continue;
+            }
+            System.out.println("INFO: Route " + pins.size() + " pins of " + staticNet);
+            GlobalSignalRouting.routeStaticNet(staticNet,
                     // Lambda to determine whether a node is (a) available for use,
-                    // (b) already in used for this static net, (c) unavailable
+                    // (b) already in use for this static net, (c) unavailable
                     (node) -> {
                         Net preservedNet = routingGraph.getPreservedNet(node);
                         if (preservedNet != null) {
                             // If one is present, it is unavailable only if it isn't carrying
                             // the net undergoing routing
-                            return preservedNet == net ? NodeStatus.INUSE
+                            return preservedNet == staticNet ? NodeStatus.INUSE
                                     : NodeStatus.UNAVAILABLE;
                         }
+
+                        // Check that this node is not needed by the other static net
+                        preservedNet = pin2net.get(node);
+                        if (preservedNet != null && preservedNet != staticNet) {
+                            return NodeStatus.UNAVAILABLE;
+                        }
+
                         // A RouteNode will only be created if the net is necessary for
-                        // a to-be-routed connection
+                        // a to-be-routed (non-static) connection
                         return routingGraph.getNode(node) == null ? NodeStatus.AVAILABLE
                                 : NodeStatus.UNAVAILABLE;
                     },
                     design, routethruHelper);
 
-            preserveNet(net, false);
+            preserveNet(staticNet, false);
         }
     }
 


### PR DESCRIPTION
Discovered by https://github.com/Xilinx/RapidWright/pull/691 which changed `RWRoute.staticNetsAndRoutingTargets` to be an `IdentityHashMap` which has a non-deterministic iteration order.

This exposed a bug whereby the static net router would -- when routing static nets in a particular order -- allow one static net to overuse a node that was actually the pin-node for the other static net.

Fix this oversight, and make static net routing deterministic.