### PR TITLE
Multilevel macro expansion

### DIFF
--- a/src/com/xilinx/rapidwright/util/DataVersions.java
+++ b/src/com/xilinx/rapidwright/util/DataVersions.java
@@ -351,6 +351,6 @@ public class DataVersions {
         dataVersionMap.put("data/devices/zynquplusrfsoc/xqzu49dr_db.dat", new Pair<>("xqzu49dr-db-dat", "ff145122f2caea588120ac4da439d838"));
         dataVersionMap.put("data/partdump.csv", new Pair<>("partdump-csv", "f5aa2d4c08196e330576bda0e644772a"));
         dataVersionMap.put("data/parts.db", new Pair<>("parts-db", "f5d8a26178d35bd1a68c441b37a04279"));
-        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "cb19c277094bcbe1fb88277e032cd7f9"));
+        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "ce8410650ad739c8630b12c3152693a3"));
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.xilinx.rapidwright.design.Unisim;
-import com.xilinx.rapidwright.device.Series;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -39,10 +37,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.IOStandard;
 import com.xilinx.rapidwright.device.Part;
 import com.xilinx.rapidwright.device.PartNameTools;
+import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.edif.compare.EDIFNetlistComparator;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 
@@ -520,5 +520,22 @@ class TestEDIFNetlist {
 
         netlist.expandMacroUnisims(Series.UltraScalePlus);
         Assertions.assertEquals(cellType, obufds.getCellType().getName());
+    }
+
+    @Test
+    public void testMultiLevelMacroExpansion() {
+        final EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+        netlist.setDevice(Device.getDevice(Device.AWS_F1));
+
+        EDIFCell top = netlist.getTopCell();
+
+        EDIFCellInst iobufdse3 = top.createChildCellInst("IOBUFDSE3_expandme",
+                netlist.getHDIPrimitive(Unisim.IOBUFDSE3));
+        netlist.getHDIPrimitivesLibrary().addCell(iobufdse3.getCellType());
+
+        netlist.expandMacroUnisims(Series.UltraScalePlus);
+
+        EDIFCellInst childInst = iobufdse3.getCellType().getCellInst("OBUFTDS");
+        Assertions.assertEquals(childInst.getCellType().getName(), "OBUFTDS_DCIEN_DUAL_BUF");
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -537,5 +537,6 @@ class TestEDIFNetlist {
 
         EDIFCellInst childInst = iobufdse3.getCellType().getCellInst("OBUFTDS");
         Assertions.assertEquals(childInst.getCellType().getName(), "OBUFTDS_DCIEN_DUAL_BUF");
+        Assertions.assertEquals(childInst.getCellType().getCellInsts().size(), 3);
     }
 }


### PR DESCRIPTION
In a DCP design created from https://github.com/litex-hub/linux-on-litex-vexriscv, there were instances of `IOBUFDSE3` which would have a child instance of `OBUFTDS_DCIEN` that would also get expanded to `OBUFTDS_DCIEN_DUAL_BUF`.   RapidWright was not handling this previous to this PR.  This updates the data file to include `OBUFTDS_DCIEN_DUAL_BUF` and changes the expansion correctly.  