### PR TITLE
Fix 748 - Updates RAM32X1S property to correct default

### DIFF
--- a/src/com/xilinx/rapidwright/util/DataVersions.java
+++ b/src/com/xilinx/rapidwright/util/DataVersions.java
@@ -351,6 +351,6 @@ public class DataVersions {
         dataVersionMap.put("data/devices/zynquplusrfsoc/xqzu49dr_db.dat", new Pair<>("xqzu49dr-db-dat", "ff145122f2caea588120ac4da439d838"));
         dataVersionMap.put("data/partdump.csv", new Pair<>("partdump-csv", "f5aa2d4c08196e330576bda0e644772a"));
         dataVersionMap.put("data/parts.db", new Pair<>("parts-db", "f5d8a26178d35bd1a68c441b37a04279"));
-        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "ce8410650ad739c8630b12c3152693a3"));
+        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "85322379ad298d5a710d24a731d151e8"));
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -543,9 +543,6 @@ class TestEDIFNetlist {
     @ParameterizedTest
     @CsvSource({
             "RAM32X1S,1'b0",
-            "RAM32X1S_1,1'b1",
-            "RAM16X1S,1'b0",
-            "RAM16X1S_1,1'b1",
     })
     public void testRAM32X1SExpansion(String unisim, String expected) {
         EDIFNetlist n = EDIFTools.createNewNetlist("test");
@@ -559,5 +556,28 @@ class TestEDIFNetlist {
         EDIFCellInst inst = n.getCellInstFromHierName("inst/SP");
         Assertions.assertNotNull(inst);
         Assertions.assertEquals(expected, inst.getProperty("IS_CLK_INVERTED").getValue());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "RAM32X1S_1",
+            "RAM16X1S",
+            "RAM16X1S_1",
+    })
+    public void testUnsupportedMacroExpansionAndProperty(String unisim) {
+        EDIFNetlist n = EDIFTools.createNewNetlist("test");
+
+        EDIFCell macro = n.getHDIPrimitivesLibrary().addCell(Design.getUnisimCell(Unisim.valueOf(unisim)));
+        EDIFCellInst inst = n.getTopCell().createChildCellInst("inst", macro);
+
+        Assertions.assertEquals(0, inst.getCellType().getCellInsts().size());
+
+        n.expandMacroUnisims(Series.Series7);
+
+        // Assert no expansion/retargeting occurred for unsupported macros
+        Assertions.assertEquals(0, inst.getCellType().getCellInsts().size());
+
+        // Assert no property exists on unsupported macros either
+        Assertions.assertNull(inst.getProperty("IS_CLK_INVERTED"));
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -539,4 +539,19 @@ class TestEDIFNetlist {
         Assertions.assertEquals(childInst.getCellType().getName(), "OBUFTDS_DCIEN_DUAL_BUF");
         Assertions.assertEquals(childInst.getCellType().getCellInsts().size(), 3);
     }
+
+    @Test
+    public void testRAM32X1SExpansion() {
+        EDIFNetlist n = EDIFTools.createNewNetlist("test");
+
+        EDIFCell ram32x1s = n.getHDIPrimitivesLibrary().addCell(Design.getUnisimCell(Unisim.RAM32X1S));
+        n.getTopCell().createChildCellInst("inst", ram32x1s);
+
+        Assertions.assertNull(n.getCellInstFromHierName("inst/SP"));
+
+        n.expandMacroUnisims(Series.Series7);
+        EDIFCellInst inst = n.getCellInstFromHierName("inst/SP");
+        Assertions.assertNotNull(inst);
+        Assertions.assertEquals("string(1'b0)", inst.getProperty("IS_CLK_INVERTED").toString());
+    }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -540,18 +540,24 @@ class TestEDIFNetlist {
         Assertions.assertEquals(childInst.getCellType().getCellInsts().size(), 3);
     }
 
-    @Test
-    public void testRAM32X1SExpansion() {
+    @ParameterizedTest
+    @CsvSource({
+            "RAM32X1S,1'b0",
+            "RAM32X1S_1,1'b1",
+            "RAM16X1S,1'b0",
+            "RAM16X1S_1,1'b1",
+    })
+    public void testRAM32X1SExpansion(String unisim, String expected) {
         EDIFNetlist n = EDIFTools.createNewNetlist("test");
 
-        EDIFCell ram32x1s = n.getHDIPrimitivesLibrary().addCell(Design.getUnisimCell(Unisim.RAM32X1S));
-        n.getTopCell().createChildCellInst("inst", ram32x1s);
+        EDIFCell macro = n.getHDIPrimitivesLibrary().addCell(Design.getUnisimCell(Unisim.valueOf(unisim)));
+        n.getTopCell().createChildCellInst("inst", macro);
 
         Assertions.assertNull(n.getCellInstFromHierName("inst/SP"));
 
         n.expandMacroUnisims(Series.Series7);
         EDIFCellInst inst = n.getCellInstFromHierName("inst/SP");
         Assertions.assertNotNull(inst);
-        Assertions.assertEquals("string(1'b0)", inst.getProperty("IS_CLK_INVERTED").toString());
+        Assertions.assertEquals(expected, inst.getProperty("IS_CLK_INVERTED").getValue());
     }
 }


### PR DESCRIPTION
Fixes #748 by updating `unisim_data.dat` with the appropriate setting for `IS_CLK_INVERTED`.