### PR TITLE
[RWRoute] RouteNode to extend Node

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -252,7 +252,7 @@ public class Connection implements Comparable<Connection>{
             RouteNode rnode = getRnodes().get(i);
             RouteNode parent = getRnodes().get(i+1);
             routeDelay += rnode.getDelay() +
-                    DelayEstimatorBase.getExtraDelay(rnode.getNode(), DelayEstimatorBase.isLong(parent.getNode()));
+                    DelayEstimatorBase.getExtraDelay(rnode, DelayEstimatorBase.isLong(parent));
         }
         return routeDelay;
     }

--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -483,7 +483,7 @@ public class Connection implements Comparable<Connection>{
 
     public void setAllTargets(boolean target) {
         if (sinkRnode.countConnectionsOfUser(netWrapper) == 0 ||
-            sinkRnode.getNode().getIntentCode() == IntentCode.NODE_PINBOUNCE) {
+            sinkRnode.getIntentCode() == IntentCode.NODE_PINBOUNCE) {
             // Since this connection will have been ripped up, only mark a node
             // as a target if it's not already used by this net.
             // This prevents -- for the case where the same net needs to be routed
@@ -501,7 +501,7 @@ public class Connection implements Comparable<Connection>{
                 if (rnode.countConnectionsOfUser(netWrapper) == 0 ||
                     // Except if it is not a PINFEED_I
                     rnode.getType() != RouteNodeType.PINFEED_I) {
-                    assert(rnode.getNode().getIntentCode() != IntentCode.NODE_PINBOUNCE);
+                    assert(rnode.getIntentCode() != IntentCode.NODE_PINBOUNCE);
                     rnode.setTarget(target);
                 }
             }

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -146,8 +146,7 @@ public class PartialRouter extends RWRoute {
         // Presence of a prev pointer means that only that arc is allowed to enter this end node
         RouteNode prev = endRnode.getPrev();
         if (prev != null) {
-            assert((prev.getNode() == start) == prev.getNode().equals(start));
-            if (prev.getNode() == start && routingGraph.isPreserved(end)) {
+            if (prev.equals(start) && routingGraph.isPreserved(end)) {
                 // Arc matches start node and end node is preserved
                 // This implies that both start and end nodes must be preserved for the same net
                 // (which assumedly is the net we're currently routing, and is asserted upstream)
@@ -502,17 +501,17 @@ public class PartialRouter extends RWRoute {
     protected Collection<Net> pickNetsToUnpreserve(Connection connection) {
         Set<Net> unpreserveNets = new HashSet<>();
 
-        Node sourceNode = connection.getSourceRnode().getNode();
-        Node sinkNode = connection.getSinkRnode().getNode();
+        RouteNode sourceRnode = connection.getSourceRnode();
+        RouteNode sinkRnode = connection.getSinkRnode();
 
         List<Node> candidateNodes = new ArrayList<>();
         // Consider the cases of [A-H](X|_I) site pins which are accessed through a bounce node,
         // meaning this connection may be unroutable because another net is preserving this node
-        candidateNodes.add(sinkNode);
+        candidateNodes.add(sinkRnode);
         // Find those reserved signals that are using uphill nodes of the target pin node
-        candidateNodes.addAll(sinkNode.getAllUphillNodes());
+        candidateNodes.addAll(sinkRnode.getAllUphillNodes());
         // Find those preserved nets that are using downhill nodes of the source pin node
-        candidateNodes.addAll(sourceNode.getAllDownhillNodes());
+        candidateNodes.addAll(sourceRnode.getAllDownhillNodes());
 
         for(Node node : candidateNodes) {
             Net toRoute = routingGraph.getPreservedNet(node);
@@ -649,13 +648,12 @@ public class PartialRouter extends RWRoute {
         routingGraph.resetExpansion();
 
         for (RouteNode rnode : rnodes) {
-            Node toBuild = rnode.getNode();
             // Check already unpreserved above
-            assert(!routingGraph.isPreserved(toBuild));
+            assert(!routingGraph.isPreserved(rnode));
 
             // Each rnode should be added as a child to all of its parents
             // that already exist
-            for (Node uphill : toBuild.getAllUphillNodes()) {
+            for (Node uphill : rnode.getAllUphillNodes()) {
                 RouteNode parent = routingGraph.getNode(uphill);
                 if (parent == null)
                     continue;

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -920,7 +920,7 @@ public class RWRoute{
                     }
                     connection.setSinkRnode(newSinkRnode);
 
-                    SitePin newSitePin = newSinkRnode.getNode().getSitePin();
+                    SitePin newSitePin = newSinkRnode.getSitePin();
                     String existing = pinSwaps.put(oldSinkSpi, newSitePin.getPinName());
                     assert(existing == null);
                 }
@@ -1073,7 +1073,7 @@ public class RWRoute{
             RouteNode sinkRnode = connection.getSinkRnode();
             List<RouteNode> rnodes = connection.getRnodes();
             if (sinkRnode == rnodes.get(0)) {
-                List<Node> switchBoxToSink = RouterHelper.findPathBetweenNodes(sinkRnode.getNode(), connection.getSink().getConnectedNode());
+                List<Node> switchBoxToSink = RouterHelper.findPathBetweenNodes(sinkRnode, connection.getSink().getConnectedNode());
                 if (switchBoxToSink.size() >= 2) {
                     for (int i = 0; i < switchBoxToSink.size() - 1; i++) {
                         nodes.add(switchBoxToSink.get(i));
@@ -1085,7 +1085,7 @@ public class RWRoute{
 
                 // Assume that it doesn't need unprojecting back to the sink pin
                 // since the sink node is a site pin
-                assert(rnodes.get(0).getNode().getSitePin() != null);
+                assert(rnodes.get(0).getSitePin() != null);
             }
 
             for (RouteNode rnode : rnodes) {
@@ -1610,7 +1610,7 @@ public class RWRoute{
                 if (childRNode == connection.getSinkRnode() && connection.getAltSinkRnodes().isEmpty()) {
                     // This sink must be exclusively reserved for this connection already
                     assert(childRNode.getOccupancy() == 0 ||
-                            childRNode.getNode().getIntentCode() == IntentCode.NODE_PINBOUNCE);
+                            childRNode.getIntentCode() == IntentCode.NODE_PINBOUNCE);
                     earlyTermination = true;
                 } else {
                     // Target is not an exclusive sink, only early terminate if this net will not

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -992,7 +992,9 @@ public class RWRoute{
             }
 
             List<RouteNode> rnodes = connection.getRnodes();
-            nodes.addAll(rnodes);
+            for (RouteNode rnode : rnodes) {
+                nodes.add(rnode.getNode());
+            }
 
             List<Node> sourceToSwitchBox = RouterHelper.findPathBetweenNodes(connection.getSource().getConnectedNode(), connection.getSourceRnode());
             if (sourceToSwitchBox.size() >= 2) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -303,7 +303,8 @@ abstract public class RouteNode extends Node implements Comparable<RouteNode> {
             return true;
         if (obj == null)
             return false;
-        // Explicitly call the Node.equals(Node) overload, rather than the general-purpose Node.equals(Object)
+        // This method requires that object is Node or a subclass of one, otherwise exception will be thrown.
+        // If so, explicitly call the Node.equals(Node) overload, rather than the general-purpose Node.equals(Object).
         return super.equals((Node) obj);
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -297,23 +297,13 @@ abstract public class RouteNode extends Node implements Comparable<RouteNode> {
         return super.equals(obj);
     }
 
-    public boolean equals(RouteNode obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        return super.equals(obj);
-    }
-
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (obj == null)
             return false;
-        if (getClass() == obj.getClass()) {
-            return equals((RouteNode) obj);
-        }
+        // Explicitly call the Node.equals(Node) overload, rather than the general-purpose Node.equals(Object)
         return super.equals((Node) obj);
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -327,8 +327,8 @@ abstract public class RouteNode extends Node implements Comparable<RouteNode> {
     }
 
     /**
-     * Gets the associated Node of a RouteNode Object.
-     * @return The associated Node of a RouteNode Object.
+     * Returns a deep copy of the Node associated with this RouteNode Object.
+     * @return New Node deep copy.
      */
     public Node getNode() {
         return new Node(this);

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -513,12 +513,11 @@ public class RouteNodeGraph {
         return Math.round((float) sum / numNodes());
     }
 
-    public boolean isAccessible(RouteNode child, Connection connection) {
-        Node childNode = child.getNode();
-        Tile childTile = childNode.getTile();
+    public boolean isAccessible(RouteNode childRnode, Connection connection) {
+        Tile childTile = childRnode.getTile();
         TileTypeEnum childTileType = childTile.getTileTypeEnum();
         BitSet bs = accessibleWireOnlySameColumnAsTarget.get(childTileType);
-        if (bs == null || !bs.get(childNode.getWire())) {
+        if (bs == null || !bs.get(childRnode.getWire())) {
             return true;
         }
 
@@ -528,7 +527,7 @@ public class RouteNodeGraph {
             return true;
         }
 
-        Tile sinkTile = connection.getSinkRnode().getNode().getTile();
+        Tile sinkTile = connection.getSinkRnode().getTile();
         if (childX != sinkTile.getTileXCoordinate()) {
             return false;
         }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraphTimingDriven.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraphTimingDriven.java
@@ -111,13 +111,13 @@ public class RouteNodeGraphTimingDriven extends RouteNodeGraph {
         @Override
         public String toString() {
             StringBuilder s = new StringBuilder();
-            s.append("node " + node.toString());
+            s.append("node " + super.toString());
             s.append(", ");
             s.append("(" + getEndTileXCoordinate() + "," + getEndTileYCoordinate() + ")");
             s.append(", ");
             s.append(String.format("type = %s", getType()));
             s.append(", ");
-            s.append(String.format("ic = %s", node.getIntentCode()));
+            s.append(String.format("ic = %s", getIntentCode()));
             s.append(", ");
             s.append(String.format("dly = %f", delay));
             s.append(", ");

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -169,8 +169,8 @@ public class TimingAndWirelengthReport{
 
         for (Connection connection : netWrapper.getConnections()) {
             if (connection.isDirect()) continue;
-            Node sinkNode = connection.getSinkRnode().getNode();
-            LightweightRouteNode sinkrn = nodeRoutingNodeMap.get(sinkNode);
+            RouteNode sinkRnode = connection.getSinkRnode();
+            LightweightRouteNode sinkrn = nodeRoutingNodeMap.get(sinkRnode);
             if (sinkrn == null) continue;
             float connectionDelay = sinkrn.getDelayFromSource();
             if (connection.getTimingEdges() == null) continue;

--- a/src/com/xilinx/rapidwright/timing/TimingManager.java
+++ b/src/com/xilinx/rapidwright/timing/TimingManager.java
@@ -138,7 +138,7 @@ public class TimingManager {
             for (int i = connection.getRnodes().size() - 2; i >= 0; i--) {
                 RouteNode child = connection.getRnodes().get(i);
                 RouteNode parent = connection.getRnodes().get(i+1);
-                netDelay += child.getDelay() + DelayEstimatorBase.getExtraDelay(child.getNode(), DelayEstimatorBase.isLong(parent.getNode()));
+                netDelay += child.getDelay() + DelayEstimatorBase.getExtraDelay(child, DelayEstimatorBase.isLong(parent));
             }
             connection.setTimingEdgesDelay(netDelay);
             connection.setDlyPatched(true);
@@ -237,7 +237,7 @@ public class TimingManager {
                     for (int iGroup = nodes.size() -1; iGroup >= 0; iGroup--) {
                         RouteNode rnode = routingGraph.getNode(nodes.get(iGroup));
                         if (rnode != null) {
-                            System.out.println("\t " + rnode.getNode() + ", " + rnode.getNode().getIntentCode() + ", delay = " + (short) rnode.getDelay());
+                            System.out.println("\t " + rnode.getNode() + ", " + rnode.getIntentCode() + ", delay = " + (short) rnode.getDelay());
                         } else {
                             System.out.println("\t " + nodes.get(iGroup) + ", " + nodes.get(iGroup).getIntentCode() + ", delay = " + 0);
                         }


### PR DESCRIPTION
Rather than keeping a reference to `Node`, extend it to save 16 bytes per `RouteNode` when in compressed OOP mode:
* -4 bytes from the `RouteNode.node` reference no longer being needed
* -12 bytes from the `Node` compressed object header (8 bytes mark + 4 bytes class) being redundant now that it is combined with the `RouteNode` object.
