### PR TITLE
DesignTools.createMissingSitePinInsts(Design) to skip non-parent nets

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2280,9 +2280,21 @@ public class DesignTools {
      * @param design The current design
      */
     public static void createMissingSitePinInsts(Design design) {
+        EDIFNetlist netlist = design.getNetlist();
         for (Net net : design.getNets()) {
             if (net.isUsedNet()) {
                 continue;
+            }
+            EDIFHierNet ehn = net.getLogicalHierNet();
+            EDIFHierNet parentEhn = netlist.getParentNet(ehn);
+            if (!parentEhn.equals(ehn)) {
+                Net parentNet = design.getNet(parentEhn.getHierarchicalNetName());
+                if (parentNet != null) {
+                    // 'net' is not a parent net (which normally causes createMissingSitePinInsts(Design, Net)
+                    // to analyze its parent net) but that parent net also exist in the design and has been/
+                    // will be analyzed in due course, so skip doing so here
+                    continue;
+                }
             }
             createMissingSitePinInsts(design,net);
         }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2286,8 +2286,8 @@ public class DesignTools {
                 continue;
             }
             EDIFHierNet ehn = net.getLogicalHierNet();
-            EDIFHierNet parentEhn = netlist.getParentNet(ehn);
-            if (!parentEhn.equals(ehn)) {
+            EDIFHierNet parentEhn = (ehn != null) ? netlist.getParentNet(ehn) : null;
+            if (parentEhn != null && !parentEhn.equals(ehn)) {
                 Net parentNet = design.getNet(parentEhn.getHierarchicalNetName());
                 if (parentNet != null) {
                     // 'net' is not a parent net (which normally causes createMissingSitePinInsts(Design, Net)


### PR DESCRIPTION
... if they have been/will be analyzed anyway.

Reduces occurrences of this warning:
https://github.com/Xilinx/RapidWright/blob/56d9bd4aaaf24da885540fb0141d7e2b8aaeb4fa/src/com/xilinx/rapidwright/design/DesignTools.java#L2097-L2109

and potentially even reduces redundant work done too.