### PR TITLE
Linux RapidWright wrapper to not change working directory

### DIFF
--- a/.github/workflows/test-rapidwright-wrapper.yml
+++ b/.github/workflows/test-rapidwright-wrapper.yml
@@ -35,7 +35,10 @@ jobs:
         run: bin/rapidwright com.xilinx.rapidwright.rwroute.RWRoute
 
       - name: Check Jython Command Execution
-        run: bin/rapidwright Jython -c "from com.xilinx.rapidwright.device import Device;print(Device.AWS_F1)"
+        run: bin/rapidwright Jython -c "print(Device.AWS_F1)"
+
+      - name: Check PWD
+        run: test $(bin/rapidwright Jython -c "import os; print(os.getcwd())") = $(pwd)
 
       - name: Terminate Gradle to allow caching
         run: ./gradlew --stop

--- a/.github/workflows/test-rapidwright-wrapper.yml
+++ b/.github/workflows/test-rapidwright-wrapper.yml
@@ -41,7 +41,7 @@ jobs:
         run: | 
              mkdir -p sub/dir/ectory
              cd sub/dir/ectory
-             test $($GITHUB_WORKSPACE/bin/rapidwright Jython -c "import os; print(os.getcwd())") = $(pwd)
+             bin/rapidwright Jython -c "import sys, os; sys.exit(0 if os.getcwd() == sys.argv[1] else 1)" $(pwd)
 
       - name: Terminate Gradle to allow caching
         run: ./gradlew --stop

--- a/.github/workflows/test-rapidwright-wrapper.yml
+++ b/.github/workflows/test-rapidwright-wrapper.yml
@@ -38,10 +38,10 @@ jobs:
         run: bin/rapidwright Jython -c "print(Device.AWS_F1)"
 
       - name: Check PWD
-        run: | 
+        run: |
              mkdir -p sub/dir/ectory
              cd sub/dir/ectory
-             bin/rapidwright Jython -c "import sys, os; sys.exit(0 if os.getcwd() == sys.argv[1] else 1)" $(pwd)
+             ${{ github.workspace }}/bin/rapidwright Jython -c "import sys, os; sys.exit(0 if os.getcwd() == sys.argv[1] else 1)" $(pwd)
 
       - name: Terminate Gradle to allow caching
         run: ./gradlew --stop

--- a/.github/workflows/test-rapidwright-wrapper.yml
+++ b/.github/workflows/test-rapidwright-wrapper.yml
@@ -38,7 +38,10 @@ jobs:
         run: bin/rapidwright Jython -c "print(Device.AWS_F1)"
 
       - name: Check PWD
-        run: test $(bin/rapidwright Jython -c "import os; print(os.getcwd())") = $(pwd)
+        run: | 
+             mkdir -p sub/dir/ectory
+             cd sub/dir/ectory
+             test $($GITHUB_WORKSPACE/bin/rapidwright Jython -c "import os; print(os.getcwd())") = $(pwd)
 
       - name: Terminate Gradle to allow caching
         run: ./gradlew --stop

--- a/bin/rapidwright
+++ b/bin/rapidwright
@@ -19,30 +19,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
-# Reproduced from from `gradlew`
- PRG="$0" 
- # Need this for relative symlinks. 
- while [ -h "$PRG" ] ; do 
-     ls=`ls -ld "$PRG"` 
-     link=`expr "$ls" : '.*-> \(.*\)$'` 
-     if expr "$link" : '/.*' > /dev/null; then 
-         PRG="$link" 
-     else 
-         PRG=`dirname "$PRG"`"/$link" 
-     fi 
- done 
- SAVED="`pwd`" 
- cd "`dirname \"$PRG\"`/" >/dev/null
- cd .. > /dev/null
- APP_HOME="`pwd -P`" 
-
+RAPIDWRIGHT_PATH="$(dirname $(dirname $0))"
 
 # Check that the main jar has been built
 # NOTE: Does not check that it is up-to-date
-MAIN_JAR=${APP_HOME}/build/libs/main.jar
+MAIN_JAR=${RAPIDWRIGHT_PATH}/build/libs/main.jar
 if [ ! -f ${MAIN_JAR} ]; then
-    echo "RapidWright not yet compiled. Please run './gradlew compileJava' from '${APP_HOME}'"
+    echo "RapidWright not yet compiled. Please run './gradlew compileJava' from '${RAPIDWRIGHT_PATH}'"
     exit 1
 fi
 


### PR DESCRIPTION
Found by @zakn-amd.

It appears that the new `rapidwright` wrapper on Linux changes the current working directory (to the root of the git repository) , thus when an application writes to the current directory it appears there as opposed to where it was invoked.