### PR TITLE
Simplify and make DesignTools.updatePinsIsRouted() more robust

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3897,10 +3897,11 @@ public class DesignTools {
     }
 
     /**
-     * Update the SitePinInst.isRouted() value of all sink pins on the given
-     * Net. A pin will be marked as being routed if it is reachable from the
+     * Update the SitePinInst.isRouted() value of all pins on the given
+     * Net. A sink pin will be marked as being routed if it is reachable from the
      * Net's source pins (or in the case of static nets, also from nodes
      * tied to GND or VCC) when following the Net's PIPs.
+     * A source pin will be marked as being routed if it drives at least one PIP.
      * @param net Net on which pins are to be updated.
      */
     public static void updatePinsIsRouted(Net net) {
@@ -3935,6 +3936,7 @@ public class DesignTools {
             Node node = spi.getConnectedNode();
             if (spi.isOutPin()) {
                 if (node2fanout.get(node) == null) {
+                    // Skip source pins with no fanout
                     continue;
                 }
                 queue.add(node);


### PR DESCRIPTION
By remove the a Node's `fanouts` immediately from the map, we are inherently more robust to the presence of loops. This is possible because each node should only be visited once anyway.

This also means we don't need to track and avoid bidirectional PIPs separately, since we can no longer visit nodes more than once.