### PR TITLE
EDIFNetlist.{generateParentNetMap,getNetAliases}() to be inout-aware

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1232,7 +1232,7 @@ public class EDIFNetlist extends EDIFName {
 
         EDIFHierPortInst source = null;
         EDIFHierNet parentNet = null;
-        EDIFHierNet possibleParentNet = null;
+        EDIFHierNet fallbackParentNet = null;
         while (!queue.isEmpty()) {
             EDIFHierNet net = queue.poll();
             if (!visited.add(net)) {
@@ -1262,11 +1262,11 @@ public class EDIFNetlist extends EDIFName {
                 // and thus a parent net
                 boolean isToplevelInout = isTopLevelPortInst && !p.isInput() && !p.isOutput();
                 if (isToplevelInout) {
-                    if (possibleParentNet != null) {
+                    if (fallbackParentNet != null) {
                         throw new RuntimeException("Multiple sources!");
                     } else if (parentNet == null) {
                         source = p;
-                        possibleParentNet = net;
+                        fallbackParentNet = net;
                     }
                 }
 
@@ -1291,8 +1291,8 @@ public class EDIFNetlist extends EDIFName {
         }
 
         if (parentNet == null) {
-            // No other parent net was found, promote the possible net
-            parentNet = possibleParentNet;
+            // No other parent net was found, promote the fallback net
+            parentNet = fallbackParentNet;
         }
 
         if (parentNet != null) {

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1232,6 +1232,7 @@ public class EDIFNetlist extends EDIFName {
 
         EDIFHierPortInst source = null;
         EDIFHierNet parentNet = null;
+        EDIFHierNet possibleParentNet = null;
         while (!queue.isEmpty()) {
             EDIFHierNet net = queue.poll();
             if (!visited.add(net)) {
@@ -1247,7 +1248,8 @@ public class EDIFNetlist extends EDIFName {
                 }
 
 
-                boolean isToplevelInput = p.getHierarchicalInst().isTopLevelInst() && relP.getCellInst() == null && p.isInput();
+                boolean isTopLevelPortInst = p.getHierarchicalInst().isTopLevelInst() && relP.getCellInst() == null;
+                boolean isToplevelInput = isTopLevelPortInst && p.isInput();
                 if (isToplevelInput || (isCellPin && p.isOutput())) {
                     if (parentNet != null) {
                         throw new RuntimeException("Multiple sources!");
@@ -1256,6 +1258,17 @@ public class EDIFNetlist extends EDIFName {
                     parentNet = net;
                 }
 
+                // For top-level INOUT ports, consider the possibility that it might be an input
+                // and thus a parent net
+                boolean isToplevelInout = isTopLevelPortInst && !p.isInput() && !p.isOutput();
+                if (isToplevelInout) {
+                    if (possibleParentNet != null) {
+                        throw new RuntimeException("Multiple sources!");
+                    } else if (parentNet == null) {
+                        source = p;
+                        possibleParentNet = net;
+                    }
+                }
 
                 if (p.getPortInst().getCellInst() == null) {
                     // Moving up in hierarchy
@@ -1277,6 +1290,10 @@ public class EDIFNetlist extends EDIFName {
             }
         }
 
+        if (parentNet == null) {
+            // No other parent net was found, promote the possible net
+            parentNet = possibleParentNet;
+        }
 
         if (parentNet != null) {
             switch (identifyNetType(source)) {
@@ -1375,11 +1392,11 @@ public class EDIFNetlist extends EDIFName {
         EDIFCell c = getTopCell();
         EDIFHierCellInst topCellInst = getTopHierCellInst();
         Queue<EDIFHierPortInst> queue = new LinkedList<>();
-        // All parent nets are either top-level inputs or outputs of leaf cells
-        // Here we gather all top-level inputs
+        // All parent nets are either top-level inputs/inouts or outputs of leaf cells
+        // Here we gather all top-level inputs/inouts
         for (EDIFNet n : c.getNets()) {
             for (EDIFPortInst p : n.getPortInsts()) {
-                if (p.isTopLevelPort() && p.isInput()) {
+                if (p.isTopLevelPort() && !p.isOutput()) {
                     queue.add(new EDIFHierPortInst(topCellInst, p));
                 }
             }

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -300,6 +300,46 @@ public class TestDesignTools {
     }
 
     @Test
+    public void testCreateMissingSitePinInstsInout() {
+        Design design = RapidWrightDCP.loadDCP("inout.dcp");
+        {
+            Net i = design.getNet("i");
+            Assertions.assertEquals(0, i.getPins().size());
+            // Technically should not be present since net is fully intra-site, but harmless
+            Assertions.assertEquals("[IN IOB_X1Y253.IO]", DesignTools.createMissingSitePinInsts(design, i).toString());
+
+            Net o = design.getNet("o");
+            Assertions.assertEquals(0, o.getPins().size());
+            // Fully intra-site
+            Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, o).toString());
+        }
+        {
+            Net i = design.getNet("i2_p");
+            Assertions.assertEquals(2, i.getPins().size());
+            Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, i).toString());
+
+            i = design.getNet("i2_n");
+            Assertions.assertEquals(2, i.getPins().size());
+            Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, i).toString());
+
+            Assertions.assertNull(design.getNet("o2_p"));
+            Assertions.assertNull(design.getNet("o2_n"));
+
+            Net o = design.getNet("ob/O");
+            Assertions.assertEquals(0, o.getPins().size());
+            Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, o).toString());
+
+            o = design.getNet("ob/OB");
+            Assertions.assertEquals(0, o.getPins().size());
+            Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, o).toString());
+
+            o = design.getNet("ob/I_B");
+            Assertions.assertEquals(2, o.getPins().size());
+            Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, o).toString());
+        }
+    }
+
+    @Test
     public void testBlackBoxCreation() {
         Design design = RapidWrightDCP.loadDCP("bnn.dcp");
         String hierCellName = "bd_0_i/hls_inst/inst/dmem_V_U";

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -305,20 +305,22 @@ public class TestDesignTools {
         {
             Net i = design.getNet("i");
             Assertions.assertEquals(0, i.getPins().size());
-            // Technically should not be present since net is fully intra-site, but harmless
+            // Technically should not be present since net is fully intra-site (PAD to INBUF), but harmless
             Assertions.assertEquals("[IN IOB_X1Y253.IO]", DesignTools.createMissingSitePinInsts(design, i).toString());
 
             Net o = design.getNet("o");
             Assertions.assertEquals(0, o.getPins().size());
-            // Fully intra-site
+            // Fully intra-site (OBUF to PAD)
             Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, o).toString());
         }
         {
             Net i = design.getNet("i2_p");
+            // PAD to DIFFINBUF
             Assertions.assertEquals(2, i.getPins().size());
             Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, i).toString());
 
             i = design.getNet("i2_n");
+            // PAD to DIFFINBUF
             Assertions.assertEquals(2, i.getPins().size());
             Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, i).toString());
 
@@ -326,14 +328,18 @@ public class TestDesignTools {
             Assertions.assertNull(design.getNet("o2_n"));
 
             Net o = design.getNet("ob/O");
+            // Fully intra-site (OBUF to PAD)
             Assertions.assertEquals(0, o.getPins().size());
             Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, o).toString());
 
             o = design.getNet("ob/OB");
