### PR TITLE
[PhysNetlistWriter] No IO site port output BELPins without SitePinInst

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -415,6 +415,11 @@ public class PhysNetlistWriter {
                             // onto site instance)
                             continue;
                         }
+
+                        if (bel.getName().equals("IO") && siteInst.getSitePinInst(belPin.getName()) == null) {
+                            // Skip IO site ports without a site pin
+                            continue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
The `IO.IO` site port BELPin is actually an input site pin/output site port BEL pin. When an OUTBUF instance is present in the IOB site, the `OUTBUF_O` sitewire appears to be driven by the `OUTBUF.O` BEL pin as well as by the `IO.IO` site port. This cannot be true, so omit the `IO.IO` site port when its corresponding `SitePinInst` is not present.

![image](https://github.com/Xilinx/RapidWright/assets/90657806/ad400246-01a6-4885-b021-69e795aba21b)
