### PR TITLE
Create a common interface for Node and Wire Objects

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2023.2.1-rc2.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2023.2.1-rc3.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2023.2.1-rc2-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2023.2.1-rc3-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2023.2.1-rc2-beta
+  RAPIDWRIGHT_VERSION: v2023.2.1-rc3-beta
 
 jobs:
   build:

--- a/src/com/xilinx/rapidwright/device/WireInterface.java
+++ b/src/com/xilinx/rapidwright/device/WireInterface.java
@@ -25,18 +25,76 @@ package com.xilinx.rapidwright.device;
  * An interface to enable methods to operate on the common methods of a Wire
  * object as well as a Node object. At their heart, they both specify a Tile and
  * a wire (in the case of a Node it is the base wire).
+ * 
+ * @since 2023.2.1
  */
 public interface WireInterface {
 
+    /**
+     * Gets the tile corresponding to this wire/base wire.
+     * 
+     * @return The tile of this wire/base wire.
+     * @since 2023.2.1
+     */
     public Tile getTile();
 
+    /**
+     * Gets the tile name corresponding to this wire/base wire.
+     * 
+     * @return The tile name of this wire/base wire.
+     * @since 2023.2.1
+     */
     public String getTileName();
 
+    /**
+     * Gets the wire index corresponding to this wire/base wire.
+     * 
+     * @return The wire index of this wire/base wire.
+     * @since 2023.2.1
+     */
     public int getWireIndex();
 
+    /**
+     * Gets the wire name corresponding to this wire/base wire.
+     * 
+     * @return The wire name of this wire/base wire.
+     * @since 2023.2.1
+     */
     public String getWireName();
 
+    /**
+     * Gets the intent code corresponding to this wire/base wire.
+     * 
+     * @return The intent code of this wire/base wire.
+     * @since 2023.2.1
+     */
     public IntentCode getIntentCode();
 
+    /**
+     * Gets the corresponding site pin (if any) to this wire/base wire.
+     * 
+     * @return The site pin connected to this wire/base wire, or null if not
+     *         present.
+     * @since 2023.2.1
+     */
     public SitePin getSitePin();
+
+    /**
+     * Produces a hash code based on the tile and wire of the object.
+     * 
+     * @return A hash code derived from the tile and wire.
+     * @since 2023.2.1
+     */
+    public int hashCode();
+
+    /**
+     * Checks equality (based on tile and wire values) between this and another
+     * WireInterface
+     * 
+     * @param w The other object to check against for equality.
+     * @return True if the two objects have the same tile and wire index, false
+     *         otherwise.
+     * @since 2023.2.1
+     */
+    public boolean equals(WireInterface w);
 }

--- a/src/com/xilinx/rapidwright/device/WireInterface.java
+++ b/src/com/xilinx/rapidwright/device/WireInterface.java
@@ -26,7 +26,7 @@ package com.xilinx.rapidwright.device;
  * object as well as a Node object. At their heart, they both specify a Tile and
  * a wire (in the case of a Node it is the base wire).
  */
