### PR TITLE
VivadoTools.runTcl to throw exception if exitcode != 0

### DIFF
--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -84,7 +84,10 @@ public class VivadoTools {
     public static List<String> runTcl(Path outputLog, Path tclScript, boolean verbose) {
         final String vivadoCmd = "vivado -log " + outputLog.toString() + " -mode batch -source "
                 + tclScript.toString();
-        FileTools.runCommand(vivadoCmd, verbose);
+        Integer exitCode = FileTools.runCommand(vivadoCmd, verbose);
+        if (exitCode != 0) {
+            throw new RuntimeException("Exited with " + exitCode);
+        }
         return FileTools.getLinesFromTextFile(outputLog.toString());
     }
 

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -86,7 +86,7 @@ public class VivadoTools {
                 + tclScript.toString();
         Integer exitCode = FileTools.runCommand(vivadoCmd, verbose);
         if (exitCode != 0) {
-            throw new RuntimeException("Exited with " + exitCode);
+            throw new RuntimeException("Vivado exited with code: " + exitCode);
         }
         return FileTools.getLinesFromTextFile(outputLog.toString());
     }

--- a/test/src/com/xilinx/rapidwright/util/TestVivadoTools.java
+++ b/test/src/com/xilinx/rapidwright/util/TestVivadoTools.java
@@ -45,6 +45,16 @@ public class TestVivadoTools {
         Assertions.assertTrue(results.get(0).contains("Exiting Vivado"));
     }
 
+    @Test
+    public void testRunTclCmdThrowsException(@TempDir Path tempDir) {
+        Assumptions.assumeTrue(FileTools.isVivadoOnPath());
+
+        RuntimeException ex = Assertions.assertThrows(RuntimeException.class,
+                () -> VivadoTools.runTcl(tempDir.resolve("outputLog.log"), "exit 1", true)
+        );
+        Assertions.assertEquals("Vivado exited with code: 1", ex.getMessage());
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testReportRouteStatus(boolean fromDisk) {


### PR DESCRIPTION
CC: @zakn-amd 

For catching scenarios where Vivado exits abruptly -- e.g. it was unable to read the DCP.