### PR TITLE
Fixes necessary to take advantage of/fix for FF routethru cells 

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3065,38 +3065,30 @@ public class DesignTools {
         for (SiteInst si : design.getSiteInsts()) {
             if (!Utils.isSLICE(si)) continue;
             for (BEL bel : si.getBELs()) {
-                if (si.getCell(bel) != null) continue;
-                BELPin q = bel.getPin("Q");
-                if (q != null) {
-                    Net netQ = si.getNetFromSiteWire(q.getSiteWireName());
-                    if (netQ == null) continue;
-                    BELPin dPin = bel.getPin("D");
-                    if (dPin != null) {
-                        Net netD = si.getNetFromSiteWire(dPin.getSiteWireName());
-                        if (netQ == netD) {
-                            //System.out.println(si.getSiteName() + "/" + bel + ": " + netQ);
-                            // Need VCC at CE
-                            BELPin ceInput = bel.getPin("CE");
-                            String ceInputSitePinName = ceInput.getConnectedSitePinName();
-                            SitePinInst ceSitePin = si.getSitePinInst(ceInputSitePinName);
-                            if (ceSitePin == null) {
-                                ceSitePin = vcc.createPin(ceInputSitePinName, si);
-                            }
-                            si.routeIntraSiteNet(vcc, ceSitePin.getBELPin(), ceInput);
-                            // ...and GND at CLK
-                            BELPin clkInput = bel.getPin("CLK");
-                            BELPin clkInvOut = clkInput.getSourcePin();
-                            si.routeIntraSiteNet(gnd, clkInvOut, clkInput);
-                            BELPin clkInvIn = clkInvOut.getBEL().getPin(0);
-                            String clkInputSitePinName = clkInvIn.getConnectedSitePinName();
-                            SitePinInst clkInputSitePin = si.getSitePinInst(clkInputSitePinName);
-                            if (clkInputSitePin == null) {
-                                clkInputSitePin = vcc.createPin(clkInputSitePinName, si);
-                            }
-                            si.routeIntraSiteNet(vcc, clkInputSitePin.getBELPin(), clkInvIn);
-                        }
-                    }
+                Cell cell = si.getCell(bel);
+                if (cell == null || !cell.isFFRoutethruCell()) {
+                    continue;
                 }
+
+                // Need VCC at CE
+                BELPin ceInput = bel.getPin("CE");
+                String ceInputSitePinName = ceInput.getConnectedSitePinName();
+                SitePinInst ceSitePin = si.getSitePinInst(ceInputSitePinName);
+                if (ceSitePin == null) {
+                    ceSitePin = vcc.createPin(ceInputSitePinName, si);
+                }
+                si.routeIntraSiteNet(vcc, ceSitePin.getBELPin(), ceInput);
+                // ...and GND at CLK
+                BELPin clkInput = bel.getPin("CLK");
+                BELPin clkInvOut = clkInput.getSourcePin();
+                si.routeIntraSiteNet(gnd, clkInvOut, clkInput);
+                BELPin clkInvIn = clkInvOut.getBEL().getPin(0);
+                String clkInputSitePinName = clkInvIn.getConnectedSitePinName();
+                SitePinInst clkInputSitePin = si.getSitePinInst(clkInputSitePinName);
+                if (clkInputSitePin == null) {
+                    clkInputSitePin = vcc.createPin(clkInputSitePinName, si);
+                }
+                si.routeIntraSiteNet(vcc, clkInputSitePin.getBELPin(), clkInvIn);
             }
         }
     }

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -136,7 +136,11 @@ public class PhysNetlistWriter {
                 if (!cell.isPlaced()) continue;
                 String cellName = cell.getName();
                 if (cellName.equals(PhysNetlistWriter.LOCKED)) continue;
-                if (!design.getCell(cellName).getBELName().equals(cell.getBELName())) {
+                Cell multiCell = design.getCell(cellName);
+                if (multiCell == null) {
+                    assert(cell.isFFRoutethruCell());
+                }
+                else if (!multiCell.getBELName().equals(cell.getBELName())) {
                     multiBelCells.computeIfAbsent(cellName, (k) -> new ArrayList<>())
                             .add(cell);
                     // Don't add multi-bel cells, store relevant info in pin placements

--- a/test/src/com/xilinx/rapidwright/design/TestCell.java
+++ b/test/src/com/xilinx/rapidwright/design/TestCell.java
@@ -93,7 +93,6 @@ public class TestCell {
         Assertions.assertNotNull(rtCell);
         Assertions.assertTrue(rtCell.isRoutethru());
         Assertions.assertTrue(rtCell.isFFRoutethruCell());
-        Assertions.assertEquals(Cell.FF_ROUTETHRU_TYPE, rtCell.getType());
         Assertions.assertEquals("D", rtCell.getLogicalPinMapping("D"));
         Assertions.assertEquals("Q", rtCell.getLogicalPinMapping("Q"));
 

--- a/test/src/com/xilinx/rapidwright/design/TestCell.java
+++ b/test/src/com/xilinx/rapidwright/design/TestCell.java
@@ -25,6 +25,9 @@ package com.xilinx.rapidwright.design;
 
 
 import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.util.FileTools;
+import com.xilinx.rapidwright.util.VivadoTools;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -80,5 +83,24 @@ public class TestCell {
         Cell cell = new Cell("cell");
         Assertions.assertNull(cell.getEDIFCellInst());
         Assertions.assertNull(cell.getProperty("any_property"));
+    }
+
+    @Test
+    public void testFFRoutethruCell() {
+        Design d = RapidWrightDCP.loadDCP("optical-flow.dcp");
+        SiteInst si = d.getSiteInstFromSiteName("SLICE_X72Y144");
+        Cell rtCell = si.getCell("CFF");
+        Assertions.assertNotNull(rtCell);
+        Assertions.assertTrue(rtCell.isRoutethru());
+        Assertions.assertTrue(rtCell.isFFRoutethruCell());
+        Assertions.assertEquals(Cell.FF_ROUTETHRU_TYPE, rtCell.getType());
+        Assertions.assertEquals("D", rtCell.getLogicalPinMapping("D"));
+        Assertions.assertEquals("Q", rtCell.getLogicalPinMapping("Q"));
+
+        Assertions.assertNull(d.getCell(rtCell.getName()));
+
+        if (FileTools.isVivadoOnPath()) {
+            Assertions.assertTrue(VivadoTools.reportRouteStatus(d).isFullyRouted());
+        }
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestCell.java
+++ b/test/src/com/xilinx/rapidwright/design/TestCell.java
@@ -100,7 +100,7 @@ public class TestCell {
         Assertions.assertNull(d.getCell(rtCell.getName()));
 
         if (FileTools.isVivadoOnPath()) {
-            Assertions.assertTrue(VivadoTools.reportRouteStatus(d).isFullyRouted());
+            Assertions.assertEquals(0, VivadoTools.reportRouteStatus(d).netsWithRoutingErrors);
         }
     }
 }


### PR DESCRIPTION
Built on #813.

An incoming release will create `Cell` objects for FF routethrus.

`DesignTools.createCeClkOfRoutethruFFtoVCC()` and `PhysNetlistWriter` have been adapted to take advantage of this/fixed to work with this new feature.

A test for such cells is also present.