### PR TITLE
DesignTools.createMissingSitePinInsts() to skip "IO" on IOB sites

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2168,7 +2168,7 @@ public class DesignTools {
                     SitePinInst newPin = si.getSitePinInst(sitePinName);
                     if (newPin != null) continue;
                     if (sitePinName.equals("IO") && Utils.isIOB(si)) {
-                        // Do not create a SitePinInst for the "IO" input port of any IOB site,
+                        // Do not create a SitePinInst for the "IO" input site pin of any IOB site,
                         // since the sitewire it drives is assumed to be driven by the IO PAD.
                         continue;
                     }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2167,17 +2167,9 @@ public class DesignTools {
                     if (sitePinName == null) continue;
                     SitePinInst newPin = si.getSitePinInst(sitePinName);
                     if (newPin != null) continue;
-                    int wireIndex = si.getSite().getTileWireIndexFromPinName(sitePinName);
-                    if (Node.getNode(si.getTile(), wireIndex) == null) {
-                        // It's possible that the discovered site pin (e.g. as for some IOB tiles)
-                        // is not actually connected to the global routing fabric; skip those
-                        continue;
-                    }
                     if (sitePinName.equals("IO") && p.getCellType() == netlist.getHDIPrimitive(Unisim.INBUF)) {
-                        assert(p.getPortInst().getParentCell() == netlist.getHDIPrimitive(Unisim.IOBUF));
                         // Do not create a SitePinInst for the "IO" port of an INBUF primitive,
-                        // which is the expanded component of the "IOBUF" macro. As stated in UG974,
-                        // this bidir IO port is to be connected directly to the top-level port.
+                        // which is the expanded component of the "IBUF", "IOBUF", etc. macros.
                         continue;
                     }
                     newPin = net.createPin(sitePinName, si);

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2167,9 +2167,9 @@ public class DesignTools {
                     if (sitePinName == null) continue;
                     SitePinInst newPin = si.getSitePinInst(sitePinName);
                     if (newPin != null) continue;
-                    if (sitePinName.equals("IO") && p.getCellType() == netlist.getHDIPrimitive(Unisim.INBUF)) {
-                        // Do not create a SitePinInst for the "IO" port of an INBUF primitive,
-                        // which is the expanded component of the "IBUF", "IOBUF", etc. macros.
+                    if (sitePinName.equals("IO") && Utils.isIOB(si)) {
+                        // Do not create a SitePinInst for the "IO" input port of any IOB site,
+                        // since the sitewire it drives is assumed to be driven by the IO PAD.
                         continue;
                     }
                     newPin = net.createPin(sitePinName, si);

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2173,6 +2173,13 @@ public class DesignTools {
                         // is not actually connected to the global routing fabric; skip those
                         continue;
                     }
+                    if (sitePinName.equals("IO") && p.getCellType() == netlist.getHDIPrimitive(Unisim.INBUF)) {
+                        assert(p.getPortInst().getParentCell() == netlist.getHDIPrimitive(Unisim.IOBUF));
+                        // Do not create a SitePinInst for the "IO" port of an INBUF primitive,
+                        // which is the expanded component of the "IOBUF" macro. As stated in UG974,
+                        // this bidir IO port is to be connected directly to the top-level port.
+                        continue;
+                    }
                     newPin = net.createPin(sitePinName, si);
                     if (newPin != null) newPins.add(newPin);
                 }

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -305,8 +305,7 @@ public class TestDesignTools {
         {
             Net i = design.getNet("i");
             Assertions.assertEquals(0, i.getPins().size());
-            // Technically should not be present since net is fully intra-site (PAD to INBUF), but harmless
-            Assertions.assertEquals("[IN IOB_X1Y253.IO]", DesignTools.createMissingSitePinInsts(design, i).toString());
+            Assertions.assertEquals("[]", DesignTools.createMissingSitePinInsts(design, i).toString());
 
             Net o = design.getNet("o");
             Assertions.assertEquals(0, o.getPins().size());


### PR DESCRIPTION
Replace #724 with a more general rule to skip the `IO` site pin for all IOB tiles, since I've discovered at least one case (`A28`/`IOB_X0Y47` on an xcvu3p) where the `IO` site pin does have a node feeding it (which appears to be driven by the `HPIOBDIFFOUTBUF_X0Y22/AOUT` pin) which I've never seen used.

Also update the `TestDesignTools.testCreateMissingSitePinInstsInout()` test to remove the harmless site pin that was previously created.