-public interface WireObject {
+public interface WireInterface {
 
     public Tile getTile();
 

--- a/src/com/xilinx/rapidwright/device/WireInterface.java
+++ b/src/com/xilinx/rapidwright/device/WireInterface.java
@@ -36,7 +36,7 @@ public interface WireInterface {
      * @return The tile of this wire/base wire.
      * @since 2023.2.1
      */
-    public Tile getTile();
+    Tile getTile();
 
     /**
      * Gets the tile name corresponding to this wire/base wire.
@@ -44,7 +44,9 @@ public interface WireInterface {
      * @return The tile name of this wire/base wire.
      * @since 2023.2.1
      */
-    public String getTileName();
+    default String getTileName() {
+        return getTile().getName();
+    }
 
     /**
      * Gets the wire index corresponding to this wire/base wire.
@@ -52,7 +54,7 @@ public interface WireInterface {
      * @return The wire index of this wire/base wire.
      * @since 2023.2.1
      */
-    public int getWireIndex();
+    int getWireIndex();
 
     /**
      * Gets the wire name corresponding to this wire/base wire.
@@ -60,7 +62,9 @@ public interface WireInterface {
      * @return The wire name of this wire/base wire.
      * @since 2023.2.1
      */
-    public String getWireName();
+    default String getWireName() {
+        return getTile().getWireName(getWireIndex());
+    }
 
     /**
      * Gets the intent code corresponding to this wire/base wire.
@@ -68,7 +72,7 @@ public interface WireInterface {
      * @return The intent code of this wire/base wire.
      * @since 2023.2.1
      */
-    public IntentCode getIntentCode();
+    IntentCode getIntentCode();
 
     /**
      * Gets the corresponding site pin (if any) to this wire/base wire.
@@ -77,7 +81,7 @@ public interface WireInterface {
      *         present.
      * @since 2023.2.1
      */
-    public SitePin getSitePin();
+    SitePin getSitePin();
 
     /**
      * Produces a hash code based on the tile and wire of the object.
@@ -85,7 +89,7 @@ public interface WireInterface {
      * @return A hash code derived from the tile and wire.
      * @since 2023.2.1
      */
-    public int hashCode();
+    int hashCode();
 
     /**
      * Checks equality (based on tile and wire values) between this and another
@@ -96,5 +100,5 @@ public interface WireInterface {
      *         otherwise.
      * @since 2023.2.1
      */
-    public boolean equals(WireInterface w);
+    boolean equals(WireInterface w);
 }

--- a/src/com/xilinx/rapidwright/device/WireObject.java
+++ b/src/com/xilinx/rapidwright/device/WireObject.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.device;
+
+/**
+ * An interface to enable methods to operate on the common methods of a Wire
+ * object as well as a Node object. At their heart, they both specify a Tile and
+ * a wire (in the case of a Node it is the base wire).
+ */
+public interface WireObject {
+
+    public Tile getTile();
+
+    public String getTileName();
+
+    public int getWireIndex();
+
+    public String getWireName();
+
+    public IntentCode getIntentCode();
+
+    public SitePin getSitePin();
+}

--- a/test/src/com/xilinx/rapidwright/device/TestWireInterface.java
+++ b/test/src/com/xilinx/rapidwright/device/TestWireInterface.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.xilinx.rapidwright.device;
 
 import org.junit.jupiter.api.Assertions;

--- a/test/src/com/xilinx/rapidwright/device/TestWireInterface.java
+++ b/test/src/com/xilinx/rapidwright/device/TestWireInterface.java
@@ -1,0 +1,43 @@
+package com.xilinx.rapidwright.device;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestWireInterface {
+
+    @Test
+    public void testWireInterface() {
+        Device device = Device.getDevice(Device.KCU105);
+
+//        get_nodes INT_X45Y18/WW2_W_BEG1
+//        INT_X45Y18/WW2_W_BEG1
+//        get_wires -of [get_nodes INT_X45Y18/WW2_W_BEG1]
+//        INT_X45Y18/WW2_W_BEG1 INT_X44Y18/WW2_W_END1 CLEL_R_X44Y18/EASTBUSOUT_FT1_17 FSR_GAP_X44Y18/EASTBUSOUT_FT1_17 CLE_M_X45Y18/EASTBUSOUT_FT1_17 CFRM_CBRK_L_X45Y0/EASTBUSOUT_FT1_18_17
+
+        Node node = device.getNode("INT_X45Y18/WW2_W_BEG1");
+        Wire[] wires = node.getAllWiresInNode();
+
+        // Node vs. Wire
+        for (int i = 0; i < wires.length; i++) {
+            Assertions.assertEquals(i == 0, node.getTile().equals(wires[i].getTile()));
+            Assertions.assertEquals(i == 0, node.getWireIndex() == wires[i].getWireIndex());
+        }
+
+        // Node vs. WireInterface
+        WireInterface[] wireInts = wires;
+        for (int i = 0; i < wireInts.length; i++) {
+            Assertions.assertEquals(i == 0, node.hashCode() == wireInts[i].hashCode());
+            Assertions.assertEquals(i == 0, node.equals(wireInts[i]));
+            Assertions.assertEquals(i == 0, wireInts[i].equals(node));
+        }
+
+        // WireInterface vs. Wire
+        WireInterface wireInt = node;
+        for (int i = 0; i < wires.length; i++) {
+            Assertions.assertEquals(i == 0, wireInt.hashCode() == wires[i].hashCode());
+            Assertions.assertEquals(i == 0, wireInt.equals(wires[i]));
+            Assertions.assertEquals(i == 0, wires[i].equals(wireInt));
+        }
+
+    }
+}


### PR DESCRIPTION
This update will take a few steps, but getting the interface in place first has no dependencies.  

In a future release, `Node` and `Wire` objects would implement this interface.

At a minimum, it would allow us to collapse `RouteThruHelper.isRouteThruPIPAvailable(Design, Node, Node)` and `RouteThruHelper.isRouteThruPIPAvailable(Design, Wire, Wire)`.