### PR TITLE
Set reversed flag on bi-directional PIPs used from end->start

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -374,7 +374,7 @@ public class GlobalSignalRouting {
                         if (debug) System.out.println("  " + routingNode.toString());
                         routingNode = routingNode.getPrev();
                     }
-                    netPIPs.addAll(RouterHelper.getPIPsFromNodes(pathNodes));
+                    netPIPs.addAll(RouterHelper.getPIPsFromNodes(pathNodes, true));
 
                     // If the source is an output site pin, put it aside for consideration
                     // to add as a new source pin

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -374,6 +374,9 @@ public class GlobalSignalRouting {
                         if (debug) System.out.println("  " + routingNode.toString());
                         routingNode = routingNode.getPrev();
                     }
+
+                    // Note that the static net router goes backward from sinks to sources,
+                    // requiring the srcToSinkOrder parameter to be set to true below
                     netPIPs.addAll(RouterHelper.getPIPsFromNodes(pathNodes, true));
 
                     // If the source is an output site pin, put it aside for consideration

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -197,19 +197,41 @@ public class RouterHelper {
         return getPIPsFromNodes(connection.getNodes());
     }
 
-
     /**
      * Gets a list of {@link PIP} instances from a list of {@link Node} instances.
-     * @param connectionNodes The list of nodes of a routed {@link Connection} instance.
+     * 
+     * @param connectionNodes The list of nodes of a routed {@link Connection}
+     *                        instance.
      * @return A list of PIPs generated from the list of nodes.
      */
     public static List<PIP> getPIPsFromNodes(List<Node> connectionNodes) {
+        return getPIPsFromNodes(connectionNodes, false);
+    }
+
+    /**
+     * Gets a list of {@link PIP} instances from a list of {@link Node} instances.
+     * 
+     * @param connectionNodes The list of nodes of a routed {@link Connection}
+     *                        instance.
+     * @param srcToSinkOrder  Specifies the order of the connection nodes. True
+     *                        indicates the first node is the source and the last
+     *                        is the sink. False indicates the opposite.
+     * @return A list of PIPs generated from the list of nodes.
+     */
+    public static List<PIP> getPIPsFromNodes(List<Node> connectionNodes, boolean srcToSinkOrder) {
         List<PIP> connectionPIPs = new ArrayList<>();
         if (connectionNodes == null) return connectionPIPs;
-        // Nodes of a connection are added to the list starting from its sink to its source
+        // Nodes of a connection are added to the list starting from its sink to its
+        // source -- unless srcToSinkOrder is true (as is the case in static routing)
+        int driverOffsetIdx = 1;
+        int loadOffsetIdx = 0;
+        if (srcToSinkOrder) {
+            driverOffsetIdx = 0;
+            loadOffsetIdx = 1;
+        }
         for (int i = 0; i < connectionNodes.size() - 1; i++) {
-            Node driver = connectionNodes.get(i+1);
-            Node load = connectionNodes.get(i);
+            Node driver = connectionNodes.get(i + driverOffsetIdx);
+            Node load = connectionNodes.get(i + loadOffsetIdx);
             PIP pip = findPIPbetweenNodes(driver, load);
             if (pip != null) {
                 connectionPIPs.add(pip);

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -249,6 +249,9 @@ public class RouterHelper {
             if (wire.getTile().equals(loadTile)) {
                 pip = loadTile.getPIP(wire.getWireIndex(), loadWire);
                 if (pip != null) {
+                    if (pip.isBidirectional() && pip.getStartWireIndex() == loadWire) {
+                        pip.setIsReversed(true);
+                    }
                     break;
                 }
             }
@@ -268,8 +271,12 @@ public class RouterHelper {
                 return p;
         }
         for (PIP p : driver.getAllUphillPIPs()) {
-            if (p.getStartNode().equals(load))
+            if (p.getStartNode().equals(load)) {
+                if (p.isBidirectional()) {
+                    p.setIsReversed(true);
+                }
                 return p;
+            }
         }
         return null;
     }


### PR DESCRIPTION
Previously, RWRoute was not setting the isReversed() flag on `PIP` objects.  This PR makes it so that all `PIP`s are properly set.  This also found that when routing static nets, the `PIP` creation process was using a less efficient method as it was presenting the connection nodes in order (rather than reverse order in typical routing).  This also modifies how static `PIP`s are created to present the driver/load ordering correctly.