### PR TITLE
PartialRouter preprocessing and clock routing improvements

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -752,7 +752,7 @@ public class PartialRouter extends RWRoute {
     /**
      * Routes a design in the partial non-timing-driven routing mode.
      * @param design The {@link Design} instance to be routed.
-     * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed. If null, route all nets with no routing PIPs already present.
+     * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed. If null, route all unrouted pins in the design.
      */
     public static Design routeDesignPartialNonTimingDriven(Design design, Collection<SitePinInst> pinsToRoute) {
         return routeDesignPartialNonTimingDriven(design, pinsToRoute, false);
@@ -761,7 +761,7 @@ public class PartialRouter extends RWRoute {
     /**
      * Routes a design in the partial non-timing-driven routing mode.
      * @param design The {@link Design} instance to be routed.
-     * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed. If null, route all nets with no routing PIPs already present.
+     * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed. If null, route all unrouted pins in the design.
      * @param softPreserve Allow routed nets to be unrouted and subsequently rerouted in order to improve routability.
      */
     public static Design routeDesignPartialNonTimingDriven(Design design, Collection<SitePinInst> pinsToRoute, boolean softPreserve) {
@@ -784,7 +784,7 @@ public class PartialRouter extends RWRoute {
     /**
      * Routes a design in the partial timing-driven routing mode.
      * @param design The {@link Design} instance to be routed.
-     * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed. If null, route all nets with no routing PIPs already present.
+     * @param pinsToRoute Collection of {@link SitePinInst}-s to be routed. If null, route all unrouted pins in the design.
      * @param softPreserve Allow routed nets to be unrouted and subsequently rerouted in order to improve routability.
      */
     public static Design routeDesignPartialTimingDriven(Design design, Collection<SitePinInst> pinsToRoute, boolean softPreserve) {

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -33,7 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.xilinx.rapidwright.design.Design;
@@ -45,7 +44,6 @@ import com.xilinx.rapidwright.device.IntentCode;
 import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.SitePin;
-import com.xilinx.rapidwright.router.UltraScaleClockRouting;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.timing.ClkRouteTiming;
 import com.xilinx.rapidwright.timing.TimingManager;
@@ -242,17 +240,10 @@ public class PartialRouter extends RWRoute {
 
     @Override
     protected void routeGlobalClkNets() {
-        if (clkNets.isEmpty()) {
+        if (clkNets.isEmpty())
             return;
-        }
 
-        for (Net clk : clkNets) {
-            List<SitePinInst> clkPins = netToPins.get(clk);
-            System.out.println("INFO: Routing " + clkPins.size() + " pins of clock " + clk + " (non timing-driven)");
-            Function<Node, NodeStatus> gns = (node) -> this.getGlobalRoutingNodeStatus(clk, node);
-            UltraScaleClockRouting.incrementalClockRouter(clk, clkPins, gns);
-            preserveNet(clk, false);
-        }
+        super.routeGlobalClkNets();
 
         List<Net> unpreserveNets = unpreserveCongestedNets(clkNets);
         if (!unpreserveNets.isEmpty()) {

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.xilinx.rapidwright.design.Design;
@@ -44,6 +45,7 @@ import com.xilinx.rapidwright.device.IntentCode;
 import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.SitePin;
+import com.xilinx.rapidwright.router.UltraScaleClockRouting;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.timing.ClkRouteTiming;
 import com.xilinx.rapidwright.timing.TimingManager;
@@ -243,7 +245,21 @@ public class PartialRouter extends RWRoute {
         if (clkNets.isEmpty())
             return;
 
-        super.routeGlobalClkNets();
+        for (Net clk : clkNets) {
+            List<SitePinInst> clkPins = netToPins.get(clk);
+            if (clkPins == null || clkPins.isEmpty()) {
+                continue;
+            }
+
+            if (!clk.hasPIPs()) {
+                super.routeGlobalClkNet(clk);
+            } else {
+                System.out.println("INFO: Routing " + clkPins.size() + " pins of clock " + clk + " (non timing-driven)");
+                Function<Node, NodeStatus> gns = (node) -> this.getGlobalRoutingNodeStatus(clk, node);
+                UltraScaleClockRouting.incrementalClockRouter(clk, clkPins, gns);
+                preserveNet(clk, false);
+            }
+        }
 
         List<Net> unpreserveNets = unpreserveCongestedNets(clkNets);
         if (!unpreserveNets.isEmpty()) {

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1799,7 +1799,7 @@ public class RWRoute{
         printFormattedString("  All site pins to be routed: ", (indirectPins + staticPins + clkPins));
         printFormattedString("    Connections to be routed: ", indirectPins);
         printFormattedString("      With SLR crossings: ", getNumConnectionsCrossingSLRs());
-        printFormattedString("    Static net pins: ", getNumStaticNetPins());
+        printFormattedString("    Static net pins: ", staticPins);
         printFormattedString("    Clock pins: ", clkPins);
         printFormattedString("Nets not needing routing: ", numNotNeedingRoutingNets);
         if (numUnrecognizedNets != 0)
@@ -1841,6 +1841,7 @@ public class RWRoute{
 
         // For testing
         System.setProperty("rapidwright.rwroute.nodesPopped", String.valueOf(nodesPopped));
+        System.setProperty("rapidwright.rwroute.numStaticNetPins", String.valueOf(getNumStaticNetPins()));
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -400,29 +400,31 @@ public class RWRoute{
      * TODO: fix the potential issue.
      */
     protected void routeGlobalClkNets() {
-        if (clkNets.isEmpty())
-            return;
         for (Net clk : clkNets) {
-            // Since we preserved all pins in addGlobalClkRoutingTargets(), unpreserve them here
-            for (SitePinInst spi : clk.getPins()) {
-                routingGraph.unpreserve(spi.getConnectedNode());
-            }
-            Function<Node, NodeStatus> gns = (node) -> getGlobalRoutingNodeStatus(clk, node);
-            if (routesToSinkINTTiles != null) {
-                // routes clock nets with references of partial routes
-                System.out.println("INFO: Routing " + clk.getPins().size() + " pins of clock " + clk + " (timing-driven)");
-                GlobalSignalRouting.routeClkWithPartialRoutes(clk, routesToSinkINTTiles, design.getDevice(), gns);
-            } else {
-                // routes clock nets from scratch
-                System.out.println("INFO: Routing " + clk.getPins().size() + " pins of clock " + clk + " (non timing-driven)");
-                GlobalSignalRouting.symmetricClkRouting(clk, design.getDevice(), gns);
-            }
-            preserveNet(clk, false);
+            routeGlobalClkNet(clk);
+        }
+    }
 
-            if (clk.hasPIPs()) {
-                clk.getSource().setRouted(true);
-                assert(clk.getAlternateSource() == null);
-            }
+    protected void routeGlobalClkNet(Net clk) {
+        // Since we preserved all pins in addGlobalClkRoutingTargets(), unpreserve them here
+        for (SitePinInst spi : clk.getPins()) {
+            routingGraph.unpreserve(spi.getConnectedNode());
+        }
+        Function<Node, NodeStatus> gns = (node) -> getGlobalRoutingNodeStatus(clk, node);
+        if (routesToSinkINTTiles != null) {
+            // routes clock nets with references of partial routes
+            System.out.println("INFO: Routing " + clk.getPins().size() + " pins of clock " + clk + " (timing-driven)");
+            GlobalSignalRouting.routeClkWithPartialRoutes(clk, routesToSinkINTTiles, design.getDevice(), gns);
+        } else {
+            // routes clock nets from scratch
+            System.out.println("INFO: Routing " + clk.getPins().size() + " pins of clock " + clk + " (non timing-driven)");
+            GlobalSignalRouting.symmetricClkRouting(clk, design.getDevice(), gns);
+        }
+        preserveNet(clk, false);
+
+        if (clk.hasPIPs()) {
+            clk.getSource().setRouted(true);
+            assert(clk.getAlternateSource() == null);
         }
     }
 


### PR DESCRIPTION
Currently, the PartialRouter has two modes of operation:
1. Provide a list of pins to route
2. Ask it to infer a list of pins to route

Item 2 is rather simplistic in that it seeks out those nets that no PIPs, and tries to route all its pins. Partially routed nets with PIPs and some unrouted pins are not picked up. This PR resolves this by employing `DesignTools.updatePinsIsRouted()` (added in https://github.com/Xilinx/RapidWright/pull/762) as part of 2 (specifically, during `PartialRouter.preprocess()`) in order to identify which pins it needs to route.

A second change in this PR is for PartialRouter to support incremental clock routing, which kicks in if there are unrouted pins on a clock net, and that clock net is partially routed. (If the clock net is entirely unrouted, use the existing full clock router in RWRoute).