### PR TITLE
Fix DesignTools.makePhysNetNamesConsistent() 

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2747,7 +2747,17 @@ public class DesignTools {
                 continue;
             }
             if (!hierNet.equals(parentHierNet)) {
-                Net parentPhysNet = design.getNet(parentHierNet.getHierarchicalNetName());
+                String parentHierNetName = parentHierNet.getHierarchicalNetName();
+                Net parentPhysNet;
+                if (parentHierNetName.equals(EDIFTools.LOGICAL_VCC_NET_NAME)) {
+                    parentHierNetName = Net.VCC_NET;
+                    parentPhysNet = design.getVccNet();
+                } else if (parentHierNetName.equals(EDIFTools.LOGICAL_GND_NET_NAME)) {
+                    parentHierNetName = Net.GND_NET;
+                    parentPhysNet = design.getGndNet();
+                } else {
+                    parentPhysNet = design.getNet(parentHierNetName);
+                }
                 if (parentPhysNet != null) {
                     // Merge both physical nets together
                     for (SiteInst si : net.getSiteInsts()) {
@@ -2759,7 +2769,7 @@ public class DesignTools {
                         }
                     }
                     design.movePinsToNewNetDeleteOldNet(net, parentPhysNet, true);
-                } else if (!net.rename(parentHierNet.getHierarchicalNetName())) {
+                } else if (!net.rename(parentHierNetName)) {
                     System.out.println("WARNING: Failed to adjust physical net name " + net.getName());
                 }
             }

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -948,4 +948,34 @@ public class TestDesignTools {
             Assertions.assertEquals(vcc, spi.getNet());
         }
     }
+
+    @Test
+    public void testMakePhysNetNamesConsistentLogicalVccGnd() {
+        Design design = RapidWrightDCP.loadDCP("bug701.dcp");
+
+        // Design has no GLOBAL_LOGIC{0,1}
+        Assertions.assertNull(design.getNet(Net.VCC_NET));
+        Assertions.assertNull(design.getNet(Net.GND_NET));
+
+        DesignTools.makePhysNetNamesConsistent(design);
+
+        // Check those nets were created
+        Net vcc = design.getNet(Net.VCC_NET);
+        Assertions.assertNotNull(vcc);
+        Assertions.assertEquals(1, vcc.getSiteInsts().size());
+        int numSitewires = 0;
+        for (SiteInst si : vcc.getSiteInsts()) {
+            numSitewires += si.getSiteWiresFromNet(vcc).size();
+        }
+        Assertions.assertEquals(1, numSitewires);
+
+        Net gnd = design.getNet(Net.GND_NET);
+        Assertions.assertNotNull(gnd);
+        Assertions.assertEquals(4, gnd.getSiteInsts().size());
+        numSitewires = 0;
+        for (SiteInst si : gnd.getSiteInsts()) {
+            numSitewires += si.getSiteWiresFromNet(gnd).size();
+        }
+        Assertions.assertEquals(31, numSitewires);
+    }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -959,7 +959,8 @@ public class TestDesignTools {
 
         DesignTools.makePhysNetNamesConsistent(design);
 
-        // Check those nets were created
+        // Check those nets were created and all sitewires
+        // were switched over correctly
         Net vcc = design.getNet(Net.VCC_NET);
         Assertions.assertNotNull(vcc);
         Assertions.assertEquals(1, vcc.getSiteInsts().size());

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -265,7 +265,9 @@ public class TestRWRoute {
 
         RWRoute.routeDesignFullNonTimingDriven(design);
 
-        assertVivadoFullyRouted(design);
+        // Testcase has a number of undriven nets, so just check for unrouted nets
+        ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(design);
+        Assertions.assertEquals(0, rrs.unroutedNets);
     }
 
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -258,4 +258,14 @@ public class TestRWRoute {
             break;
         }
     }
+
+    @Test
+    public void testBug701() {
+        Design design = RapidWrightDCP.loadDCP("bug701.dcp");
+
+        RWRoute.routeDesignFullNonTimingDriven(design);
+
+        assertVivadoFullyRouted(design);
+    }
+
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -265,9 +265,19 @@ public class TestRWRoute {
 
         RWRoute.routeDesignFullNonTimingDriven(design);
 
-        // Testcase has a number of undriven nets, so just check for unrouted nets
-        ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(design);
-        Assertions.assertEquals(0, rrs.unroutedNets);
+        Net vcc = design.getVccNet();
+        Assertions.assertEquals(1, vcc.getPins().size());
+        Assertions.assertTrue(vcc.getPins().stream().allMatch(SitePinInst::isRouted));
+
+        Net gnd = design.getGndNet();
+        Assertions.assertEquals(31, gnd.getPins().size());
+        Assertions.assertTrue(gnd.getPins().stream().allMatch(SitePinInst::isRouted));
+
+        if (FileTools.isVivadoOnPath()) {
+            // Testcase has a number of undriven nets, so just check for unrouted nets
+            ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(design);
+            Assertions.assertEquals(0, rrs.unroutedNets);
+        }
     }
 
 }


### PR DESCRIPTION
By transforming logical static nets named `<const{0,1}>` into physical static nets `GLOBAL_LOGIC{0,1}`

Fixes #701.

CC: @haydenc-amd