### PR TITLE
DesignTools.makePhysNetNamesConsistent() to consider */<const{0,1}>

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2810,16 +2810,17 @@ public class DesignTools {
                 continue;
             }
             if (!hierNet.equals(parentHierNet)) {
-                String parentHierNetName = parentHierNet.getHierarchicalNetName();
+                String parentNetName = parentHierNet.getNet().getName();
                 Net parentPhysNet;
-                if (parentHierNetName.equals(EDIFTools.LOGICAL_VCC_NET_NAME)) {
-                    parentHierNetName = Net.VCC_NET;
+                // Assume that a net named <const1> or <const0> is always a VCC or GND net
+                if (parentNetName.equals(EDIFTools.LOGICAL_VCC_NET_NAME)) {
+                    parentNetName = Net.VCC_NET;
                     parentPhysNet = design.getVccNet();
-                } else if (parentHierNetName.equals(EDIFTools.LOGICAL_GND_NET_NAME)) {
-                    parentHierNetName = Net.GND_NET;
+                } else if (parentNetName.equals(EDIFTools.LOGICAL_GND_NET_NAME)) {
+                    parentNetName = Net.GND_NET;
                     parentPhysNet = design.getGndNet();
                 } else {
-                    parentPhysNet = design.getNet(parentHierNetName);
+                    parentPhysNet = design.getNet(parentNetName);
                 }
                 if (parentPhysNet != null) {
                     // Merge both physical nets together
@@ -2832,7 +2833,7 @@ public class DesignTools {
                         }
                     }
                     design.movePinsToNewNetDeleteOldNet(net, parentPhysNet, true);
-                } else if (!net.rename(parentHierNetName)) {
+                } else if (!net.rename(parentNetName)) {
                     System.out.println("WARNING: Failed to adjust physical net name " + net.getName());
                 }
             }


### PR DESCRIPTION
Look at the non-hier logical net name to determine if it's a static net.

https://github.com/Xilinx/RapidWright/pull/703 previously only considered `<const{0,1}>` logical nets in the top cell; this PR considers their appearance in any cell.

Greater discussion should be had as to whether we should rely solely on the assumption that all logical nets with a name of `<const{0,1}>` are GND/VCC nets. A more robust solution would be to examine the this logical net to find its source pin, and make sure it really is driven by the `GND` or `VCC` primitive; however, this would be a linear search on every single processed net.

We could take a shortcut and use a different assumption that static nets must be driven by a cell instance called `GND` or `VCC` (allowing a binary search into `EDIFNet.portInsts`) but I'm not sure that's much better.

Alternatively, `EDIFNetlist.generateParentNetMap()` already does computation to collect a list GND and VCC logical port instances, perhaps it can be extended to track static nets too?