### PR TITLE
Add test for Design.movePinsToNewNetDeleteOldNet()

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3035,15 +3035,6 @@ public class DesignTools {
             }
 
             if (parentPhysNet != null) {
-                // Merge both physical nets together
-                for (SiteInst si : new ArrayList<>(net.getSiteInsts())) {
-                    List<String> siteWires = new ArrayList<>(si.getSiteWiresFromNet(net));
-                    for (String siteWire : siteWires) {
-                        BELPin[] pins = si.getSiteWirePins(siteWire);
-                        si.unrouteIntraSiteNet(pins[0], pins[0]);
-                        si.routeIntraSiteNet(parentPhysNet, pins[0], pins[0]);
-                    }
-                }
                 design.movePinsToNewNetDeleteOldNet(net, parentPhysNet, true);
             }
         }


### PR DESCRIPTION
Including one which has no pins (but does have intra-site routing).

Also eliminate redundant sitewire operations in `DesignTools.makePhysNetNamesConsistent()`.