### PR TITLE
DesignTools.makePhysNetNamesConsistent() to copy before modifying

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2812,7 +2812,7 @@ public class DesignTools {
                 }
                 if (parentPhysNet != null) {
                     // Merge both physical nets together
-                    for (SiteInst si : net.getSiteInsts()) {
+                    for (SiteInst si : new ArrayList<>(net.getSiteInsts())) {
                         List<String> siteWires = new ArrayList<>(si.getSiteWiresFromNet(net));
                         for (String siteWire : siteWires) {
                             BELPin[] pins = si.getSiteWirePins(siteWire);


### PR DESCRIPTION
Pulled out from #708, necessary for testing the next release.