### PR TITLE
Minor RWRoute and UltraScaleClockRouting fixes

### DIFF
--- a/src/com/xilinx/rapidwright/router/UltraScaleClockRouting.java
+++ b/src/com/xilinx/rapidwright/router/UltraScaleClockRouting.java
@@ -117,6 +117,11 @@ public class UltraScaleClockRouting {
             for (Wire w : curr.getWireConnections()) {
                 RouteNode parent = curr.getParent();
                 if (parent != null) {
+                    if (parent.getIntentCode() == IntentCode.NODE_GLOBAL_VROUTE &&
+                            w.getIntentCode() == IntentCode.NODE_GLOBAL_HROUTE) {
+                        // Disallow ability to go from VROUTE back to HROUTE
+                        continue;
+                    }
                     if (w.getIntentCode()     == IntentCode.NODE_GLOBAL_VDISTR &&
                        curr.getIntentCode()   == IntentCode.NODE_GLOBAL_VROUTE &&
                        parent.getIntentCode() == IntentCode.NODE_GLOBAL_VROUTE &&

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1402,11 +1402,15 @@ public class RWRoute{
 
         RouteNode sourceRnode = rnodes.get(rnodes.size()-1);
         if (!sourceRnode.equals(connection.getSourceRnode())) {
+            if (!sourceRnode.equals(connection.getAltSourceRnode())) {
+                // Didn't backtrack to alternate source either -- invalid routing
+                return false;
+            }
+
             // Used source node is different to the one set on the connection
             Net net = connection.getNetWrapper().getNet();
 
             // Update connection's source SPI
-            assert(sourceRnode.equals(connection.getAltSourceRnode()));
             if (connection.getSource() == net.getSource()) {
                 // Swap to alternate source
                 connection.setSource(net.getAlternateSource());


### PR DESCRIPTION
* `RWRoute.saveRouting()` to detect invalid traced-back solutions
* `UltraScaleClockRouting` to disallow going from a `VROUTE` node back to a `HROUTE` node.