### PR TITLE
Update tests to infer missing SitePinInsts

### DIFF
--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -134,6 +134,8 @@ public class TestDesignTools {
 
         Design src = Design.readCheckpoint(dcpPath);
 
+        DesignTools.createPossiblePinsToStaticNets(src);
+
         List<EDIFHierCellInst> srcCell = src.getNetlist().findCellInsts("*"+ srcCellName);
         String cellName = srcCell.get(0).getFullHierarchicalInstName();
         EDIFNetlist srcCellNetlist = EDIFTools.createNewNetlist(src.getNetlist().getHierCellInstFromName(cellName).getInst());


### PR DESCRIPTION
In the upcoming release, there has been a change in how `SitePinInst` objects are inferred from the placement and routing information. Specifically, this change infers these pins much more conservatively (arguably, correctly) such that some pins that were previously picked up may now be omitted and require an examination of the logical (EDIF) netlist to restore.

This change is necessary to cope with routing solutions that have have conflicted nodes leading to site pins.

Updates tests where this situation occurs.