### PR TITLE
RWRoute improvements

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -326,9 +327,27 @@ public class PartialRouter extends RWRoute {
         super.determineRoutingTargets();
 
         // Go through all nets to be routed
+        Map<RouteNode, RouteNode> stashedPrev = new HashMap<>();
         for (Map.Entry<Net, NetWrapper> e : nets.entrySet()) {
             Net net = e.getKey();
             NetWrapper netWrapper = e.getValue();
+
+            // Temporarily stash the prev pointer of all sink nodes ahead of recovering routing
+            // (it's possible for another connection to use a bounce node, but now that node is
+            // needed as a site pin)
+            for (Connection connection : netWrapper.getConnections()) {
+                for (RouteNode rnode : Arrays.asList(connection.getSinkRnode(), connection.getAltSinkRnode())) {
+                    if (rnode == null) {
+                        continue;
+                    }
+                    RouteNode prev = rnode.getPrev();
+                    if (prev == null) {
+                        continue;
+                    }
+                    stashedPrev.put(rnode, prev);
+                    rnode.clearPrev();
+                }
+            }
 
             // Create all nodes used by this net and set its previous pointer so that:
             // (a) the routing for each connection can be recovered by
@@ -356,6 +375,14 @@ public class PartialRouter extends RWRoute {
                     finishRouteConnection(connection, connection.getSinkRnode());
                 }
             }
+
+            // Restore prev to avoid assertions firing
+            for (Map.Entry<RouteNode, RouteNode> e2 : stashedPrev.entrySet()) {
+                RouteNode rnode = e2.getKey();
+                RouteNode prev = e2.getValue();
+                rnode.setPrev(prev);
+            }
+            stashedPrev.clear();
         }
 
         routingGraph.resetExpansion();

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -304,14 +304,13 @@ public class RWRoute{
                 addStaticNetRoutingTargets(net);
 
             } else if (net.getType().equals(NetType.WIRE)) {
-                if (RouterHelper.isRoutableNetWithSourceSinks(net)) {
+                if (RouterHelper.isDriverLessOrLoadLessNet(net) ||
+                        RouterHelper.isInternallyRoutedNet(net) ||
+                        net.getName().equals(Net.Z_NET)) {
+                    preserveNet(net, true);
+                    numNotNeedingRoutingNets++;
+                } else if (RouterHelper.isRoutableNetWithSourceSinks(net)) {
                     addNetConnectionToRoutingTargets(net);
-                } else if (RouterHelper.isDriverLessOrLoadLessNet(net)) {
-                    preserveNet(net, true);
-                    numNotNeedingRoutingNets++;
-                } else if (RouterHelper.isInternallyRoutedNet(net)) {
-                    preserveNet(net, true);
-                    numNotNeedingRoutingNets++;
                 } else {
                     numNotNeedingRoutingNets++;
                 }

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -846,20 +846,21 @@ public class RWRoute{
                 // Set the routed state on those source pins that were actually used
                 NetWrapper netWrapper = e.getValue();
                 for (Connection connection : netWrapper.getConnections()) {
-                    List<RouteNode> rnodes = connection.getRnodes();
-                    if (rnodes.isEmpty()) {
+                    // Examine getNodes() because connection.getRnodes() is empty for direct connections
+                    List<Node> nodes = connection.getNodes();
+                    if (nodes.isEmpty()) {
                         // Unroutable connection
                         continue;
                     }
 
                     // Set the routed state of the used source node
-                    RouteNode sourceRnode = rnodes.get(rnodes.size() - 1);
-                    if (sourceRnode.equals(connection.getSourceRnode())) {
+                    Node sourceNode = nodes.get(nodes.size() - 1);
+                    if (sourceNode.equals(connection.getSource().getConnectedNode())) {
                         connection.getSource().setRouted(true);
                     } else {
                         // Source used must have been the Net's alternate source
-                        assert(sourceRnode.equals(connection.getAltSourceRnode()));
                         assert(!altSource.equals(connection.getSource()));
+                        assert(sourceNode.equals(altSource.getConnectedNode()));
                         altSource.setRouted(true);
                     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -846,22 +846,25 @@ public class RWRoute{
                 // Set the routed state on those source pins that were actually used
                 NetWrapper netWrapper = e.getValue();
                 for (Connection connection : netWrapper.getConnections()) {
-                    List<Node> nodes = connection.getNodes();
-                    if (nodes.isEmpty()) {
+                    List<RouteNode> rnodes = connection.getRnodes();
+                    if (rnodes.isEmpty()) {
                         // Unroutable connection
                         continue;
                     }
 
-                    Node sourceRnode = nodes.get(nodes.size() - 1);
-                    if (sourceRnode.equals(connection.getSource().getConnectedNode())) {
+                    // Set the routed state of the used source node
+                    RouteNode sourceRnode = rnodes.get(rnodes.size() - 1);
+                    if (sourceRnode.equals(connection.getSourceRnode())) {
                         connection.getSource().setRouted(true);
                     } else {
-                        assert (sourceRnode.equals(altSource.getConnectedNode()));
-                        assert (connection.getSource().equals(source));
+                        // Source used must have been the Net's alternate source
+                        assert(sourceRnode.equals(connection.getAltSourceRnode()));
+                        assert(!altSource.equals(connection.getSource()));
                         altSource.setRouted(true);
                     }
 
                     if (source.isRouted() && (altSource == null || altSource.isRouted())) {
+                        // Break if all sources have been set to be routed
                         break;
                     }
                 }


### PR DESCRIPTION
* RWRoute to ignore the `GLOBAL_DUMMY_ROUTE` net
* `postRouteProcess()` and `saveRouting()` to be more robust with swapped sources
* `PartialRouter.determineRoutingTargets()` to stash the `RouteNode.prev` pointer when attempting to recover existing routing on connections, in order to prevent backtracking to the wrong source.