### PR TITLE
[RWRoute] Tidy up RouteNode.setChildren()

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -77,8 +77,12 @@ public class PartialRouter extends RWRoute {
         }
 
         @Override
-        protected boolean mustInclude(Node parent, Node child) {
-            return isPartOfExistingRoute(parent, child);
+        protected boolean isExcluded(Node parent, Node child) {
+            // Routing part of an existing (preserved) route are never excluded
+            if (isPartOfExistingRoute(parent, child)) {
+                return false;
+            }
+            return super.isExcluded(parent, child);
         }
     }
 
@@ -88,8 +92,11 @@ public class PartialRouter extends RWRoute {
         }
 
         @Override
-        protected boolean mustInclude(Node parent, Node child) {
-            return isPartOfExistingRoute(parent, child);
+        protected boolean isExcluded(Node parent, Node child) {
+            if (isPartOfExistingRoute(parent, child)) {
+                return false;
+            }
+            return super.isExcluded(parent, child);
         }
     }
 
@@ -131,7 +138,7 @@ public class PartialRouter extends RWRoute {
      * @param end End Node of arc.
      * @return True if arc is part of an existing route.
      */
-    private boolean isPartOfExistingRoute(Node start, Node end) {
+    protected boolean isPartOfExistingRoute(Node start, Node end) {
         // End node can only be part of existing route if it is in the graph already
         RouteNode endRnode = routingGraph.getNode(end);
         if (endRnode == null)

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -130,9 +130,8 @@ abstract public class RouteNode implements Comparable<RouteNode> {
         List<Node> allDownHillNodes = node.getAllDownhillNodes();
         List<RouteNode> childrenList = new ArrayList<>(allDownHillNodes.size());
         for (Node downhill: allDownHillNodes) {
-            if (!mustInclude(node, downhill)) {
-                if (isPreserved(downhill) || isExcluded(node, downhill))
-                    continue;
+            if (isExcluded(downhill)) {
+                continue;
             }
 
             RouteNode child = getOrCreate(downhill, null);
@@ -629,7 +628,6 @@ abstract public class RouteNode implements Comparable<RouteNode> {
      * @return true, if a RouteNode instance has been visited before.
      */
     public boolean isVisited(int id) {
-        assert(id > 0);
         return visited == id;
     }
 
@@ -668,27 +666,11 @@ abstract public class RouteNode implements Comparable<RouteNode> {
     }
 
     /**
-     * Checks if a routing arc must be included.
-     * @param parent The routing arc's parent node.
-     * @param child The routing arc's parent node.
-     * @return True, if the arc should be included in the routing resource graph.
-     */
-    abstract public boolean mustInclude(Node parent, Node child);
-
-    /**
-     * Checks if a node has been preserved and thus cannot be used.
-     * @param node The node in question.
+     * Checks if a downhill node has been excluded should not be present in the routing graph.
+     * @param child The downhill node.
      * @return True, if the arc should be excluded from the routing resource graph.
      */
-    abstract public boolean isPreserved(Node node);
-
-    /**
-     * Checks if a routing arc has been excluded thus cannot be used.
-     * @param parent The routing arc's parent node.
-     * @param child The routing arc's parent node.
-     * @return True, if the arc should be excluded from the routing resource graph.
-     */
-    abstract public boolean isExcluded(Node parent, Node child);
+    abstract public boolean isExcluded(Node child);
 
     abstract public int getSLRIndex();
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -114,18 +114,8 @@ public class RouteNodeGraph {
         }
 
         @Override
-        public boolean mustInclude(Node parent, Node child) {
-            return RouteNodeGraph.this.mustInclude(parent, child);
-        }
-
-        @Override
-        public boolean isPreserved(Node node) {
-            return RouteNodeGraph.this.isPreserved(node);
-        }
-
-        @Override
-        public boolean isExcluded(Node parent, Node child) {
-            return RouteNodeGraph.this.isExcluded(parent, child);
+        public boolean isExcluded(Node child) {
+            return RouteNodeGraph.this.isExcluded(node, child);
         }
 
         @Override
@@ -381,10 +371,6 @@ public class RouteNodeGraph {
         allowedTileEnums = EnumSet.copyOf(tempAllowedTileEnums);
     }
 
-    protected boolean mustInclude(Node parent, Node child) {
-        return false;
-    }
-
     protected boolean isExcludedTile(Node child) {
         Tile tile = child.getTile();
         TileTypeEnum tileType = tile.getTileTypeEnum();
@@ -392,6 +378,10 @@ public class RouteNodeGraph {
     }
 
     protected boolean isExcluded(Node parent, Node child) {
+        if (isPreserved(child)) {
+            return true;
+        }
+
         if (isExcludedTile(child)) {
             return true;
         }


### PR DESCRIPTION
Instead of running a gauntlet of three methods to determine if a routing node should be excluded from the graph:
* `mustInclude()`
* `isPreserved()`
* `isExcluded()`

Reconcile all into a single `isExcluded()`.