### PR TITLE
Update to fixed microblazeAndILA_3pblocks.dcp

### DIFF
--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -287,10 +287,13 @@ public class RelocationTools {
                     } else {
                         String destTileName = st.getRootName() + "_X" + (st.getTileXCoordinate() + tileColOffset)
                                 + "Y" + (st.getTileYCoordinate() + tileRowOffset);
-                        System.out.println("ERROR: Failed to move PIP '" + sp + "' to Tile '" + destTileName +
-                                "' (Net '" + n.getName() + "')");
-                        revertRouting = true;
-                        throw new RuntimeException();
+                        if (sp.isStub()) {
+                            System.out.println("INFO: Skipping stub PIP '" + sp + "' that failed to move to Tile '" + destTileName +
+                                    "' (Net '" + n.getName() + "')");
+                        } else {
+                            throw new RuntimeException("ERROR: Failed to move PIP '" + sp + "' to Tile '" + destTileName +
+                                    "' (Net '" + n.getName() + "')");
+                        }
                     }
                 } else {
                     assert (st.getTileTypeEnum() == dt.getTileTypeEnum());


### PR DESCRIPTION
As documented in https://github.com/eddieh-xlnx/RapidWrightDCP/pull/25.

Needs `RelocationTools.relocate()` to be fixed to handle stub PIPs too.