### PR TITLE
Unroute site routing when removing a cell

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1492,7 +1492,7 @@ public class DesignTools {
     }
 
     /**
-     * Unroutes the site routing connected the provided cell's logical pin.
+     * Unroutes the site routing connected to the provided cell's logical pin.
      * Preserves other parts of the net if used by other sinks in the site if an
      * input. For the unrouting to be successful, this method depends on the site
      * routing to be consistent.
@@ -1500,7 +1500,7 @@ public class DesignTools {
      * @param cell           The cell of the pin
      * @param logicalPinName The logical pin name source or sink to have routing
      *                       removed.
-     * @returns The set of site pins removed as part of the unroute.
+     * @returns A list of site pins that should be removed as part of the unroute.
      */
     public static List<SitePinInst> unrouteCellPinSiteRouting(Cell cell, String logicalPinName) {
         String physPinName = cell.getPhysicalPinMapping(logicalPinName);

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1616,9 +1616,13 @@ public class DesignTools {
             }
         }
 
+        Set<String> updatedNets = new HashSet<>();
         for (Entry<Net, String> e : netsToUpdate.entrySet()) {
             EDIFHierNet newSource = d.getNetlist().getHierNetFromName(e.getValue());
-            DesignTools.updateNetName(d, e.getKey(), newSource.getNet(), e.getValue());
+            Net updatedNet = DesignTools.updateNetName(d, e.getKey(), newSource.getNet(), e.getValue());
+            if (updatedNet != null) {
+                updatedNets.add(updatedNet.getName());
+            }
         }
 
         t.stop().start("cleanup siteinsts");
