### PR TITLE
DesignTools.createMissingSitePinInsts() to ignore inout SPIs

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2173,6 +2173,10 @@ public class DesignTools {
                         // is not actually connected to the global routing fabric; skip those
                         continue;
                     }
+                    if (!si.isSitePinOutput(sitePinName) && !si.isSitePinInput(sitePinName)) {
+                        // This site pin is an INOUT (only seen in I/O tiles) -- ignore
+                        continue;
+                    }
                     newPin = net.createPin(sitePinName, si);
                     if (newPin != null) newPins.add(newPin);
                 }


### PR DESCRIPTION
Specifically, in a tristate I/O situation as below:

![image](https://github.com/Xilinx/RapidWright/assets/90657806/f517a80f-9fcf-4fc6-ad5b-d147958d9665)

`DesignTools.createMissingSitePinInsts()` would attach a `SitePinInst` to the the green net inside the `IOBUF` -- even though the SPI is an inout that goes to the off-chip port.