### PR TITLE
Fix RouterHelper.projectOutputPinToINTNode() for depop pins

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -121,11 +121,14 @@ public class RouterHelper {
      * @return A node that connects to an INT tile from an output pin.
      */
     public static Node projectOutputPinToINTNode(SitePinInst output) {
-        Node intNode = null;
+        Node intNode = output.getConnectedNode();
         int watchdog = 5;
 
-        List<Node> downhillNodes = output.getConnectedNode().getAllDownhillNodes();
-        while (!downhillNodes.isEmpty() && downhillNodes.get(0).getTile().getTileTypeEnum() != TileTypeEnum.INT) {
+        List<Node> downhillNodes = intNode.getAllDownhillNodes();
+        if (downhillNodes.isEmpty()) {
+            return null;
+        }
+        while (downhillNodes.get(0).getTile().getTileTypeEnum() != TileTypeEnum.INT) {
             intNode = downhillNodes.get(0);
             if (downhillNodes.size() > 1) {
                 int i = 1;
@@ -136,8 +139,7 @@ public class RouterHelper {
             }
             watchdog--;
             if (intNode.getAllDownhillNodes().size() == 0 || watchdog < 0) {
-                intNode = null;
-                break;
+                return null;
             }
             downhillNodes = intNode.getAllDownhillNodes();
         }

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -121,16 +121,16 @@ public class RouterHelper {
      * @return A node that connects to an INT tile from an output pin.
      */
     public static Node projectOutputPinToINTNode(SitePinInst output) {
-        Node intNode = output.getConnectedNode();
+        Node intNode = null;
         int watchdog = 5;
 
-        while (intNode.getAllDownhillNodes().get(0).getTile().getTileTypeEnum() != TileTypeEnum.INT) {
-            List<Node> downhills = intNode.getAllDownhillNodes();
-            intNode = downhills.get(0);
-            if (downhills.size() > 1) {
+        List<Node> downhillNodes = output.getConnectedNode().getAllDownhillNodes();
+        while (!downhillNodes.isEmpty() && downhillNodes.get(0).getTile().getTileTypeEnum() != TileTypeEnum.INT) {
+            intNode = downhillNodes.get(0);
+            if (downhillNodes.size() > 1) {
                 int i = 1;
                 while (intNode.getAllDownhillNodes().size() == 0) {
-                    intNode = downhills.get(i);
+                    intNode = downhillNodes.get(i);
                     i++;
                 }
             }
@@ -139,6 +139,7 @@ public class RouterHelper {
                 intNode = null;
                 break;
             }
+            downhillNodes = intNode.getAllDownhillNodes();
         }
         return intNode;
     }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
@@ -5,15 +5,19 @@ import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestRouterHelper {
     @ParameterizedTest
-    @ValueSource(strings = {"SLICE_X0Y0", "SLICE_X0Y299"})
-    public void testProjectOutputPinToINTNodeCOUT(String siteName) {
+    @CsvSource({
+            "SLICE_X0Y0,COUT,null",
+            "SLICE_X0Y299,COUT,null",
+            "SLICE_X0Y0,A_O,CLEL_R_X0Y0/CLE_CLE_L_SITE_0_A_O"
+    })
+    public void testProjectOutputPinToINTNode(String siteName, String pinName, String nodeAsString) {
         Design design = new Design("design", "xcvu3p");
         SiteInst si = design.createSiteInst(siteName);
-        SitePinInst spi = new SitePinInst("COUT", si);
-        Assertions.assertNull(RouterHelper.projectOutputPinToINTNode(spi));
+        SitePinInst spi = new SitePinInst(pinName, si);
+        Assertions.assertEquals(nodeAsString, String.valueOf(RouterHelper.projectOutputPinToINTNode(spi)));
     }
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
@@ -1,0 +1,19 @@
+package com.xilinx.rapidwright.rwroute;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.design.SitePinInst;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestRouterHelper {
+    @ParameterizedTest
+    @ValueSource(strings = {"SLICE_X0Y0", "SLICE_X0Y299"})
+    public void testProjectOutputPinToINTNodeCOUT(String siteName) {
+        Design design = new Design("design", "xcvu3p");
+        SiteInst si = design.createSiteInst(siteName);
+        SitePinInst spi = new SitePinInst("COUT", si);
+        Assertions.assertNull(RouterHelper.projectOutputPinToINTNode(spi));
+    }
+}


### PR DESCRIPTION
e.g. `COUT` on the uppermost row of the device.