### PR TITLE
Add DcpToInterchange class

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -66,6 +66,7 @@ import com.xilinx.rapidwright.examples.SLRCrosserGenerator;
 import com.xilinx.rapidwright.examples.StampPlacement;
 import com.xilinx.rapidwright.examples.UpdateRoutingUsingSATRouter;
 import com.xilinx.rapidwright.examples.tilebrowser.PartTileBrowser;
+import com.xilinx.rapidwright.interchange.DcpToInterchange;
 import com.xilinx.rapidwright.interchange.DeviceResourcesExample;
 import com.xilinx.rapidwright.interchange.EnumerateCellBelMapping;
 import com.xilinx.rapidwright.interchange.GenerateInterchangeDevices;
@@ -122,6 +123,7 @@ public class MainEntrypoint {
         addFunction("CompareRouteStatusReports", CompareRouteStatusReports::main);
         addFunction("CopyMMCMCell", CopyMMCMCell::main);
         addFunction("CustomRouting", CustomRouting::main);
+        addFunction("DcpToInterchange", DcpToInterchange::main);
         addFunction("DecomposeLUT", DecomposeLUT::main);
         addFunction("DesignImplementationDiff", DesignImplementationDiff::main);
         addFunction("DesignInstrumentor", DesignInstrumentor::main);

--- a/src/com/xilinx/rapidwright/interchange/DcpToInterchange.java
+++ b/src/com/xilinx/rapidwright/interchange/DcpToInterchange.java
@@ -43,12 +43,12 @@ public class DcpToInterchange {
         Design design = Design.readCheckpoint(args[0]);
         String baseName = Paths.get(args[0]).getFileName().toString();
         baseName = FileTools.removeFileExtension(baseName);
-        String logNlistName = baseName + ".netlist";
-        String physNlistName = baseName + ".phys";
+        String logNetlistName = baseName + ".netlist";
+        String physNetlistName = baseName + ".phys";
         String xdcName = baseName + ".xdc";
 
-        LogNetlistWriter.writeLogNetlist(design.getNetlist(), logNlistName);
-        PhysNetlistWriter.writePhysNetlist(design, physNlistName);
+        LogNetlistWriter.writeLogNetlist(design.getNetlist(), logNetlistName);
+        PhysNetlistWriter.writePhysNetlist(design, physNetlistName);
 
         List<String> constraints = design.getXDCConstraints(ConstraintGroup.NORMAL);
         try (FileOutputStream f = new FileOutputStream(xdcName)) {

--- a/src/com/xilinx/rapidwright/interchange/DcpToInterchange.java
+++ b/src/com/xilinx/rapidwright/interchange/DcpToInterchange.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Zak Nafziger, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.interchange;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.xilinx.rapidwright.design.ConstraintGroup;
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.ipi.XDCParser;
+
+public class DcpToInterchange {
+    public static void main(String[] args) throws IOException {
+        if (args.length != 1) {
+            System.out.println("USAGE: java " + DcpToInterchange.class.getCanonicalName() + " "
+                    + "<dcp to convert>");
+            return;
+        }
+
+        Design design = Design.readCheckpoint(args[0]);
+        String baseName = Path.of(args[0]).getFileName().toString();
+        baseName = baseName.substring(0, baseName.lastIndexOf('.'));
+        String logNlistName = baseName + ".netlist";
+        String physNlistName = baseName + ".phys";
+        String xdcName = baseName + ".xdc";
+
+        LogNetlistWriter.writeLogNetlist(design.getNetlist(), logNlistName);
+        PhysNetlistWriter.writePhysNetlist(design, physNlistName);
+
+        List<String> constraints = design.getXDCConstraints(ConstraintGroup.NORMAL);
+        FileOutputStream f = new FileOutputStream(xdcName);
+        XDCParser.writeXDC(constraints, f);
+    }
+}

--- a/src/com/xilinx/rapidwright/interchange/DcpToInterchange.java
+++ b/src/com/xilinx/rapidwright/interchange/DcpToInterchange.java
@@ -25,23 +25,24 @@ package com.xilinx.rapidwright.interchange;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import com.xilinx.rapidwright.design.ConstraintGroup;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.ipi.XDCParser;
+import com.xilinx.rapidwright.util.FileTools;
 
 public class DcpToInterchange {
     public static void main(String[] args) throws IOException {
         if (args.length != 1) {
-            System.out.println("USAGE: java " + DcpToInterchange.class.getCanonicalName() + " "
-                    + "<dcp to convert>");
+            System.out.println("USAGE: <input.dcp>");
             return;
         }
 
         Design design = Design.readCheckpoint(args[0]);
-        String baseName = Path.of(args[0]).getFileName().toString();
-        baseName = baseName.substring(0, baseName.lastIndexOf('.'));
+        String baseName = Paths.get(args[0]).getFileName().toString();
+        baseName = FileTools.removeFileExtension(baseName);
         String logNlistName = baseName + ".netlist";
         String physNlistName = baseName + ".phys";
         String xdcName = baseName + ".xdc";
@@ -50,7 +51,8 @@ public class DcpToInterchange {
         PhysNetlistWriter.writePhysNetlist(design, physNlistName);
 
         List<String> constraints = design.getXDCConstraints(ConstraintGroup.NORMAL);
-        FileOutputStream f = new FileOutputStream(xdcName);
-        XDCParser.writeXDC(constraints, f);
+        try (FileOutputStream f = new FileOutputStream(xdcName)) {
+            XDCParser.writeXDC(constraints, f);
+        }
     }
 }


### PR DESCRIPTION
For conversion of DCP into a Logical and Physical Interchange netlist, along with (normal) XDC constraints.

Also accessible through `rapidwright DcpToInterchange` due to addition to `MainEntrypoint`.