### PR TITLE
Known failing test for Tile.getSites() result different to Vivado

### DIFF
--- a/test/src/com/xilinx/rapidwright/device/TestTile.java
+++ b/test/src/com/xilinx/rapidwright/device/TestTile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Eddie Hung, Advanced Micro Devices, Inc.
@@ -49,14 +49,16 @@ public class TestTile {
 
     @ParameterizedTest
     @CsvSource({
-            "xcvu3p,LAG_LAG_X30Y50,'[]'",
-            "xcvu3p,LAG_LAG_X30Y250,'[]'",
-            "xcvu5p,LAG_LAG_X30Y50,'[]'",
-            "xcvu5p,LAG_LAG_X30Y250,'[LAGUNA_X6Y140, LAGUNA_X6Y141, LAGUNA_X7Y140, LAGUNA_X7Y141]'",
+            "xcvu5p,LAG_LAG_X30Y250,'[LAGUNA_X6Y140, LAGUNA_X6Y141, LAGUNA_X7Y140, LAGUNA_X7Y141]',true",
+
+            // FIXME: Known broken -- see https://github.com/Xilinx/RapidWright/issues/745
+            "xcvu3p,LAG_LAG_X30Y50,'[]',false",
+            "xcvu3p,LAG_LAG_X30Y250,'[]',false",
+            "xcvu5p,LAG_LAG_X30Y50,'[]',false",
     })
-    public void testGetSites(String partName, String tileName, String expectedSites) {
+    public void testGetSites(String partName, String tileName, String expectedSites, boolean expectPass) {
         Device dev = Device.getDevice(partName);
         Tile tile = dev.getTile(tileName);
-        Assertions.assertEquals(expectedSites, Arrays.toString(tile.getSites()));
+        Assertions.assertEquals(expectPass, expectedSites.equals(Arrays.toString(tile.getSites())));
     }
 }

--- a/test/src/com/xilinx/rapidwright/device/TestTile.java
+++ b/test/src/com/xilinx/rapidwright/device/TestTile.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.Arrays;
+
 public class TestTile {
     @ParameterizedTest
     @CsvSource({
@@ -43,5 +45,18 @@ public class TestTile {
         } else {
             Assertions.assertDoesNotThrow(e);
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "xcvu3p,LAG_LAG_X30Y50,'[]'",
+            "xcvu3p,LAG_LAG_X30Y250,'[]'",
+            "xcvu5p,LAG_LAG_X30Y50,'[]'",
+            "xcvu5p,LAG_LAG_X30Y250,'[LAGUNA_X6Y140, LAGUNA_X6Y141, LAGUNA_X7Y140, LAGUNA_X7Y141]'",
+    })
+    public void testGetSites(String partName, String tileName, String expectedSites) {
+        Device dev = Device.getDevice(partName);
+        Tile tile = dev.getTile(tileName);
+        Assertions.assertEquals(expectedSites, Arrays.toString(tile.getSites()));
     }
 }


### PR DESCRIPTION
On VU3P:
```
get_sites -of [get_tiles LAG_LAG_X30Y250]
WARNING: [Vivado 12-3731] No sites matched '*'
```

On VU5P:
```
get_sites -of [get_tiles LAG_LAG_X30Y250]
LAGUNA_X6Y140 LAGUNA_X6Y141 LAGUNA_X7Y140 LAGUNA_X7Y141
```

whereas RapidWright currently returns sites for all four testcases (the first three of which is incorrect).

Discovered during the analysis of https://github.com/Xilinx/RapidWright/issues/738 which uses the VU3P (not that nextpnr should place a regular `FDRE` onto a Laguna BEL, even if there was a valid site)