### PR TITLE
Cap RWRoute.presentCongestionFactor to prevent accuracy loss

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1064,6 +1064,7 @@ public class RWRoute{
     private void updateCostFactors() {
         updateCongestionCosts.start();
         presentCongestionFactor *= config.getPresentCongestionMultiplier();
+        presentCongestionFactor = Math.min(presentCongestionFactor, config.getMaxPresentCongestionFactor());
         updateCost();
         updateCongestionCosts.stop();
     }

--- a/src/com/xilinx/rapidwright/rwroute/RWRouteConfig.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRouteConfig.java
@@ -98,7 +98,7 @@ public class RWRouteConfig {
         enlargeBoundingBox = false;
         extensionYIncrement = 2;
         extensionXIncrement = 1;
-        wirelengthWeight = 0.8f;
+        setWirelengthWeight(0.8f);
         timingWeight = 0.35f;
         timingMultiplier = 1f;
         shareExponent = 2;
@@ -107,7 +107,7 @@ public class RWRouteConfig {
         reroutePercentage = (short) 3;
         initialPresentCongestionFactor = 0.5f;
         presentCongestionMultiplier = 2f;
-        setWirelengthWeight(1f);
+        historicalCongestionFactor = 1f;
         timingDriven = true;
         clkRouteTiming = null;
         pessimismA = 1.03f;
@@ -378,8 +378,8 @@ public class RWRouteConfig {
 
         // Assume that the minimum unit we want to observe is 1/8th of the wirelengthWeight
         // (since during RWRoute.evaluateCostAndPush(), distanceToSink is scaled by wirelengthWeight)
-        // compute the largest floating-point value that results in this Units-in-Last-Place value.
-        final float maxUlp = getWirelengthWeight() / 8;
+        // compute the largest floating-point value that results in this Units-in-the-Last-Place value.
+        final float maxUlp = wirelengthWeight / 8;
         float maxPresentCongestionFactor = Float.MAX_VALUE;
         while (Math.ulp(maxPresentCongestionFactor) >= maxUlp) {
             maxPresentCongestionFactor /= 2;


### PR DESCRIPTION
Specifically, it's been observed that when RWRoute operates on a hard design requiring many routing iterations to resolve congestion, its `presentCongestionFactor` can grow to such large values that overusing any node will inflate the path cost such that all other factors (distance to sink) cannot be captured using single-precision floating point causing the routing algorithm to fly blind. In particular, with `presentCongestionMultiplier` having a default value of 2, within 20 or so iterations, the [units-in-the-last-place](https://en.wikipedia.org/wiki/Unit_in_the_last_place) rises to 1.0 (`Math.ulp((float) Math.pow(2, 23)) == 1.0`).

Cap the `presentCongestionFactor` value using a heuristic that depends on the wirelength weight since RWRoute scales the distance to sink by this value:
https://github.com/Xilinx/RapidWright/blob/7bb791d319d9c863de0ce1666230fa5481d2e63c/src/com/xilinx/rapidwright/rwroute/RWRoute.java#L1634