### PR TITLE
1.8 compliance

### DIFF
--- a/src/com/xilinx/rapidwright/router/RouteThruHelper.java
+++ b/src/com/xilinx/rapidwright/router/RouteThruHelper.java
@@ -24,7 +24,6 @@
 package com.xilinx.rapidwright.router;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -98,7 +97,7 @@ public class RouteThruHelper {
     private void init() {
         String serializedFileName = getSerializedFileName(device.getName());
         routeThrus = new HashMap<TileTypeEnum,HashSet<Integer>>();
-        if (new File(serializedFileName).exists() && !FileTools.isFileGzipped(Path.of(serializedFileName))) {
+        if (new File(serializedFileName).exists() && !FileTools.isFileGzipped(Paths.get(serializedFileName))) {
             readFile();
             return;
         }


### PR DESCRIPTION
`Path.of()` appeared in Java 11 and is not in Java 1.8, the equivalent is `Paths.get()`.  This is not caught in `gradlew` or Eclipse when setting compiler compliance to 1.8.  This was only detected with using a 1.8 JDK.