### PR TITLE
[ECOTools] Inline cell insertion

### DIFF
--- a/src/com/xilinx/rapidwright/eco/ECOTools.java
+++ b/src/com/xilinx/rapidwright/eco/ECOTools.java
@@ -1108,16 +1108,17 @@ public class ECOTools {
 
     /**
      * Creates and places a new primitive cell inline from the existing net driving
-     * the input pin provided and connects its output to the existing input. For
-     * example, if input is 'FF/D' and reference is a LUT1, this will create a new
-     * cell instance of type LUT1 where its input 'I0' will replace the connection
-     * 'D' on 'FF' and a new net will be created that will connect 'LUT1/O' to
-     * 'FF/D'.
+     * the input pin provided and connects its output to the existing input. The
+     * cell will be created as a sibling to the instance of the provided input pin
+     * and will be named with the prefix 'inline_insertion_'. For example, if input
+     * is 'FF/D' and reference is a LUT1, this will create a new cell instance of
+     * type LUT1 where its input 'I0' will replace the connection 'D' on 'FF' and a
+     * new net will be created that will connect 'LUT1/O' to 'FF/D'.
      * 
      * This is useful for scenarios like inserting a LUT1 inline when routethru
      * instances are not possible.
      * 
-     * @param design    The existing design
+     * @param design    The existing design.
      * @param input     The reference logical input pin on which the new inline cell
      *                  should be created and connected.
      * @param reference The primitive cell type to create.
@@ -1125,12 +1126,12 @@ public class ECOTools {
      * @param bel       The BEL within the provided site onto which the cell should
      *                  be placed.
      * @param logInput  The logical cell's input pin that should connect to the
-     *                  existing input's net
+     *                  existing input's net.
      * @param logOutput The logical cell's output pin that should connect to the
-     *                  existing input
+     *                  existing input.
      * @return A hierarchical reference to the newly created cell instance.
      */
-    public static Cell createInlineCellOnInputPin(Design design, EDIFHierPortInst input,
+    public static Cell createAndPlaceInlineCellOnInputPin(Design design, EDIFHierPortInst input,
             Unisim reference, Site site, BEL bel, String logInput, String logOutput) {
         if (!input.isInput()) return null;
         EDIFHierNet net = input.getHierarchicalNet();

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -153,7 +153,7 @@ public class EDIFCellInst extends EDIFPropertyObject {
     }
 
     /**
-     * Gets the named EDIFPortInst or creates it (if it correctly named) and returns
+     * Gets the named EDIFPortInst or creates it (if correctly named) and returns
      * it. If the port instance is to be created, it will not be connected to an
      * EDIFNet.
      * 

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -153,6 +153,22 @@ public class EDIFCellInst extends EDIFPropertyObject {
     }
 
     /**
+     * Gets the named EDIFPortInst or creates it (if it correctly named) and returns
+     * it. If the port instance is to be created, it will not be connected to an
+     * EDIFNet.
+     * 
+     * @param name Name of the port instance to get.
+     * @return The existing or created port instance.
+     */
+    public EDIFPortInst getOrCreatePortInst(String name) {
+        EDIFPortInst portInst = portInsts == null ? null : portInsts.get(this, name);
+        if (portInsts == null || portInst == null) {
+            portInst = EDIFPortInst.createPortInstFromPortInstName(name, this);
+        }
+        return portInst;
+    }
+
+    /**
      * Gets the port on the underlying cell type.  It is the same as
      * calling getCellType().getPort(name).
      * @param name Name of the port to get.

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -149,6 +149,25 @@ public class EDIFPortInst implements Comparable<EDIFPortInst> {
 
     }
 
+    /**
+     * Creates a new port instance without connecting it to a net.
+     * 
+     * @param portInstName Name of the port instance
+     * @param inst         The instance on which to create the new port instance
+     * @return The new port instance.
+     */
+    public static EDIFPortInst createPortInstFromPortInstName(String portInstName, EDIFCellInst inst) {
+        EDIFPort port = inst.getCellType().getPortByPortInstName(portInstName);
+        if (port == null)
+            return null;
+        int portIdx = -1;
+        if (port.isBus()) {
+            int idx = EDIFTools.getPortIndexFromName(portInstName);
+            portIdx = port.getPortIndexFromNameIndex(idx);
+        }
+        return new EDIFPortInst(port, null, portIdx, inst, false);
+    }
+
     public String getPortInstNameFromPort() {
         return port.getPortInstNameFromPort(index);
     }

--- a/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
+++ b/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
@@ -425,7 +425,7 @@ public class TestECOTools {
     }
 
     @Test
-    public void testCreateInlineCellOnInputPin() {
+    public void testCreateAndPlaceInlineCellOnInputPin() {
         Design d = new Design("Test", Device.KCU105);
 
         Cell and2 = d.createAndPlaceCell("and2", Unisim.AND2, "SLICE_X100Y100/A6LUT");

--- a/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
+++ b/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
@@ -40,6 +40,7 @@ import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.router.Router;
+import com.xilinx.rapidwright.rwroute.TestRWRoute;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.util.FileTools;
 import com.xilinx.rapidwright.util.ReportRouteStatusResult;
@@ -455,7 +456,7 @@ public class TestECOTools {
         Site site = d.getDevice().getSite("SLICE_X100Y101");
         BEL bel = site.getBEL("A6LUT");
         Unisim lut1Type = Unisim.LUT1;
-        ECOTools.createInlineCellOnInputPin(d, input, lut1Type, site, bel, "I0", "O");
+        ECOTools.createAndPlaceInlineCellOnInputPin(d, input, lut1Type, site, bel, "I0", "O");
 
         // Route nets between sites
         new Router(d).routeDesign();
@@ -466,8 +467,7 @@ public class TestECOTools {
         Assertions.assertEquals(net0, lut1.getSitePinFromLogicalPin("I0", null).getNet());
         Assertions.assertNotEquals(net0, lut1.getSitePinFromLogicalPin("O", null).getNet());
 
-        Assumptions.assumeTrue(FileTools.isVivadoOnPath());
-        Assertions.assertTrue(VivadoTools.reportRouteStatus(d).isFullyRouted());
+        TestRWRoute.assertVivadoFullyRouted(d);
     }
 
     @Test


### PR DESCRIPTION
ECO to insert a cell inline based on a specific input pin.  Method signature:
```
 public static Cell createInlineCellOnInputPin(Design design, EDIFHierPortInst input,
            Unisim reference, Site site, BEL bel, String logInput, String logOutput)
```

For example:

![image](https://github.com/Xilinx/RapidWright/assets/20803522/aac4d5be-0d0c-4284-8942-ac946a76e8fe)

The magenta colored LUT1 was inserted along with the cyan colored net to connect it to the existing input pin.  

Also added a few convenience methods.