### PR TITLE
[PhysNetlistWriter] Set PhysPIP.setForward() even if not bidir

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -525,9 +525,7 @@ public class PhysNetlistWriter {
                 physPIP.setWire0(strings.getIndex(pip.getStartWireName()));
                 physPIP.setWire1(strings.getIndex(pip.getEndWireName()));
                 physPIP.setIsFixed(pip.isPIPFixed());
-                if (pip.isBidirectional()) {
-                    physPIP.setForward(!pip.isReversed());
-                }
+                physPIP.setForward(!pip.isReversed());
                 break;
             }
             case BEL_PIN:{


### PR DESCRIPTION
Since PhysNetlistReader always consumes it, even if not bidir:
https://github.com/Xilinx/RapidWright/blob/7cec5122cab9359b532701dd97bafd74b2a94baa/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java#L564-L566

