### PR TITLE
PartialRouter's global router to not unpreserve sink nodes

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -192,17 +192,18 @@ public class PartialRouter extends RWRoute {
     @Override
     protected NodeStatus getGlobalRoutingNodeStatus(Net net, Node node) {
         // In softPreserve mode, allow global router to use all nodes -- including
-        // those already preserved by another net
+        // those already preserved by another net -- unless it is a must-have node
+        // (e.g. sink node on a hierarchical net; Vivado will complain otherwise)
 
         Net preservedNet = routingGraph.getPreservedNet(node);
         if (preservedNet != null) {
             // Unavailable only if it isn't carrying the net undergoing routing
-            return preservedNet == net ? NodeStatus.INUSE :
-                          softPreserve ? NodeStatus.AVAILABLE :
-                                         NodeStatus.UNAVAILABLE;
+            return (preservedNet == net) ? NodeStatus.INUSE :
+                    (softPreserve && routingGraph.getNode(node) == null) ? NodeStatus.AVAILABLE :
+                    NodeStatus.UNAVAILABLE;
         }
 
-        // A RouteNode will only be created if the net is necessary for
+        // A RouteNode will only be created if the node is necessary for
         // a to-be-routed connection
         return softPreserve || routingGraph.getNode(node) == null ? NodeStatus.AVAILABLE
                                                                   : NodeStatus.UNAVAILABLE;

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -195,22 +195,20 @@ public class PartialRouter extends RWRoute {
         if (preservedNet == net) {
             return NodeStatus.INUSE;
         }
-        if (preservedNet != null) {
-            // In softPreserve mode, allow global router to use all nodes -- including
-            // those already preserved by another net, unless it's the input pin
-            RouteNode rnode = (softPreserve) ? routingGraph.getNode(node) : null;
-            if (rnode == null) {
-                return NodeStatus.AVAILABLE;
-            }
-
-            return (rnode.getType() != RouteNodeType.PINFEED_I) ? NodeStatus.AVAILABLE :
-                    NodeStatus.UNAVAILABLE;
+        if (!softPreserve && preservedNet != null) {
+            return NodeStatus.UNAVAILABLE;
         }
 
-        // A RouteNode would only have been created if it is necessary for
-        // a to-be-routed connection
-        return softPreserve || routingGraph.getNode(node) == null ? NodeStatus.AVAILABLE
-                                                                  : NodeStatus.UNAVAILABLE;
+        RouteNode rnode = routingGraph.getNode(node);
+        if (rnode != null) {
+            // In softPreserve mode, allow global router to use all nodes -- including
+            // those already preserved by another net, unless it's an input pin
+            if (!softPreserve || rnode.getType() == RouteNodeType.PINFEED_I) {
+                return NodeStatus.UNAVAILABLE;
+            }
+        }
+
+        return NodeStatus.AVAILABLE;
     }
 
     @Override

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -655,7 +655,7 @@ public class PartialRouter extends RWRoute {
                 pinsToRoute, softPreserve);
     }
 
-    /**`
+    /**
      * Routes a design in the partial timing-driven routing mode.
      * @param design The {@link Design} instance to be routed.
      * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed. If null, route all nets with no routing PIPs already present.

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -302,6 +302,14 @@ public class RWRoute{
                     addNetConnectionToRoutingTargets(net);
                 } else if (RouterHelper.isDriverLessOrLoadLessNet(net)) {
                     preserveNet(net, true);
+                    if (DesignTools.isNetDrivenByHierPort(net)) {
+                        // For the case of nets driven by hierarchical ports (out of context designs)
+                        // create a RouteNode for all its sink ports in order to prevent them from
+                        // being unpreserved
+                        for (SitePinInst spi : net.getSinkPins()) {
+                            getOrCreateRouteNode(spi.getConnectedNode(), RouteNodeType.PINFEED_I);
+                        }
+                    }
                     numNotNeedingRoutingNets++;
                 } else if (RouterHelper.isInternallyRoutedNet(net)) {
                     preserveNet(net, true);

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -379,8 +379,8 @@ public class RWRoute{
     protected NodeStatus getGlobalRoutingNodeStatus(Net net, Node node) {
         if (routingGraph.isPreserved(node)) {
             // Node is preserved by any net -- for base RWRoute, we don't need
-            // to check which net it is because global/static nets are routed
-            // fully in one pass
+            // to check which net it is nor whether it is already in use
+            // because global/static nets are routed from scratch
             return NodeStatus.UNAVAILABLE;
         }
 


### PR DESCRIPTION
1. PartialRouter's global router -- when `softPreserved` is enabled -- currently allows it to use any node preserved by any othernet. Amend it so that input pin nodes (identified through its associated `RouteNode`) cannot be repurposed.
2. For hier-ports (i.e. out of context top-level inputs), create input pin nodes so that the global router cannot steal them. Not doing so causes Vivado to flag a conflict, presumably because a future net would have no chance of getting to that pin.