### PR TITLE
GlobalSignalRouting.routeStaticNet() to create output SPIs

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -52,6 +52,7 @@ import com.xilinx.rapidwright.device.Part;
 import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.TileTypeEnum;
+import com.xilinx.rapidwright.edif.EDIFHierNet;
 import com.xilinx.rapidwright.router.RouteThruHelper;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.timing.ClkRouteTiming;
@@ -177,7 +178,13 @@ public class RWRoute{
                 + "supported series: " + SUPPORTED_SERIES;
     }
 
-    protected static void preprocess(Design design) {
+    /**
+     * Pre-process the design to ensure that only the physical {@link Net}-s corresponding to
+     * the parent logical {@link EDIFHierNet} exists, and that such {@link Net}-s contain
+     * all necessary {@link SitePinInst} objects.
+     * @param design Design to preprocess
+     */
+    public static void preprocess(Design design) {
         Series series = design.getPart().getSeries();
         if (!SUPPORTED_SERIES.contains(series)) {
             throw new RuntimeException(getUnsupportedSeriesMessage(design.getPart()));

--- a/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
@@ -24,10 +24,9 @@ package com.xilinx.rapidwright.rwroute;
 
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
-import com.xilinx.rapidwright.design.DesignTools;
 import com.xilinx.rapidwright.design.Net;
-import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.design.SitePinInst;
+import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.router.RouteThruHelper;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
@@ -69,9 +68,7 @@ public class TestGlobalSignalRouting {
     public void testRouteStaticNet() {
         Design design = RapidWrightDCP.loadDCP("optical-flow.dcp");
 
-        DesignTools.makePhysNetNamesConsistent(design);
-        DesignTools.createPossiblePinsToStaticNets(design);
-        DesignTools.createMissingSitePinInsts(design);
+        RWRoute.preprocess(design);
 
         List<SitePinInst> gndPins = design.getGndNet().getPins();
         List<SitePinInst> vccPins = design.getVccNet().getPins();

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -264,8 +264,9 @@ public class TestRWRoute {
         Assertions.assertTrue(vcc.getPins().stream().allMatch(SitePinInst::isRouted));
 
         Net gnd = design.getGndNet();
-        Assertions.assertEquals(31, gnd.getPins().size());
-        Assertions.assertTrue(gnd.getPins().stream().allMatch(SitePinInst::isRouted));
+        List<SitePinInst> sinks = gnd.getSinkPins();
+        Assertions.assertEquals(31, sinks.size());
+        Assertions.assertTrue(sinks.stream().allMatch(SitePinInst::isRouted));
 
         if (FileTools.isVivadoOnPath()) {
             // Testcase has a number of undriven nets, so just check for unrouted nets


### PR DESCRIPTION
... when using non-tied-node sources (e.g. LUTs).

It appears that `Design.readCheckpoint()` does this for (fully-routed) static nets loaded from DCP, it makes sense that we do this when routing ourselves too.

Maintaining this invariant can also make the determination of non-tied-node static sources more efficient. An example would be `DesignTools.unrouteGNDNetAndLUTSources()` from #760, as well as for #762.