### PR TITLE
Declare gradle dependency explicitly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ task cleanupScripts(type: Delete) {
 }
 
 task restoreScripts(type: Copy) {
+    dependsOn(tasks.named("jar"))
     from preserveDir
     into 'bin'
     finalizedBy(cleanupScripts)

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,8 @@ task restoreScripts(type: Copy) {
     finalizedBy(cleanupScripts)
 }
 
+run.dependsOn(restoreScripts)
+
 task mainJar(type: Jar, dependsOn: classes) {
     archiveBaseName = 'main'
     from sourceSets.main.output include mainClassName


### PR DESCRIPTION
This removes the warning from Gradle:
```
Execution optimizations have been disabled for task ':jar' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'RapidWright/bin'. Reason: Task ':jar' uses this output of task ':restoreScripts' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4.2/userguide/command_line_interface.html#sec:command_line_warnings

Execution optimizations have been disabled for 1 invalid unit(s) of work during this build to ensure correctness.
Please consult deprecation warnings for more details.


```