### PR TITLE
Use dummy LUTs instead of PROHIBITs

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3917,7 +3917,7 @@ public class DesignTools {
                                     c.setBELFixed(true);
                                     c.setSiteFixed(true);
                                     boolean connected = false;
-                                    for (int i = 1; i < 5; i++) {
+                                    for (int i = 1; i <= 5; i++) {
                                         String inputName = bel.getName().charAt(0) + Integer.toString(i);
                                         Net net = si.getNetFromSiteWire(inputName);
                                         NetType type = net == null ? NetType.VCC : net.getType();

--- a/src/com/xilinx/rapidwright/util/MakeBlackBox.java
+++ b/src/com/xilinx/rapidwright/util/MakeBlackBox.java
@@ -50,7 +50,7 @@ public class MakeBlackBox {
         }
 
         // Necessary to make the design place-able by Vivado later
-        DesignTools.prohibitPartialHalfSlices(input);
+        DesignTools.prohibitPartialHalfSlices(input, true);
 
         t.stop().start("Write DCP");
         input.writeCheckpoint(args[1], CodePerfTracker.SILENT);


### PR DESCRIPTION
Alternative way to keep future placement away from partially used half-SLICEs.  This will create valid dummy LUTs and place them into partially used half SLICEs so that no other part of the LUTs in that half-SLICE can be used for placement.  