+
+            // Fully intra-site (OBUF to PAD)
             Assertions.assertEquals(0, o.getPins().size());
             Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, o).toString());
 
             o = design.getNet("ob/I_B");
+            // OUTINV to OBUF
             Assertions.assertEquals(2, o.getPins().size());
             Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, o).toString());
         }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -580,4 +580,25 @@ class TestEDIFNetlist {
         // Assert no property exists on unsupported macros either
         Assertions.assertNull(inst.getProperty("IS_CLK_INVERTED"));
     }
+
+    @Test
+    public void testGetPhysicalPinsInout() {
+        Design design = RapidWrightDCP.loadDCP("inout.dcp");
+        EDIFNetlist netlist = design.getNetlist();
+
+        {
+            Assertions.assertEquals("[i_IBUF_inst/INBUF_INST/PAD]", netlist.getPhysicalPins("i").toString());
+            Assertions.assertEquals(null, netlist.getPhysicalPins("i_IBUF"));
+            Assertions.assertEquals("[o_OBUF_inst/O]", netlist.getPhysicalPins("o").toString());
+            Assertions.assertEquals(null, netlist.getPhysicalPins("o_IBUF"));
+        }
+        {
+            Assertions.assertEquals("[ib/DIFFINBUF_INST/DIFF_IN_P]", netlist.getPhysicalPins("i2_p").toString());
+            Assertions.assertEquals("[ib/DIFFINBUF_INST/DIFF_IN_N]", netlist.getPhysicalPins("i2_n").toString());
+            Assertions.assertEquals(null, netlist.getPhysicalPins("o2_p"));
+            Assertions.assertEquals("[ob/N/O]", netlist.getPhysicalPins("ob/OB").toString());
+            Assertions.assertEquals(null, netlist.getPhysicalPins("o2_n"));
+            Assertions.assertEquals("[ob/P/O]", netlist.getPhysicalPins("ob/O").toString());
+        }
+    }
 }


### PR DESCRIPTION
Specifically, aware of top-level ports that are `inout`s.

Prior to this PR, both `EDIFNetlist.generateParentNetMap()` and `EDIFNetlist.getNetAliases()` would only consider top-level `input` ports, and never `inout` ports when determining parent nets and thus physical pins.

Fix this by consider `inout` ports as being a fallback parent net drivers (i.e. when there is no other parent net).

~Depends on https://github.com/eddieh-xlnx/RapidWrightDCP/pull/26~