@@ -1626,7 +1630,8 @@ public class DesignTools {
         for (SiteInst siteInst : touched) {
             for (SitePinInst pin : siteInst.getSitePinInsts()) {
                 Net net = pin.getNet();
-                if (net == null) continue;
+                if (net == null || updatedNets.contains(net.getName()))
+                    continue;
                 pinsToRemove.computeIfAbsent(net, ($) -> new HashSet<>()).add(pin);
             }
         }
@@ -1652,14 +1657,14 @@ public class DesignTools {
     }
 
     /**
-     * Helper method for makeBlackBox().  When cutting out nets that used
-     * to be source'd from something inside a black box, the net names
-     * need to be updated.
-     * @param d The current design
-     * @param currNet Current net that requires a name change
+     * Helper method for makeBlackBox(). When cutting out nets that used to be
+     * source'd from something inside a black box, the net names need to be updated.
+     * 
+     * @param d         The current design
+     * @param currNet   Current net that requires a name change
      * @param newSource The source net (probably a pin on the black box)
-     * @param newName New name for the net
-     * @return True if the operation succeeded, false otherwise.
+     * @param newName   New name for the net
+     * @return A reference to the newly updated/renamed net.
      */
     private static Net updateNetName(Design d, Net currNet, EDIFNet newSource, String newName) {
         List<PIP> pips = currNet.getPIPs();

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1500,7 +1500,7 @@ public class DesignTools {
      * @param cell           The cell of the pin
      * @param logicalPinName The logical pin name source or sink to have routing
      *                       removed.
-     * @returns A list of site pins that should be removed as part of the unroute.
+     * @returns A list of site pins (if any) that should also be removed from inter-site routing to complete the unroute.
      */
     public static List<SitePinInst> unrouteCellPinSiteRouting(Cell cell, String logicalPinName) {
         String physPinName = cell.getPhysicalPinMapping(logicalPinName);

--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -34,6 +34,7 @@ import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
@@ -101,7 +102,19 @@ public class LUTTools {
     }
 
     /**
-     * Checks if this cell is a LUT (LUT1, LUT2, LUT3,...). A CFGLUT5 will return false.
+     * Gets the output pin from the BEL of a LUT
+     * 
+     * @param bel The physical bel site of the LUT
+     * @return O5 or O6 based on the BEL
+     */
+    public static BELPin getLUTOutputPin(BEL bel) {
+        return bel.getPin("O" + bel.getName().charAt(1));
+    }
+
+    /**
+     * Checks if this cell is a LUT (LUT1, LUT2, LUT3,...). A CFGLUT5 will return
+     * false.
+     * 
      * @param c The cell in question
      * @return True if this is a LUT[1-6], false otherwise.
      */

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -1039,7 +1039,7 @@ public class TestDesignTools {
         Cell lut0 = design.createAndPlaceCell("lut0", Unisim.LUT5, "SLICE_X0Y0/C6LUT");
         Cell f7mux0 = design.createAndPlaceCell("f7mux0", Unisim.MUXF7, "SLICE_X0Y0/F7MUX_CD");
         SiteInst si0 = lut0.getSiteInst();
-        Net net0 = design.createNet("lut0/O");
+        Net net0 = design.createNet("O");
         net0.connect(lut0, "O");
         net0.getLogicalNet().createPortInst("I1", f7mux0);
         si0.routeIntraSiteNet(net0, lut0.getBEL().getPin("O6"), f7mux0.getBEL().getPin("1"));
@@ -1055,7 +1055,7 @@ public class TestDesignTools {
         Cell lut1 = design.createAndPlaceCell("lut1", Unisim.LUT6, "SLICE_X0Y1/B6LUT");
         Cell ff1 = design.createAndPlaceCell("ff1", Unisim.FDRE, "SLICE_X0Y1/BFF");
         SiteInst si1 = lut1.getSiteInst();
-        Net net1 = design.createNet("lut1/O");
+        Net net1 = design.createNet("O1");
         net1.connect(lut1, "O");
         net1.connect(ff1, "D");
         si1.routeIntraSiteNet(net1, lut1.getBEL().getPin("O6"), ff1.getBEL().getPin("D"));
@@ -1117,7 +1117,7 @@ public class TestDesignTools {
         Cell lut4 = design.createAndPlaceCell("lut4", Unisim.LUT6, "SLICE_X0Y4/B6LUT");
         Cell ff4 = design.createAndPlaceCell("ff4", Unisim.FDRE, "SLICE_X0Y4/BFF");
         SiteInst si4 = lut4.getSiteInst();
-        Net net4 = design.createNet("lut4/O");
+        Net net4 = design.createNet("O4");
         net4.connect(lut4, "O");
         net4.connect(ff4, "D");
         carry4.addPinMapping("S1", "S[1]");

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -34,11 +34,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import com.xilinx.rapidwright.device.Series;
-import com.xilinx.rapidwright.edif.EDIFCell;
-import com.xilinx.rapidwright.edif.EDIFDirection;
-import com.xilinx.rapidwright.edif.EDIFNet;
-import com.xilinx.rapidwright.edif.EDIFPort;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,9 +45,14 @@ import com.xilinx.rapidwright.design.blocks.UtilizationType;
 import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.PIP;
+import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFDirection;
 import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPort;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
@@ -1029,5 +1029,116 @@ public class TestDesignTools {
                 Assertions.assertNotNull(c.getSiteInst());
             }
         }
+    }
+
+    @Test
+    public void testUnrouteCellPinSiteRouting() {
+        Design design = new Design("test", Device.KCU105);
+
+        // Test internal routing removal - no sitepips
+        Cell lut0 = design.createAndPlaceCell("lut0", Unisim.LUT5, "SLICE_X0Y0/C6LUT");
+        Cell f7mux0 = design.createAndPlaceCell("f7mux0", Unisim.MUXF7, "SLICE_X0Y0/F7MUX_CD");
+        SiteInst si0 = lut0.getSiteInst();
+        Net net0 = design.createNet("lut0/O");
+        net0.connect(lut0, "O");
+        net0.getLogicalNet().createPortInst("I1", f7mux0);
+        si0.routeIntraSiteNet(net0, lut0.getBEL().getPin("O6"), f7mux0.getBEL().getPin("1"));
+        Assertions.assertEquals(net0, si0.getNetFromSiteWire("C_O"));
+
+        DesignTools.unrouteCellPinSiteRouting(lut0, "O");
+        Assertions.assertNull(si0.getNetFromSiteWire("C_O"));
+
+        DesignTools.unrouteCellPinSiteRouting(f7mux0, "I1");
+        Assertions.assertNull(si0.getNetFromSiteWire("C_O"));
+
+        // Test internal routing removal - with sitepips
+        Cell lut1 = design.createAndPlaceCell("lut1", Unisim.LUT6, "SLICE_X0Y1/B6LUT");
+        Cell ff1 = design.createAndPlaceCell("ff1", Unisim.FDRE, "SLICE_X0Y1/BFF");
+        SiteInst si1 = lut1.getSiteInst();
+        Net net1 = design.createNet("lut1/O");
+        net1.connect(lut1, "O");
+        net1.connect(ff1, "D");
+        si1.routeIntraSiteNet(net1, lut1.getBEL().getPin("O6"), ff1.getBEL().getPin("D"));
+        Assertions.assertEquals(net1, si1.getNetFromSiteWire("B_O"));
+        Assertions.assertEquals(net1, si1.getNetFromSiteWire("FFMUXB1_OUT1"));
+        Assertions.assertEquals("D6", si1.getUsedSitePIP("FFMUXB1").getInputPinName());
+
+        DesignTools.unrouteCellPinSiteRouting(lut1, "O");
+        Assertions.assertNull(si1.getNetFromSiteWire("B_O"));
+        Assertions.assertNull(si1.getNetFromSiteWire("FFMUXB1_OUT1"));
+        Assertions.assertNull(si1.getUsedSitePIP("FFMUXB1"));
+
+        DesignTools.unrouteCellPinSiteRouting(f7mux0, "I1");
+        Assertions.assertNull(si1.getNetFromSiteWire("B_O"));
+        Assertions.assertNull(si1.getNetFromSiteWire("FFMUXB2_OUT2"));
+        Assertions.assertNull(si1.getUsedSitePIP("FFMUXB2"));
+
+        // Test internal routing removal - routethru
+        Cell carry2 = design.createAndPlaceCell("carry2", Unisim.CARRY8, "SLICE_X0Y2/CARRY8");
+        SiteInst si2 = carry2.getSiteInst();
+        Net net2 = design.createNet("some_source");
+        net2.getLogicalNet().createPortInst("DI[0]", carry2);
+        si2.routeIntraSiteNet(net2, si2.getBELPin("A2", "A2"), carry2.getBEL().getPin("DI0"));
+        net2.createPin("A2", si2);
+
+        Assertions.assertTrue(si2.getCell("A5LUT").isRoutethru());
+        Assertions.assertEquals(net2, si2.getNetFromSiteWire("A2"));
+        Assertions.assertEquals(net2, si2.getNetFromSiteWire("A5LUT_O5"));
+
+        DesignTools.unrouteCellPinSiteRouting(carry2, "DI[0]");
+
+        Assertions.assertNull(si2.getCell("A5LUT"));
+        Assertions.assertNull(si2.getNetFromSiteWire("A2"));
+        Assertions.assertNull(si2.getNetFromSiteWire("A5LUT_O5"));
+
+        // Test internal routing removal - routethru with fanout
+        Cell carry3 = design.createAndPlaceCell("carry3", Unisim.CARRY8, "SLICE_X0Y3/CARRY8");
+        Cell lut3 = design.createAndPlaceCell("lut3", Unisim.LUT6, "SLICE_X0Y3/A6LUT");
+        lut3.addPinMapping("A2", "I2");
+        SiteInst si3 = carry3.getSiteInst();
+        Net net3 = design.createNet("some_source2");
+        net3.getLogicalNet().createPortInst("DI[0]", carry3);
+        si3.routeIntraSiteNet(net3, si3.getBELPin("A2", "A2"), carry3.getBEL().getPin("DI0"));
+        net3.connect(lut3, "I2");
+
+        Assertions.assertEquals(net3, si3.getSitePinInst("A2").getNet());
+        Assertions.assertTrue(si3.getCell("A5LUT").isRoutethru());
+        Assertions.assertEquals(net3, si3.getNetFromSiteWire("A2"));
+        Assertions.assertEquals(net3, si3.getNetFromSiteWire("A5LUT_O5"));
+
+        DesignTools.unrouteCellPinSiteRouting(carry3, "DI[0]");
+
+        Assertions.assertNull(si3.getCell("A5LUT"));
+        Assertions.assertEquals(net3, si3.getNetFromSiteWire("A2"));
+        Assertions.assertNull(si3.getNetFromSiteWire("A5LUT_O5"));
+
+        // Test internal routing removal - fanout
+        Cell carry4 = design.createAndPlaceCell("carry4", Unisim.CARRY8, "SLICE_X0Y4/CARRY8");
+        Cell lut4 = design.createAndPlaceCell("lut4", Unisim.LUT6, "SLICE_X0Y4/B6LUT");
+        Cell ff4 = design.createAndPlaceCell("ff4", Unisim.FDRE, "SLICE_X0Y4/BFF");
+        SiteInst si4 = lut4.getSiteInst();
+        Net net4 = design.createNet("lut4/O");
+        net4.connect(lut4, "O");
+        net4.connect(ff4, "D");
+        carry4.addPinMapping("S1", "S[1]");
+        net4.getLogicalNet().createPortInst("S[1]", carry4);
+
+        si4.routeIntraSiteNet(net4, lut4.getBEL().getPin("O6"), ff4.getBEL().getPin("D"));
+
+        Assertions.assertEquals(net4, si4.getNetFromSiteWire("B_O"));
+        Assertions.assertEquals(net4, si4.getNetFromSiteWire("FFMUXB1_OUT1"));
+        Assertions.assertEquals("D6", si4.getUsedSitePIP("FFMUXB1").getInputPinName());
+
+        DesignTools.unrouteCellPinSiteRouting(ff4, "D");
+
+        Assertions.assertNull(si4.getNetFromSiteWire("FFMUXB1_OUT1"));
+        Assertions.assertNull(si4.getUsedSitePIP("FFMUXB1"));
+        Assertions.assertEquals(net4, si4.getNetFromSiteWire("B_O"));
+
+        DesignTools.unrouteCellPinSiteRouting(carry4, "S[1]");
+
+        Assertions.assertNull(si4.getNetFromSiteWire("FFMUXB1_OUT1"));
+        Assertions.assertNull(si4.getUsedSitePIP("FFMUXB1"));
+        Assertions.assertNull(si4.getNetFromSiteWire("B_O"));
     }
 }


### PR DESCRIPTION
Improves the behavior of `DesignTools.makeBlackBox()` such that is more cleanly removes site routing when a black boxed components removed cells share sites with logic that will remain in the design.  This adds a new method that aims to correctly unroute site routing for a given pin of a placed and routed cell.