### PR TITLE
[PhysNetlistWriter] Skip cell pin mapping for unconnected pins

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -178,8 +178,11 @@ public class PhysNetlistWriter {
             EDIFHierCellInst ehci = cell.getEDIFHierCellInst();
             int numPinMappings;
             if (ehci == null) {
+                // Logical cell unavailable (e.g. logical netlist has been detached)
+                // Assume connected and propagate all pin mappings
                 numPinMappings = cell.getPinMappingsP2L().size();
             } else {
+                // Only write out pin mappings where a net is connected
                 numPinMappings = 0;
                 for (Entry<String, String> e : cell.getPinMappingsP2L().entrySet()) {
                     String logicalPin = e.getValue();

--- a/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
@@ -353,5 +353,81 @@ public class TestPhysNetlistWriter {
         Assertions.assertEquals("[SLICE_X15Y237/G6LUT/O6, SLICE_X15Y237/G_O/G_O, SLICE_X15Y237/OUTMUXG/D6, SLICE_X15Y237/OUTMUXG/OUT, SLICE_X16Y236/H_I/H_I, SLICE_X16Y236/H5LUT/DI1, SLICE_X16Y236/G_I/G_I, SLICE_X16Y236/G5LUT/DI1, SLICE_X13Y235/B3/B3, SLICE_X13Y235/B5LUT/A3, SLICE_X13Y235/B6LUT/A3]",
                 belPins.toString());
     }
+
+    @Test
+    public void testSitePIP(@TempDir Path tempDir) throws IOException {
+        Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
+
+        String interchangePath = tempDir.resolve("design.phys").toString();
+        PhysNetlistWriter.writePhysNetlist(design, interchangePath);
+
+        ReaderOptions rdOptions =
+                new ReaderOptions(ReaderOptions.DEFAULT_READER_OPTIONS.traversalLimitInWords * 64,
+                        ReaderOptions.DEFAULT_READER_OPTIONS.nestingLimit * 128);
+        MessageReader readMsg = Interchange.readInterchangeFile(interchangePath, rdOptions);
+
+        PhysNetlist.Reader physNetlist = readMsg.getRoot(PhysNetlist.factory);
+
+        List<String> allStrings = PhysNetlistReader.readAllStrings(physNetlist);
+
+        PhysNet.Reader net = null;
+        for (PhysNet.Reader n : physNetlist.getPhysNets()) {
+            String netName = allStrings.get(n.getName());
+            if (!netName.equals("processor/active_interrupt_lut/O5"))
+                continue;
+
+            net = n;
+            break;
+        }
+
+        StructList.Reader<RouteBranch.Reader> fanouts = net.getSources();
+        Assertions.assertEquals(1, fanouts.size());
+        RouteBranch.Reader HLUT5_O5_branch = fanouts.get(0);
+        Assertions.assertEquals(RouteSegment.Which.BEL_PIN, HLUT5_O5_branch.getRouteSegment().which());
+        PhysBelPin.Reader HLUT5_O5 = HLUT5_O5_branch.getRouteSegment().getBelPin();
+        Assertions.assertEquals("H5LUT", allStrings.get(HLUT5_O5.getBel()));
+        Assertions.assertEquals("O5", allStrings.get(HLUT5_O5.getPin()));
+
+        fanouts = HLUT5_O5_branch.getBranches();
+        Assertions.assertEquals(1, fanouts.size());
+        RouteBranch.Reader OUTMUXH_D5_branch = fanouts.get(0);
+        Assertions.assertEquals(RouteSegment.Which.BEL_PIN, OUTMUXH_D5_branch.getRouteSegment().which());
+        PhysBelPin.Reader OUTMUXH_D5 = OUTMUXH_D5_branch.getRouteSegment().getBelPin();
+        Assertions.assertEquals("OUTMUXH", allStrings.get(OUTMUXH_D5.getBel()));
+        Assertions.assertEquals("D5", allStrings.get(OUTMUXH_D5.getPin()));
+
+        fanouts = OUTMUXH_D5_branch.getBranches();
+        Assertions.assertEquals(1, fanouts.size());
+        RouteBranch.Reader OUTMUXH_branch = fanouts.get(0);
+        Assertions.assertEquals(RouteSegment.Which.SITE_P_I_P, OUTMUXH_branch.getRouteSegment().which());
+        PhysNetlist.PhysSitePIP.Reader OUTMUXH = OUTMUXH_branch.getRouteSegment().getSitePIP();
+        Assertions.assertEquals("SLICE_X13Y239", allStrings.get(OUTMUXH.getSite()));
+        Assertions.assertEquals("OUTMUXH", allStrings.get(OUTMUXH.getBel()));
+        Assertions.assertEquals("D5", allStrings.get(OUTMUXH.getPin()));
+
+        fanouts = OUTMUXH_branch.getBranches();
+        Assertions.assertEquals(1, fanouts.size());
+        RouteBranch.Reader OUTMUXH_OUT_branch = fanouts.get(0);
+        Assertions.assertEquals(RouteSegment.Which.BEL_PIN, OUTMUXH_OUT_branch.getRouteSegment().which());
+        PhysBelPin.Reader OUTMUXH_OUT = OUTMUXH_OUT_branch.getRouteSegment().getBelPin();
+        Assertions.assertEquals("OUTMUXH", allStrings.get(OUTMUXH_OUT.getBel()));
+        Assertions.assertEquals("OUT", allStrings.get(OUTMUXH_OUT.getPin()));
+
+        fanouts = OUTMUXH_OUT_branch.getBranches();
+        Assertions.assertEquals(1, fanouts.size());
+        RouteBranch.Reader HMUX_HMUX_branch = fanouts.get(0);
+        Assertions.assertEquals(RouteSegment.Which.BEL_PIN, HMUX_HMUX_branch.getRouteSegment().which());
+        PhysBelPin.Reader HMUX_HMUX = HMUX_HMUX_branch.getRouteSegment().getBelPin();
+        Assertions.assertEquals("HMUX", allStrings.get(HMUX_HMUX.getBel()));
+        Assertions.assertEquals("HMUX", allStrings.get(HMUX_HMUX.getPin()));
+
+        fanouts = HMUX_HMUX_branch.getBranches();
+        Assertions.assertEquals(1, fanouts.size());
+        RouteBranch.Reader HMUX_branch = fanouts.get(0);
+        Assertions.assertEquals("SITE_PIN", HMUX_branch.getRouteSegment().which().toString());
+        PhysNetlist.PhysSitePin.Reader HMUX = HMUX_branch.getRouteSegment().getSitePin();
+        Assertions.assertEquals("SLICE_X13Y239", allStrings.get(HMUX.getSite()));
+        Assertions.assertEquals("HMUX", allStrings.get(HMUX.getPin()));
+    }
 }
 }

--- a/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
@@ -25,8 +25,11 @@ package com.xilinx.rapidwright.interchange;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Queue;
 
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
@@ -353,81 +356,4 @@ public class TestPhysNetlistWriter {
         Assertions.assertEquals("[SLICE_X15Y237/G6LUT/O6, SLICE_X15Y237/G_O/G_O, SLICE_X15Y237/OUTMUXG/D6, SLICE_X15Y237/OUTMUXG/OUT, SLICE_X16Y236/H_I/H_I, SLICE_X16Y236/H5LUT/DI1, SLICE_X16Y236/G_I/G_I, SLICE_X16Y236/G5LUT/DI1, SLICE_X13Y235/B3/B3, SLICE_X13Y235/B5LUT/A3, SLICE_X13Y235/B6LUT/A3]",
                 belPins.toString());
     }
-
-    @Test
-    public void testSitePIP(@TempDir Path tempDir) throws IOException {
-        Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
-
-        String interchangePath = tempDir.resolve("design.phys").toString();
-        PhysNetlistWriter.writePhysNetlist(design, interchangePath);
-
-        ReaderOptions rdOptions =
-                new ReaderOptions(ReaderOptions.DEFAULT_READER_OPTIONS.traversalLimitInWords * 64,
-                        ReaderOptions.DEFAULT_READER_OPTIONS.nestingLimit * 128);
-        MessageReader readMsg = Interchange.readInterchangeFile(interchangePath, rdOptions);
-
-        PhysNetlist.Reader physNetlist = readMsg.getRoot(PhysNetlist.factory);
-
-        List<String> allStrings = PhysNetlistReader.readAllStrings(physNetlist);
-
-        PhysNet.Reader net = null;
-        for (PhysNet.Reader n : physNetlist.getPhysNets()) {
-            String netName = allStrings.get(n.getName());
-            if (!netName.equals("processor/active_interrupt_lut/O5"))
-                continue;
-
-            net = n;
-            break;
-        }
-
-        StructList.Reader<RouteBranch.Reader> fanouts = net.getSources();
-        Assertions.assertEquals(1, fanouts.size());
-        RouteBranch.Reader HLUT5_O5_branch = fanouts.get(0);
-        Assertions.assertEquals(RouteSegment.Which.BEL_PIN, HLUT5_O5_branch.getRouteSegment().which());
-        PhysBelPin.Reader HLUT5_O5 = HLUT5_O5_branch.getRouteSegment().getBelPin();
-        Assertions.assertEquals("H5LUT", allStrings.get(HLUT5_O5.getBel()));
-        Assertions.assertEquals("O5", allStrings.get(HLUT5_O5.getPin()));
-
-        fanouts = HLUT5_O5_branch.getBranches();
-        Assertions.assertEquals(1, fanouts.size());
-        RouteBranch.Reader OUTMUXH_D5_branch = fanouts.get(0);
-        Assertions.assertEquals(RouteSegment.Which.BEL_PIN, OUTMUXH_D5_branch.getRouteSegment().which());
-        PhysBelPin.Reader OUTMUXH_D5 = OUTMUXH_D5_branch.getRouteSegment().getBelPin();
-        Assertions.assertEquals("OUTMUXH", allStrings.get(OUTMUXH_D5.getBel()));
-        Assertions.assertEquals("D5", allStrings.get(OUTMUXH_D5.getPin()));
-
-        fanouts = OUTMUXH_D5_branch.getBranches();
-        Assertions.assertEquals(1, fanouts.size());
-        RouteBranch.Reader OUTMUXH_branch = fanouts.get(0);
-        Assertions.assertEquals(RouteSegment.Which.SITE_P_I_P, OUTMUXH_branch.getRouteSegment().which());
-        PhysNetlist.PhysSitePIP.Reader OUTMUXH = OUTMUXH_branch.getRouteSegment().getSitePIP();
-        Assertions.assertEquals("SLICE_X13Y239", allStrings.get(OUTMUXH.getSite()));
-        Assertions.assertEquals("OUTMUXH", allStrings.get(OUTMUXH.getBel()));
-        Assertions.assertEquals("D5", allStrings.get(OUTMUXH.getPin()));
-
-        fanouts = OUTMUXH_branch.getBranches();
-        Assertions.assertEquals(1, fanouts.size());
-        RouteBranch.Reader OUTMUXH_OUT_branch = fanouts.get(0);
-        Assertions.assertEquals(RouteSegment.Which.BEL_PIN, OUTMUXH_OUT_branch.getRouteSegment().which());
-        PhysBelPin.Reader OUTMUXH_OUT = OUTMUXH_OUT_branch.getRouteSegment().getBelPin();
-        Assertions.assertEquals("OUTMUXH", allStrings.get(OUTMUXH_OUT.getBel()));
-        Assertions.assertEquals("OUT", allStrings.get(OUTMUXH_OUT.getPin()));
-
-        fanouts = OUTMUXH_OUT_branch.getBranches();
-        Assertions.assertEquals(1, fanouts.size());
-        RouteBranch.Reader HMUX_HMUX_branch = fanouts.get(0);
-        Assertions.assertEquals(RouteSegment.Which.BEL_PIN, HMUX_HMUX_branch.getRouteSegment().which());
-        PhysBelPin.Reader HMUX_HMUX = HMUX_HMUX_branch.getRouteSegment().getBelPin();
-        Assertions.assertEquals("HMUX", allStrings.get(HMUX_HMUX.getBel()));
-        Assertions.assertEquals("HMUX", allStrings.get(HMUX_HMUX.getPin()));
-
-        fanouts = HMUX_HMUX_branch.getBranches();
-        Assertions.assertEquals(1, fanouts.size());
-        RouteBranch.Reader HMUX_branch = fanouts.get(0);
-        Assertions.assertEquals("SITE_PIN", HMUX_branch.getRouteSegment().which().toString());
-        PhysNetlist.PhysSitePin.Reader HMUX = HMUX_branch.getRouteSegment().getSitePin();
-        Assertions.assertEquals("SLICE_X13Y239", allStrings.get(HMUX.getSite()));
-        Assertions.assertEquals("HMUX", allStrings.get(HMUX.getPin()));
-    }
-}
 }


### PR DESCRIPTION
Built on top of #799.

In #799, we omit BELPin-s that are in the physical routing if there is no logical connectivity. An example situation is seen in #798 where the LUT output is hard-wired to a placed CARRY8's input, but the placed cell doesn't actually care about that pin. 

Go one step further, by omitting pin mappings for such cells (even though Vivado has them). This provides a very obvious indication (even after converting back into the RapidWright data model) that this physical pin should not be considered (e.g. for timing analysis) without needing to access the logical netlist (if it was even available).

Casual experiment with Vivado shows that omitting this physical-to-logical pin mapping is accepted.