### PR TITLE
Fix module relocation in the face of tile node depopulation

### DIFF
--- a/src/com/xilinx/rapidwright/design/ModuleInst.java
+++ b/src/com/xilinx/rapidwright/design/ModuleInst.java
@@ -389,6 +389,11 @@ public class ModuleInst extends AbstractModuleInst<Module, Site, ModuleInst>{
                 if (pipSet != null) {
                     pipSet.add(newPip);
                 }
+                // Some tiles have nodes that are depopulated, we need to detect those
+                if (newPip.getEndNode().getAllDownhillPIPs().size() == 0
+                        && pip.getEndNode().getAllDownhillPIPs().size() != 0) {
+                    return false;
+                }
                 net.addPIP(newPip);
             }
         }

--- a/src/com/xilinx/rapidwright/design/ModuleInst.java
+++ b/src/com/xilinx/rapidwright/design/ModuleInst.java
@@ -34,6 +34,7 @@ import com.xilinx.rapidwright.design.blocks.PBlock;
 import com.xilinx.rapidwright.design.blocks.PBlockRange;
 import com.xilinx.rapidwright.design.noc.NOCClient;
 import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.SiteTypeEnum;
@@ -390,7 +391,8 @@ public class ModuleInst extends AbstractModuleInst<Module, Site, ModuleInst>{
                     pipSet.add(newPip);
                 }
                 // Some tiles have nodes that are depopulated, we need to detect those
-                if (newPip.getEndNode().getAllDownhillPIPs().size() == 0
+                Node endNode = newPip.getEndNode();
+                if (endNode != null && endNode.getAllDownhillPIPs().size() == 0
                         && pip.getEndNode().getAllDownhillPIPs().size() != 0) {
                     return false;
                 }

--- a/test/src/com/xilinx/rapidwright/design/TestModuleInst.java
+++ b/test/src/com/xilinx/rapidwright/design/TestModuleInst.java
@@ -27,6 +27,7 @@ import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
@@ -36,6 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashSet;
+import java.util.Set;
 
 public class TestModuleInst {
     @ParameterizedTest
@@ -215,5 +217,36 @@ public class TestModuleInst {
         mi1.connect("output_port_x", 0, mi2, "input_port_a", 0);
         Assertions.assertEquals("[OUT SLICE_X15Y237.HQ2, IN SLICE_X16Y233.A2]", net1.getPins().toString());
         Assertions.assertTrue(net2.getPins().isEmpty());
+    }
+
+    @Test
+    public void testPlaceWithDepopulatedNodes() {
+        Design modDesign = new Design("module", "xcvu13p-fsga2577-1-i");
+        Cell src = modDesign.createAndPlaceCell("src", Unisim.LUT6, "SLICE_X148Y899/H6LUT");
+        Cell snk = modDesign.createAndPlaceCell("snk", Unisim.FDCE, "SLICE_X145Y899/DFF2");
+
+        Net physNet = TestDesignHelper.createTestNet(modDesign, "net0",
+                new String[] { "INT_X94Y899/INT.LOGIC_OUTS_E28->INT_NODE_SDQ_42_INT_OUT0",
+                        "INT_X94Y899/INT.INT_NODE_SDQ_42_INT_OUT1->>WW4_E_BEG7",
+                        "INT_X92Y899/INT.WW4_E_END7->>INT_NODE_GLOBAL_12_INT_OUT1", // Node fanout does not exist in all
+                                                                                    // Tiles
+                        "INT_X92Y899/INT.INT_NODE_GLOBAL_12_INT_OUT1->>CTRL_W1", });
+
+        EDIFNet logNet = physNet.getLogicalNet();
+        logNet.createPortInst("O", src);
+        logNet.createPortInst("CE", snk);
+
+        Module module = new Module(modDesign);
+
+        Design design = new Design("top", modDesign.getPartName());
+        ModuleInst mi = design.createModuleInst("inst0", module);
+
+        System.out.println(module.getAnchor().getName());
+
+        Set<Site> validAnchorSites = new HashSet<>(mi.getAllValidPlacements());
+
+        Assertions.assertFalse(validAnchorSites.contains(design.getDevice().getSite("SLICE_X117Y589")));
+        Assertions.assertEquals(70560, validAnchorSites.size());
+
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestModuleInst.java
+++ b/test/src/com/xilinx/rapidwright/design/TestModuleInst.java
@@ -241,8 +241,6 @@ public class TestModuleInst {
         Design design = new Design("top", modDesign.getPartName());
         ModuleInst mi = design.createModuleInst("inst0", module);
 
-        System.out.println(module.getAnchor().getName());
-
         Set<Site> validAnchorSites = new HashSet<>(mi.getAllValidPlacements());
 
         Assertions.assertFalse(validAnchorSites.contains(design.getDevice().getSite("SLICE_X117Y589")));


### PR DESCRIPTION
Some tiles around IO columns can have certain nodes depopulated from the standard set.  This breaks the relocatability of some modules when the routes use those nodes in other contexts.  This change detects the depopulated nodes and ensures the module cannot be placed in those locations.

For example: 
The tile `INT_X94Y899` in the `xcvu13p` device is fully populated:
![image](https://github.com/Xilinx/RapidWright/assets/20803522/5a922d06-9021-4dcb-9d84-7cb64f060fa4)

However, the tile `INT_X74Y589` in the same device is not:
![image](https://github.com/Xilinx/RapidWright/assets/20803522/24bdb521-437b-436e-abd0-d508b2495759)

