### PR TITLE
Faster prohibit constraint

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3912,14 +3912,10 @@ public class DesignTools {
      *                     '<SITE-NAME>/<BEL-NAME>'.
      */
     public static void addProhibitConstraint(Design design, List<String> belLocations) {
-        if (belLocations.size() > 0) {
-            StringBuilder sb = new StringBuilder();
-            for (String bel : belLocations) {
-                sb.append(bel);
-                sb.append(" ");
-            }
+        for (String bel : belLocations) {
             design.addXDCConstraint(ConstraintGroup.LATE,
-                    "set_property PROHIBIT true [get_bels { " + sb.toString() + "} ]");
+                    "set_property PROHIBIT true [get_bels { " + bel + "} ]");
+
         }
     }
 


### PR DESCRIPTION
This PR restructures the way `DesignTools.addProhibitConstraint()` adds the XDC Tcl command.  It previously batched up all the `get_bels` calls into a single monolithic one--with the thinking that it would be faster.  However, this is not the case.  Instead, it is faster to set the property for each bel individually.  Here is a quick comparison of DCP load times for the DCP in our [shell tutorial](https://www.rapidwright.io/docs/ReusingTimingClosedLogicAsAShell.html#creating-a-shell):

| DCP Type | Vivado Load Runtime |
| ----------- | ----------- |
| Batched BEL `set_property` (prior to this PR)     | 6m4s  |
| Individual BEL `set_property` (this PR)   | 1m22s |
| Binary Netlist+Constraints File (future work) |  37s |