### PR TITLE
DesignTools.createMissingSitePinInsts() to cope with net aliases

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1422,6 +1422,7 @@ public class DesignTools {
      */
     public static void handlePinRemovals(SitePinInst spi, Map<Net,Set<SitePinInst>> deferRemovals) {
         if (deferRemovals != null) {
+            assert(spi.getNet() != null);
             Set<SitePinInst> pins = deferRemovals.computeIfAbsent(spi.getNet(), p -> new HashSet<>());
             pins.add(spi);
         } else {

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2131,16 +2131,38 @@ public class DesignTools {
             return newPins;
         }
 
+        EDIFNetlist netlist = design.getNetlist();
+        EDIFHierNet parentEhn = null;
         for (EDIFHierPortInst p :  physPins) {
             Cell c = design.getCell(p.getFullHierarchicalInstName());
-            if (c == null || c.getBEL() == null) continue;
+            if (c == null) continue;
+            BEL bel = c.getBEL();
+            if (bel == null) continue;
             String logicalPinName = p.getPortInst().getName();
             Set<String> physPinMappings = c.getAllPhysicalPinMappings(logicalPinName);
             // BRAMs can have two (or more) physical pin mappings for a logical pin
             if (physPinMappings != null) {
                 SiteInst si = c.getSiteInst();
                 for (String physPin : physPinMappings) {
-                    String sitePinName = getRoutedSitePinFromPhysicalPin(c, net, physPin);
+                    BELPin belPin = bel.getPin(physPin);
+                    // Use the net attached to the phys pin
+                    Net siteWireNet = si.getNetFromSiteWire(belPin.getSiteWireName());
+                    if (siteWireNet == null) {
+                        continue;
+                    }
+                    if (siteWireNet != net && !siteWireNet.isStaticNet()) {
+                        if (parentEhn == null) {
+                            parentEhn = netlist.getParentNet(net.getLogicalHierNet());
+                        }
+                        EDIFHierNet parentSiteWireEhn = netlist.getParentNet(siteWireNet.getLogicalHierNet());
+                        if (!parentSiteWireEhn.equals(parentEhn)) {
+                            // Site wire net is not an alias of the net
+                            throw new RuntimeException("ERROR: Net on " + si.getSiteName() + "/" + belPin +
+                                    "'" + siteWireNet.getName() + "' is not an alias of " +
+                                    "'" + net.getName() + "'");
+                        }
+                    }
+                    String sitePinName = getRoutedSitePinFromPhysicalPin(c, siteWireNet, physPin);
                     if (sitePinName == null) continue;
                     SitePinInst newPin = si.getSitePinInst(sitePinName);
                     if (newPin != null) continue;

--- a/src/com/xilinx/rapidwright/eco/ECOTools.java
+++ b/src/com/xilinx/rapidwright/eco/ECOTools.java
@@ -492,6 +492,7 @@ public class ECOTools {
                         src + "'. Replacing with new pin '" + ehpi + "'.");
                 Cell cell = src.getPhysicalCell(design);
                 for (SitePinInst spi : cell.getAllSitePinsFromLogicalPin(src.getPortInst().getName(), null)) {
+                    assert(spi.getNet() != null);
                     deferredRemovals.computeIfAbsent(spi.getNet(), (p) -> new HashSet<>()).add(spi);
                 }
                 src.getNet().removePortInst(src.getPortInst());

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -384,6 +384,7 @@ public class TestDesignTools {
         si.routeIntraSiteNet(alias, c1, c1);
         Assertions.assertEquals(alias, si.getNetFromSiteWire("C1"));
 
+        // Only one site pin since it's an out-of-context hierarchical port
         Assertions.assertEquals("[IN SLICE_X15Y235.C1]", DesignTools.createMissingSitePinInsts(design, net).toString());
     }
 

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -371,6 +371,7 @@ public class TestDesignTools {
     public void testCreateMissingSitePinInstsAlias() {
         Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
         Net net = design.getNet("input_port_b[4]");
+        Assertions.assertEquals(0, net.getSinkPins().size());
 
         SiteInst si = design.getSiteInstFromSiteName("SLICE_X15Y235");
         Assertions.assertEquals(net, si.getNetFromSiteWire("C1"));

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -367,6 +367,25 @@ public class TestDesignTools {
         }
     }
 
+    @Test
+    public void testCreateMissingSitePinInstsAlias() {
+        Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
+        Net net = design.getNet("input_port_b[4]");
+
+        SiteInst si = design.getSiteInstFromSiteName("SLICE_X15Y235");
+        Assertions.assertEquals(net, si.getNetFromSiteWire("C1"));
+
+        // Force intra-site routing to use net alias
+        Net alias = design.createNet("processor/input_port_b[4]");
+        Assertions.assertNotNull(alias);
+        Assertions.assertNotNull(alias.getLogicalHierNet());
+        BELPin c1 = si.getBELPin("C1", "C1");
+        si.routeIntraSiteNet(alias, c1, c1);
+        Assertions.assertEquals(alias, si.getNetFromSiteWire("C1"));
+
+        Assertions.assertEquals("[IN SLICE_X15Y235.C1]", DesignTools.createMissingSitePinInsts(design, net).toString());
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testGetTrimmablePIPsFromPinsBidir(boolean unrouteAll) {


### PR DESCRIPTION
Specifically, when trying to find the routed site pin of a physical cell, use the actual intra-site net after checking that it is indeed an alias (by checking that they both have the same parent net)