### PR TITLE
RWRoute Fixes

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -350,9 +350,11 @@ public class PartialRouter extends RWRoute {
                 rend.setPrev(rstart);
             }
 
-            // Use the prev pointers to attempt to recover routing for all connections
+            // Use the prev pointers to attempt to recover routing for all indirect connections
             for (Connection connection : netWrapper.getConnections()) {
-                finishRouteConnection(connection, connection.getSinkRnode());
+                if (!connection.isDirect()) {
+                    finishRouteConnection(connection, connection.getSinkRnode());
+                }
             }
         }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1356,7 +1356,7 @@ public class RWRoute{
                     altSource = net.getSource();
                 }
                 Node altSourceINTNode = RouterHelper.projectOutputPinToINTNode(altSource);
-                if (altSourceINTNode.equals(sourceRnode.getNode())) {
+                if (sourceRnode.getNode().equals(altSourceINTNode)) {
                     RouteNode altSourceRnode = sourceRnode;
                     connection.setSource(altSource);
                     connection.setSourceRnode(altSourceRnode);


### PR DESCRIPTION
1. `PartialRouter.determineRoutingTargets()` to only recover connections for indirect connections (avoiding NPE for direct connections, which may have no sink Rnode)
2. `RWRoute.saveRouting()` to be mindful of an alternate source that doesn't have an projected INT node -- such as `COUT` -- thus avoiding another NPE.