### PR TITLE
Fix RouteThruHelper.isRouteThruPIPAvailable() for SLICEM.H[1-6]

### DIFF
--- a/src/com/xilinx/rapidwright/router/RouteThruHelper.java
+++ b/src/com/xilinx/rapidwright/router/RouteThruHelper.java
@@ -35,6 +35,7 @@ import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
 import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Node;
@@ -181,8 +182,8 @@ public class RouteThruHelper {
      * Given two Wire objects (assumed to make up a routethru PIP) check that this
      * PIP is available for use by checking for net and cell collisions within the site
      * it is routing through.
-     * Note that this method is identical to the {@link #isRouteThruPIPAvailable(Design, Node, Node)
-     * overload, kept separate to minimize unnecessary calling Node.getSitePin().}
+     * Note that this method is identical to the {@link #isRouteThruPIPAvailable(Design, Node, Node)}
+     * overload, kept separate to minimize unnecessary calling Node.getSitePin().
      */
     public static boolean isRouteThruPIPAvailable(Design design, Wire start, Wire end) {
         SitePin outPin = end.getSitePin();
@@ -194,11 +195,19 @@ public class RouteThruHelper {
         if (!isRouteThruSitePinAvailable(design, inPin)) {
             return false;
         }
+
         SiteInst siteInst = design.getSiteInstFromSite(inPin.getSite());
         if (siteInst != null) {
             for (BELPin sink : inPin.getBELPin().getSiteConns()) {
-                Cell cellCollision = siteInst.getCell(sink.getBEL());
+                BEL sinkBEL = sink.getBEL();
+                if (sinkBEL.getName().charAt(0) != inPin.getPinName().charAt(0)) {
+                    continue;
+                }
+                Cell cellCollision = siteInst.getCell(sinkBEL);
                 if (cellCollision != null) {
+                    // Ignore BELs that don't share the same LUT letter
+                    // Specifically, this is to prevent H[1-6] inputs on SLICEM sites
+                    // -- which also drive [A-G].WA[1-6] -- from considering [A-G]LUT[56]
                     return false;
                 }
             }
@@ -210,8 +219,8 @@ public class RouteThruHelper {
      * Given two Node objects (assumed to make up a routethru PIP) check that this
      * PIP is available for use by checking for net and cell collisions within the site
      * it is routing through.
-     * Note that this method is identical to the {@link #isRouteThruPIPAvailable(Design, Wire, Wire)
-     * overload, kept separate to minimize unnecessary calling Node.getSitePin().}
+     * Note that this method is identical to the {@link #isRouteThruPIPAvailable(Design, Wire, Wire)}
+     * overload, kept separate to minimize unnecessary calling Node.getSitePin().
      */
     public static boolean isRouteThruPIPAvailable(Design design, Node start, Node end) {
         SitePin outPin = end.getSitePin();
@@ -226,7 +235,14 @@ public class RouteThruHelper {
         SiteInst siteInst = design.getSiteInstFromSite(inPin.getSite());
         if (siteInst != null) {
             for (BELPin sink : inPin.getBELPin().getSiteConns()) {
-                Cell cellCollision = siteInst.getCell(sink.getBEL());
+                BEL sinkBEL = sink.getBEL();
+                if (sinkBEL.getName().charAt(0) != inPin.getPinName().charAt(0)) {
+                    // Ignore BELs that don't share the same LUT letter
+                    // Specifically, this is to prevent H[1-6] inputs on SLICEM sites
+                    // -- which also drive [A-G].WA[1-6] -- from considering [A-G]LUT[56]
+                    continue;
+                }
+                Cell cellCollision = siteInst.getCell(sinkBEL);
                 if (cellCollision != null) {
                     return false;
                 }

--- a/test/src/com/xilinx/rapidwright/router/TestRouteThruHelper.java
+++ b/test/src/com/xilinx/rapidwright/router/TestRouteThruHelper.java
@@ -72,9 +72,17 @@ public class TestRouteThruHelper {
             "CLEL_R_X10Y239/CLEL_R.CLE_CLE_L_SITE_0_D1->>CLE_CLE_L_SITE_0_D_O,false",
             "CLEL_R_X10Y239/CLEL_R.CLE_CLE_L_SITE_0_D6->>CLE_CLE_L_SITE_0_DMUX,false",
 
-            // Empty SiteInst
+            // Empty SiteInst (CLEL)
             "CLEL_R_X0Y0/CLEL_R.CLE_CLE_L_SITE_0_A1->>CLE_CLE_L_SITE_0_A_O,true",
             "CLEL_R_X0Y0/CLEL_R.CLE_CLE_L_SITE_0_A6->>CLE_CLE_L_SITE_0_AMUX,true",
+
+            // Empty SiteInst (CLEM)
+            "CLEM_X1Y0/CLEM.CLE_CLE_M_SITE_0_H1->>CLE_CLE_M_SITE_0_H_O,true",
+            "CLEM_X1Y0/CLEM.CLE_CLE_M_SITE_0_H6->>CLE_CLE_M_SITE_0_H_O,true",
+
+            // SiteInst (CLEM) with H{5,6}LUT free, but others LUTs occupied
+            "CLEM_X9Y238/CLEM.CLE_CLE_M_SITE_0_H1->>CLE_CLE_M_SITE_0_H_O,true",
+            "CLEM_X9Y238/CLEM.CLE_CLE_M_SITE_0_H6->>CLE_CLE_M_SITE_0_H_O,true",
     })
     public void testRouteThruPIPAvailable(String pipName, boolean expected) {
         Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");


### PR DESCRIPTION
The site pin `H[1-6]` on `SLICEM`s are both the read address for the `H[56]LUT` as well as the write address `[A-H][56]LUT` distributed RAMs.

Prior to this PR, querying RouteThruHelper for whether a `H[1-6]` -> `H_O` routethru is possible would fail if there was any other LUT cell (`[A-G][56]LUT`) in the same site.