### PR TITLE
Fix published maven central jar by omitting test-fixtures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,14 @@ def read_rapidwright_version() {
 }
 def rapidwright_version = project.hasProperty('override_rapidwright_version') ? override_rapidwright_version : read_rapidwright_version()
 
+// Specify coordinates (project name in settings.gradle)
+group = 'com.xilinx.rapidwright'
+version = rapidwright_version
+
+// Skipping test-fixtures for publication, see https://github.com/Xilinx/RapidWright/issues/697
+components["java"].withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
+components["java"].withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }
+
 dependencies {
     api 'com.xilinx.rapidwright:rapidwright-api-lib:' + rapidwright_version
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,6 @@ def read_rapidwright_version() {
 }
 def rapidwright_version = project.hasProperty('override_rapidwright_version') ? override_rapidwright_version : read_rapidwright_version()
 
-// Specify coordinates (project name in settings.gradle)
-group = 'com.xilinx.rapidwright'
-version = rapidwright_version
-
 // Skipping test-fixtures for publication, see https://github.com/Xilinx/RapidWright/issues/697
 components["java"].withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
 components["java"].withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }


### PR DESCRIPTION
It appears that recent `module` files generated by `gradle` have not been valid due to an issue with the test-fixtures plugin (see #697).   This change removes the test-fixtures from the published release to avoid this problem.  

This issue seems loosely related to https://github.com/gradle/gradle/issues/14936.  

This will require a new release to fix the publicly available jars.  

