### PR TITLE
DesignTools.makePhysNetNamesConsistent() to use hier name

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2820,7 +2820,7 @@ public class DesignTools {
                     parentNetName = Net.GND_NET;
                     parentPhysNet = design.getGndNet();
                 } else {
-                    parentPhysNet = design.getNet(parentNetName);
+                    parentPhysNet = design.getNet(parentHierNet.getHierarchicalNetName());
                 }
                 if (parentPhysNet != null) {
                     // Merge both physical nets together

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2833,7 +2833,7 @@ public class DesignTools {
                         }
                     }
                     design.movePinsToNewNetDeleteOldNet(net, parentPhysNet, true);
-                } else if (!net.rename(parentNetName)) {
+                } else if (!net.rename(parentHierNet.getHierarchicalNetName())) {
                     System.out.println("WARNING: Failed to adjust physical net name " + net.getName());
                 }
             }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2814,10 +2814,8 @@ public class DesignTools {
                 Net parentPhysNet;
                 // Assume that a net named <const1> or <const0> is always a VCC or GND net
                 if (parentNetName.equals(EDIFTools.LOGICAL_VCC_NET_NAME)) {
-                    parentNetName = Net.VCC_NET;
                     parentPhysNet = design.getVccNet();
                 } else if (parentNetName.equals(EDIFTools.LOGICAL_GND_NET_NAME)) {
-                    parentNetName = Net.GND_NET;
                     parentPhysNet = design.getGndNet();
                 } else {
                     parentPhysNet = design.getNet(parentHierNet.getHierarchicalNetName());


### PR DESCRIPTION
Fixes bug introduced by #734.