### PR TITLE
Add DesignTools.getAllRoutedSitePinsFromPhysicalPin()

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1313,8 +1313,7 @@ public class DesignTools {
             }
             if (otherUser == false) {
                 // Unroute site routing back to pin and remove site pin
-                String sitePinName = getRoutedSitePinFromPhysicalPin(cell, net, pin.getName());
-                if (sitePinName != null) {
+                for (String sitePinName : getAllRoutedSitePinsFromPhysicalPin(cell, net, pin.getName())) {
                     BELPin sitePortBelPin = siteInst.getSite().getBELPin(sitePinName);
                     assert(sitePortBelPin.isSitePort());
                     boolean outputSitePin = sitePortBelPin.isInput(); // Input BELPin means output SitePin

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2137,17 +2137,15 @@ public class DesignTools {
     /**
      * Gets the site pin that is currently routed to the specified cell pin.  If
      * the site instance is not routed, it will return null.
-     * Side Effect: It will set alternative source site pins on the net if present.
      * @param cell The cell with the pin of interest.
      * @param net The physical net to which this pin belongs
      * @param belPinName The physical pin name of the cell
-     * @return The name of the site pin on the cell's site to which the pin is routed.
+     * @return The name of the first site pin on the cell's site to which the pin is routed.
      */
     public static String getRoutedSitePinFromPhysicalPin(Cell cell, Net net, String belPinName) {
         SiteInst inst = cell.getSiteInst();
         if (belPinName == null) return null;
         Set<String> siteWires = new HashSet<>(inst.getSiteWiresFromNet(net));
-        String toReturn = null;
         Queue<BELPin> queue = new LinkedList<>();
         queue.add(cell.getBEL().getPin(belPinName));
         while (!queue.isEmpty()) {
@@ -2183,23 +2181,7 @@ public class DesignTools {
                     if (!siteWires.contains(sink.getSiteWireName())) continue;
                     if (sink.isSitePort()) {
                         // Check if there is a dual output scenario
-                        if (toReturn != null) {
-                            SitePinInst source = net.getSource();
-                            String toCreate;
-                            if (source != null && source.getName().equals(sink.getName())) {
-                                toCreate = toReturn;
-                                toReturn = sink.getName();
-                            } else {
-                                toCreate = sink.getName();
-                            }
-                            if (inst.getSitePinInst(toCreate) == null)
-                                net.createPin(toCreate, inst);
-                            // We'll return the first one we found, store the 2nd in the alternate
-                            // reference on the net
-                            return toReturn;
-                        } else {
-                            toReturn = sink.getName();
-                        }
+                        return sink.getName();
                     } else if (sink.getBEL().getBELClass() == BELClass.RBEL) {
                         // Check if the SitePIP is being used
                         SitePIP sitePIP = inst.getUsedSitePIP(sink.getBELName());
@@ -2218,7 +2200,7 @@ public class DesignTools {
                 }
             }
         }
-        return toReturn;
+        return null;
     }
 
     /**

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3202,9 +3202,7 @@ public class DesignTools {
         Net net = (netOnSiteWire != null) ? netOnSiteWire : si.getDesign().getVccNet();
         if (net.isStaticNet()) {
             // SRL16Es that have been transformed from SRLC32E require GND on their A6 pin
-            if (cell.getType().equals("SRL16E") && siteWireName.endsWith("6") &&
-                    //
-                    cell.getEDIFHierCellInst() != null) {
+            if (cell.getType().equals("SRL16E") && siteWireName.endsWith("6")) {
                 EDIFPropertyValue val = cell.getProperty("XILINX_LEGACY_PRIM");
                 if (val != null && val.getValue().equals("SRLC32E")) {
                     net = si.getDesign().getGndNet();

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2125,7 +2125,7 @@ public class DesignTools {
      * @param cell The cell with the pin of interest.
      * @param net The physical net to which this pin belongs
      * @param logicalPinName The logical pin name of the cell to query.
-     * @return The name of the site pin name on the cell's site to which the pin is routed.
+     * @return The name of the first site pin on the cell's site to which the pin is routed.
      */
     public static String getRoutedSitePin(Cell cell, Net net, String logicalPinName) {
         String belPinName = cell.getPhysicalPinMapping(logicalPinName);
@@ -2138,7 +2138,7 @@ public class DesignTools {
      * @param cell The cell with the pin of interest.
      * @param net The physical net to which this pin belongs
      * @param belPinName The physical pin name of the cell
-     * @return The name of the first site pin name on the cell's site to which the pin is routed.
+     * @return The name of the first site pin on the cell's site to which the pin is routed.
      */
     public static String getRoutedSitePinFromPhysicalPin(Cell cell, Net net, String belPinName) {
         List<String> sitePins = getAllRoutedSitePinsFromPhysicalPin(cell, net, belPinName);
@@ -2178,7 +2178,7 @@ public class DesignTools {
                     return Collections.singletonList(source.getName());
                 } else if (source.getBEL().getBELClass() == BELClass.RBEL) {
                     SitePIP sitePIP = inst.getUsedSitePIP(source.getBELName());
-                    if (sitePIP == null) return Collections.emptyList();
+                    if (sitePIP == null) continue;
                     queue.add(sitePIP.getInputPin());
                 } else if (source.getBEL().isLUT() || source.getBEL().getBELType().endsWith("MUX")) {
                     Cell possibleRouteThru = inst.getCell(source.getBEL());

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2157,7 +2157,7 @@ public class DesignTools {
      */
     public static List<String> getAllRoutedSitePinsFromPhysicalPin(Cell cell, Net net, String belPinName) {
         SiteInst inst = cell.getSiteInst();
-        if (belPinName == null) return null;
+        if (belPinName == null) return Collections.emptyList();
         List<String> sitePins = new ArrayList<>();
         Set<String> siteWires = new HashSet<>(inst.getSiteWiresFromNet(net));
         Queue<BELPin> queue = new LinkedList<>();
@@ -2170,11 +2170,11 @@ public class DesignTools {
                 if (siteWireName.equals("CIN") || siteWireName.equals("COUT")) {
                     return Collections.singletonList(siteWireName);
                 }
-                return null;
+                return Collections.emptyList();
             }
             if (curr.isInput()) {
                 BELPin source = curr.getSourcePin();
-                if (source == null) return null;
+                if (source == null) return Collections.emptyList();
                 if (source.isSitePort()) {
                     return Collections.singletonList(source.getName());
                 } else if (source.getBEL().getBELClass() == BELClass.RBEL) {
@@ -3185,7 +3185,9 @@ public class DesignTools {
         Net net = (netOnSiteWire != null) ? netOnSiteWire : si.getDesign().getVccNet();
         if (net.isStaticNet()) {
             // SRL16Es that have been transformed from SRLC32E require GND on their A6 pin
-            if (cell.getType().equals("SRL16E") && siteWireName.endsWith("6")) {
+            if (cell.getType().equals("SRL16E") && siteWireName.endsWith("6") &&
+                    //
+                    cell.getEDIFHierCellInst() != null) {
                 EDIFPropertyValue val = cell.getProperty("XILINX_LEGACY_PRIM");
                 if (val != null && val.getValue().equals("SRLC32E")) {
                     net = si.getDesign().getGndNet();

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -555,8 +555,7 @@ public class RWRoute{
                     if (altSource != null) {
                         assert(!altSource.equals(source));
                         Node altSourceNode = RouterHelper.projectOutputPinToINTNode(altSource);
-                        assert(altSourceNode != null);
-                        altSourceINTRnode = getOrCreateRouteNode(altSourceNode, RouteNodeType.PINFEED_O);
+                        altSourceINTRnode = altSourceNode != null ? getOrCreateRouteNode(altSourceNode, RouteNodeType.PINFEED_O) : null;
                     }
 
                     if (sourceINTNode != null) {

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -212,23 +212,35 @@ public class TestDesignTools {
 
         final Set<String> dualOutputNets = new HashSet<String>() {{
             add("picoblaze_2_25/processor/alu_result_0");
-            add("picoblaze_2_25/processor/alu_result_1");
             add("picoblaze_2_25/processor/alu_result_2");
-            add("picoblaze_8_43/processor/pc_move_is_valid");
             add("picoblaze_0_43/processor/E[0]");
+        }};
+
+        final Set<String> possibleDualOutputNets = new HashSet<String>() {{
+            add("picoblaze_2_25/processor/alu_result_1");
+            add("picoblaze_8_43/processor/pc_move_is_valid");
         }};
 
         for (Net net : design.getNets()) {
             Collection<SitePinInst> pins = net.getPins();
-            if (net.getSource() != null) {
-                Assertions.assertTrue(pins.contains(net.getSource()));
+            SitePinInst source = net.getSource();
+            if (source != null) {
+                Assertions.assertTrue(pins.contains(source));
             }
-            if (net.getAlternateSource() != null) {
-                Assertions.assertTrue(pins.contains(net.getAlternateSource()));
+            SitePinInst altSource = net.getAlternateSource();
+            if (altSource != null) {
+                Assertions.assertTrue(pins.contains(altSource));
             }
 
             if (dualOutputNets.contains(net.getName())) {
-                Assertions.assertTrue(net.getSource() != null && net.getAlternateSource() != null);
+                Assertions.assertNotNull(source);
+                Assertions.assertNotNull(altSource);
+            } else if (possibleDualOutputNets.contains(net.getName())) {
+                Assertions.assertNotNull(source);
+                Assertions.assertNull(altSource);
+                altSource = DesignTools.getLegalAlternativeOutputPin(net);
+                Assertions.assertNotNull(altSource);
+                Assertions.assertNotEquals(altSource, source);
             }
         }
     }


### PR DESCRIPTION
Prior, the only method was `DesignTools.getRoutedSitePinFromPhysicalPin()` which (a) only returned the first site pin, and (b) returned the other output site pin by adding it to the `Net` and thus having a side effect which has caused problems.

This side effect was actually causing an assumption in RWRoute (that the `COUT` pin was always the primary source, with a `HMUX` pin a possible alternate) to break since `DesignTools.getRoutedSitePinFromPhysicalPin()` actually set `HMUX` as the primary source. 

Note that `DesignTools.createMissingSitePinInsts()` -- which calls `DesignTools.getRoutedSitePinFromPhysicalPin()` -- will now not infer any dual output pins. If those are needed, they can be explicitly gotten, as RWRoute does.