### PR TITLE
[EDIFNetlist] - Ensure Macro Expansion Deep Copies Children 

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1652,7 +1652,14 @@ public class EDIFNetlist extends EDIFName {
             }
             // Add copy to prim library to avoid destructive changes when collapsed
             // Needs to be a deep copy because it may have child instances that will get updated
-            new EDIFCell(netlistPrims, toAdd, cellName);
+            EDIFCell deepCopy = new EDIFCell(netlistPrims, toAdd, cellName);
+            for (EDIFCellInst inst : deepCopy.getCellInsts()) {
+                EDIFCell child = netlistPrims.getCell(inst.getCellName());
+                if (child == null) {
+                    EDIFCell childCopy = new EDIFCell(netlistPrims, inst.getCellType(), inst.getCellType().getName());
+                    inst.setCellType(childCopy);
+                }
+            }
         }
 
         // Update all cell references to macro versions

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
@@ -26,6 +26,8 @@ import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Series;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
@@ -46,4 +46,29 @@ public class TestEDIFHierPortInst {
         // Check that we can still find it in this case
         Assertions.assertEquals(c, ehpi.getPhysicalCell(d));
     }
+
+    @Test
+    public void testGetPhysicalCellMacroHierarchy() {
+        Design design = new Design("design", "xcvc1902-vsvd1760-2MP-e-S");
+        EDIFNetlist n = design.getNetlist();
+        
+        EDIFCell macro = n.getHDIPrimitivesLibrary().addCell(Design.getUnisimCell(Unisim.valueOf("RAM64X1D")));
+        n.getTopCell().createChildCellInst("inst", macro);
+
+
+
+        n.expandMacroUnisims(Series.Versal);
+
+        String cellName = "inst/DP/RAMD64_INST";
+
+        // We can't instantiate RAM64X1D since its a transformed prim, so we'll update
+        // the type after creation
+        Cell c = design.createAndPlaceCell(cellName, Unisim.LUT6, "SLICE_X235Y138/B6LUT");
+        c.setType(Unisim.RAM64X1D.toString());
+
+        EDIFHierCellInst leafInst = n.getHierCellInstFromName("inst/DP/RAMD64_INST");
+
+        EDIFHierPortInst portInst = new EDIFHierPortInst(leafInst.getParent(), leafInst.getInst().getPortInst("O"));
+        Assertions.assertEquals(c, portInst.getPhysicalCell(design));
+    }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierPortInst.java
@@ -54,13 +54,14 @@ public class TestEDIFHierPortInst {
         Design design = new Design("design", "xcvc1902-vsvd1760-2MP-e-S");
         EDIFNetlist n = design.getNetlist();
         
-        EDIFCell macro = n.getHDIPrimitivesLibrary().addCell(Design.getUnisimCell(Unisim.valueOf("RAM64X1D")));
+        EDIFCell macro = n.getHDIPrimitive(Unisim.RAM64X1D);
+        Assertions.assertSame(n.getHDIPrimitivesLibrary(), macro.getLibrary());
         n.getTopCell().createChildCellInst("inst", macro);
         n.expandMacroUnisims(Series.Versal);
 
         String cellName = "inst/DP/RAMD64_INST";
 
-        // We can't instantiate RAM64X1D since its a transformed prim, so we'll update
+        // We can't instantiate RAM64X1D since it's a transformed prim, so we'll update
         // the type after creation
         Cell c = design.createAndPlaceCell(cellName, Unisim.LUT6, "SLICE_X235Y138/B6LUT");
         c.setType(Unisim.RAM64X1D.toString());


### PR DESCRIPTION
In #826, it was found that a recent change had caused some child macro cell types to not have the proper netlist reference in their library.  This change deep copies those children cells to ensure they point back to the parent netlist.