### PR TITLE
[RWRoute] Fix PartialRouter for when clk node already unpreserved

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -232,10 +232,13 @@ public class PartialRouter extends RWRoute {
                         if (preservedNet == clk) {
                             continue;
                         }
-                        assert(preservedNet != null);
+                        if (preservedNet == null) {
+                            // Assume this node has already been unpreserved
+                        } else {
+                            unpreserveNet(preservedNet);
+                            unpreserveNets.add(preservedNet);
+                        }
 
-                        unpreserveNet(preservedNet);
-                        unpreserveNets.add(preservedNet);
                         // Redo preserving clk
                         Net oldNet = routingGraph.preserve(node, clk);
                         assert(oldNet == null);


### PR DESCRIPTION
PartialRouter currently supports (fully) re-routing clocks like the base RWRoute, with one exception: when `softPreserve` is enabled, its clock router is allowed to "steal" resources from existing routing that would otherwise be preserved.

Afterwards, PartialRouter will examine the clock routing and unpreserve those nets that now need rerouting, and correctly preserve clock resources so that they can't be used again.

This PR fixes a flaw in this process where a "victim" net has already been unpreserved before, which would otherwise cause it to fail.