### PR TITLE
[PhysNetlistWriter] Relax assertions

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -382,7 +382,6 @@ public class PhysNetlistWriter {
                             // Skip if pin is not used by site port
                             continue;
                         }
-                        assert(spi.getNet() == net);
 
                         if (!VERBOSE_PHYSICAL_NET_ROUTING) {
                             // Skip input pins to site ports (will be set when site pin is added

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -402,7 +402,7 @@ public class PhysNetlistWriter {
                                 continue;
                             }
                         } else {
-                            assert(bel.isStaticSource());
+                            assert(bel.isStaticSource() || net.getName().equals(Net.USED_NET));
                         }
                     } else {
                         assert(bel.getBELClass() == BELClass.PORT);


### PR DESCRIPTION
* Allow `Net.USED_NET` in assertion, since it can appear as a placeholder anywhere.
* Disable onerous `assert(spi.getNet() == net)` for now