### PR TITLE
DesignTools.createCeSrRstPinsToVCC() to skip non-SLICE FFs

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3092,6 +3092,9 @@ public class DesignTools {
         for (Cell cell : design.getCells()) {
             if (isUnisimFlipFlopType(cell.getType())) {
                 SiteInst si = cell.getSiteInst();
+                if (!Utils.isSLICE(si)) {
+                    continue;
+                }
                 BEL bel = cell.getBEL();
                 Pair<String, String> sitePinNames = pinMapping.get(bel.getBELType());
                 String[] pins = new String[] {"CE", "SR"};

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3089,6 +3089,7 @@ public class DesignTools {
             gndInvertibleToVcc = design.getGndNet();
         }
         Map<String, Pair<String, String>> pinMapping = belTypeSitePinNameMapping.get(series);
+        final String[] pins = new String[] {"CE", "SR"};
         for (Cell cell : design.getCells()) {
             if (isUnisimFlipFlopType(cell.getType())) {
                 SiteInst si = cell.getSiteInst();
@@ -3097,7 +3098,6 @@ public class DesignTools {
                 }
                 BEL bel = cell.getBEL();
                 Pair<String, String> sitePinNames = pinMapping.get(bel.getBELType());
-                String[] pins = new String[] {"CE", "SR"};
                 for (String pin : pins) {
                     BELPin belPin = cell.getBEL().getPin(pin);
                     Net net = si.getNetFromSiteWire(belPin.getSiteWireName());

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -974,6 +974,15 @@ public class TestDesignTools {
     }
 
     @Test
+    public void testCreateCeSrRstPinsToVCCLaguna() {
+        Device device = Device.getDevice("xcvu5p");
+        Design design = new Design("testDesign", device.getName());
+        design.createAndPlaceCell("cell", Unisim.FDRE, "LAGUNA_X7Y341/RX_REG0");
+
+        DesignTools.createCeSrRstPinsToVCC(design);
+    }
+
+    @Test
     public void testMakePhysNetNamesConsistentLogicalVccGnd() {
         Design design = RapidWrightDCP.loadDCP("bug701.dcp");
 

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -280,18 +280,4 @@ public class TestRWRoute {
         }
     }
 
-    @Test
-    public void testBug738() {
-        Design design = RapidWrightDCP.loadDCP("bug738.dcp");
-
-        RWRoute.routeDesignFullNonTimingDriven(design);
-
-        if (FileTools.isVivadoOnPath()) {
-            // Testcase is an invalid placement, check for fully routed nets
-            ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(design);
-            Assertions.assertEquals(1912, rrs.fullyRoutedNets);
-            Assertions.assertEquals(438, rrs.netsWithRoutingErrors);
-        }
-    }
-
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -280,4 +280,18 @@ public class TestRWRoute {
         }
     }
 
+    @Test
+    public void testBug738() {
+        Design design = RapidWrightDCP.loadDCP("bug738.dcp");
+
+        RWRoute.routeDesignFullNonTimingDriven(design);
+
+        if (FileTools.isVivadoOnPath()) {
+            // Testcase is an invalid placement, check for fully routed nets
+            ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(design);
+            Assertions.assertEquals(1912, rrs.fullyRoutedNets);
+            Assertions.assertEquals(438, rrs.netsWithRoutingErrors);
+        }
+    }
+
 }


### PR DESCRIPTION
CC @zakn-amd 

Fixes #738, with test based on smaller of the two attached testcases. Both exhibit the same failure where `DesignTools.createCeSrRstPinsToVCC()` was trying to work on a Laguna flop.