### PR TITLE
Add EDIFHierCellInst.isUniquified()

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -168,10 +168,6 @@ public class EDIFCell extends EDIFPropertyObject {
                     getName() + ", trying to add instance " + instance.getName() +
                     " which already exists inside this cell.");
         }
-        EDIFCell cellType = instance.getCellType();
-        if (cellType != null) {
-            cellType.incrementInstanceCount();
-        }
         return instance;
     }
 
@@ -189,10 +185,6 @@ public class EDIFCell extends EDIFPropertyObject {
             instance.setName(instance.getName() + "_" + getLibrary().getNetlist().nameSpaceUniqueCount++);
         }
         instances.put(instance.getName(), instance);
-        EDIFCell cellType = instance.getCellType();
-        if (cellType != null) {
-            cellType.incrementInstanceCount();
-        }
         return instance;
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -690,6 +690,13 @@ public class EDIFCell extends EDIFPropertyObject {
      */
     public void decrementInstanceCount() {
         instanceCountUpdater.getAndDecrement(this);
+        if (getInstanceCount() == 0) {
+            // Since this cell is no longer instantiated, decrement the count of all the cells
+            // that gets instantiated within
+            for (EDIFCellInst instance : getCellInsts()) {
+                instance.getCellType().decrementInstanceCount();
+            }
+        }
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -678,7 +678,7 @@ public class EDIFCell extends EDIFPropertyObject {
     }
 
     /**
-     * Atomically decrement instance count of this cell.
+     * @return The number of times this cell has been instantiated.
      */
     public int getInstanceCount() {
         return instanceCountUpdater.get(this);

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -675,16 +675,6 @@ public class EDIFCell extends EDIFPropertyObject {
      */
     public void incrementInstanceCount() {
         instanceCountUpdater.incrementAndGet(this);
-
-        if (getInstanceCount() == 1) {
-            // This is the first instantiation of its cell -- increment the count all the cells
-            // that are instantiated within
-
-            // TODO: How to do this without conflicting with the initial parsers?
-
-            // TODO: How can we determine that the added instance is actually
-            //       connected to the top cell?
-        }
     }
 
     /**
@@ -692,16 +682,6 @@ public class EDIFCell extends EDIFPropertyObject {
      */
     public void decrementInstanceCount() {
         instanceCountUpdater.getAndDecrement(this);
-        if (getInstanceCount() == 0) {
-            // Since this cell is no longer instantiated, decrement the count of all the cells
-            // that gets instantiated within
-            for (EDIFCellInst instance : getCellInsts()) {
-                instance.getCellType().decrementInstanceCount();
-            }
-
-            // TODO: How can we determine that the removed instance was actually
-            // connected to the top cell to begin with?
-        }
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -66,10 +66,12 @@ public class EDIFCell extends EDIFPropertyObject {
     /**
      * An atomically updated variable to track the number of `EDIFCellInst`
      * objects (attached to a parent cell) that instantiate this cell.
+     * Note: this does not track the number of `EDIFHierCellInst` objects
+     *       that would exist if the netlist was traversed from the top cell.
      */
-    private volatile int instanceCount = 0;
-    private static final AtomicIntegerFieldUpdater<EDIFCell> instanceCountUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(EDIFCell.class, "instanceCount");
+    private volatile int nonHierInstantiationCount = 0;
+    private static final AtomicIntegerFieldUpdater<EDIFCell> nonHierInstantiationCountUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(EDIFCell.class, "nonHierInstantiationCount");
 
     public EDIFCell(EDIFLibrary lib, String name) {
         super(name);
@@ -527,7 +529,7 @@ public class EDIFCell extends EDIFPropertyObject {
             }
         }
         for (EDIFCellInst instance : getCellInsts()) {
-            instance.getCellType().decrementInstanceCount();
+            instance.getCellType().decrementNonHierInstantiationCount();
         }
         instances = null;
         nets = null;
@@ -675,29 +677,29 @@ public class EDIFCell extends EDIFPropertyObject {
     /**
      * Atomically increment instance count of this cell.
      */
-    public void incrementInstanceCount() {
-        instanceCountUpdater.incrementAndGet(this);
+    public void incrementNonHierInstantiationCount() {
+        nonHierInstantiationCountUpdater.incrementAndGet(this);
     }
 
     /**
      * Atomically decrement instance count of this cell.
      */
-    public void decrementInstanceCount() {
-        instanceCountUpdater.getAndDecrement(this);
+    public void decrementNonHierInstantiationCount() {
+        nonHierInstantiationCountUpdater.getAndDecrement(this);
     }
 
     /**
      * @return The number of times this cell has been instantiated.
      */
-    public int getInstanceCount() {
-        return instanceCountUpdater.get(this);
+    public int getNonHierInstantiationCount() {
+        return nonHierInstantiationCountUpdater.get(this);
     }
 
     /**
      * True if this cell is instantiated no more than once.
      */
     public boolean isUniquified() {
-        return getInstanceCount() <= 1;
+        return getNonHierInstantiationCount() <= 1;
     }
 }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -168,6 +168,7 @@ public class EDIFCell extends EDIFPropertyObject {
                     getName() + ", trying to add instance " + instance.getName() +
                     " which already exists inside this cell.");
         }
+        instance.getCellType().incrementInstanceCount();
         return instance;
     }
 
@@ -185,6 +186,7 @@ public class EDIFCell extends EDIFPropertyObject {
             instance.setName(instance.getName() + "_" + getLibrary().getNetlist().nameSpaceUniqueCount++);
         }
         instances.put(instance.getName(), instance);
+        instance.getCellType().incrementInstanceCount();
         return instance;
     }
 
@@ -299,7 +301,9 @@ public class EDIFCell extends EDIFPropertyObject {
     public EDIFCellInst removeCellInst(String name) {
         if (instances == null) return null;
         trackChange(EDIFChangeType.CELL_INST_REMOVE, name);
-        return instances.remove(name);
+        EDIFCellInst removedInstance = instances.remove(name);
+        removedInstance.getCellType().decrementInstanceCount();
+        return removedInstance;
     }
 
     public EDIFNet createNet(String name) {
@@ -519,6 +523,9 @@ public class EDIFCell extends EDIFPropertyObject {
             for (EDIFNet net : getNets()) {
                 netlist.trackChange(this, EDIFChangeType.NET_REMOVE, net.getName());
             }
+        }
+        for (EDIFCellInst instance : getCellInsts()) {
+            instance.getCellType().decrementInstanceCount();
         }
         instances = null;
         nets = null;

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -189,7 +189,10 @@ public class EDIFCell extends EDIFPropertyObject {
             instance.setName(instance.getName() + "_" + getLibrary().getNetlist().nameSpaceUniqueCount++);
         }
         instances.put(instance.getName(), instance);
-        instance.getCellType().incrementInstanceCount();
+        EDIFCell cellType = instance.getCellType();
+        if (cellType != null) {
+            cellType.incrementInstanceCount();
+        }
         return instance;
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -168,7 +168,10 @@ public class EDIFCell extends EDIFPropertyObject {
                     getName() + ", trying to add instance " + instance.getName() +
                     " which already exists inside this cell.");
         }
-        instance.getCellType().incrementInstanceCount();
+        EDIFCell cellType = instance.getCellType();
+        if (cellType != null) {
+            cellType.incrementInstanceCount();
+        }
         return instance;
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -63,8 +63,11 @@ public class EDIFCell extends EDIFPropertyObject {
 
     private EDIFName view = DEFAULT_VIEW;
 
+    /**
+     * An atomically updated variable to track the number of `EDIFCellInst`
+     * objects (attached to a parent cell) that instantiate this cell.
+     */
     private volatile int instanceCount = 0;
-
     private static final AtomicIntegerFieldUpdater<EDIFCell> instanceCountUpdater =
             AtomicIntegerFieldUpdater.newUpdater(EDIFCell.class, "instanceCount");
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -683,6 +683,16 @@ public class EDIFCell extends EDIFPropertyObject {
      */
     public void incrementInstanceCount() {
         instanceCountUpdater.incrementAndGet(this);
+
+        if (getInstanceCount() == 1) {
+            // This is the first instantiation of its cell -- increment the count all the cells
+            // that are instantiated within
+
+            // TODO: How to do this without conflicting with the initial parsers?
+
+            // TODO: How can we determine that the added instance is actually
+            //       connected to the top cell?
+        }
     }
 
     /**
@@ -696,6 +706,9 @@ public class EDIFCell extends EDIFPropertyObject {
             for (EDIFCellInst instance : getCellInsts()) {
                 instance.getCellType().decrementInstanceCount();
             }
+
+            // TODO: How can we determine that the removed instance was actually
+            // connected to the top cell to begin with?
         }
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -302,7 +302,9 @@ public class EDIFCell extends EDIFPropertyObject {
         if (instances == null) return null;
         trackChange(EDIFChangeType.CELL_INST_REMOVE, name);
         EDIFCellInst removedInstance = instances.remove(name);
-        removedInstance.getCellType().decrementInstanceCount();
+        if (removedInstance != null) {
+            removedInstance.getCellType().decrementInstanceCount();
+        }
         return removedInstance;
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -305,6 +305,7 @@ public class EDIFCell extends EDIFPropertyObject {
         if (instances == null) return null;
         EDIFCellInst removedInstance = instances.remove(name);
         if (removedInstance != null) {
+            assert(removedInstance.getParentCell() == this);
             removedInstance.setParentCell(null);
         }
         return removedInstance;

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -298,10 +298,9 @@ public class EDIFCell extends EDIFPropertyObject {
 
     public EDIFCellInst removeCellInst(String name) {
         if (instances == null) return null;
-        trackChange(EDIFChangeType.CELL_INST_REMOVE, name);
         EDIFCellInst removedInstance = instances.remove(name);
         if (removedInstance != null) {
-            removedInstance.getCellType().decrementInstanceCount();
+            removedInstance.setParentCell(null);
         }
         return removedInstance;
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -291,4 +291,12 @@ public class EDIFCellInst extends EDIFPropertyObject {
 
         return true;
     }
+
+
+    /**
+     * True if this is the only instantiation of its cell.
+     */
+    public boolean isUniquified() {
+        return cellType.isUniquified();
+    }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -181,8 +181,23 @@ public class EDIFCellInst extends EDIFPropertyObject {
      * @param parent the parentCell to set
      */
     public void setParentCell(EDIFCell parent) {
+        if (this.parentCell == parent) {
+            return;
+        }
+        boolean oldParentCellWasNull = (this.parentCell == null);
+        if (!oldParentCellWasNull) {
+            this.parentCell.trackChange(EDIFChangeType.CELL_INST_REMOVE, getName());
+            if (cellType != null) {
+                cellType.decrementInstanceCount();
+            }
+        }
         this.parentCell = parent;
-        parent.trackChange(EDIFChangeType.CELL_INST_ADD, getName());
+        if (parent != null) {
+            parent.trackChange(EDIFChangeType.CELL_INST_ADD, getName());
+            if (oldParentCellWasNull && cellType != null) {
+                cellType.incrementInstanceCount();
+            }
+        }
     }
 
     /**
@@ -205,14 +220,11 @@ public class EDIFCellInst extends EDIFPropertyObject {
      * @param cellType the cellType to set
      */
     public void setCellTypeRaw(EDIFCell cellType) {
-        if (this.cellType != null) {
+        if (parentCell != null && this.cellType != null) {
             this.cellType.decrementInstanceCount();
         }
         this.cellType = cellType;
-        if (parentCell != null) {
-            // Since this instance already belongs to a parent cell,
-            // (and won't undergo EDIFCell.addCellInst() again)
-            // increment the instance count
+        if (parentCell != null && cellType != null) {
             cellType.incrementInstanceCount();
         }
         setViewref(cellType != null ? cellType.getEDIFView() : null);

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -209,7 +209,12 @@ public class EDIFCellInst extends EDIFPropertyObject {
             this.cellType.decrementInstanceCount();
         }
         this.cellType = cellType;
-        this.cellType.incrementInstanceCount();
+        if (parentCell != null) {
+            // Since this instance already belongs to a parent cell,
+            // (and won't undergo EDIFCell.addCellInst() again)
+            // increment the instance count
+            cellType.incrementInstanceCount();
+        }
         setViewref(cellType != null ? cellType.getEDIFView() : null);
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -188,14 +188,14 @@ public class EDIFCellInst extends EDIFPropertyObject {
         if (!oldParentCellWasNull) {
             this.parentCell.trackChange(EDIFChangeType.CELL_INST_REMOVE, getName());
             if (cellType != null) {
-                cellType.decrementInstanceCount();
+                cellType.decrementNonHierInstantiationCount();
             }
         }
         this.parentCell = parent;
         if (parent != null) {
             parent.trackChange(EDIFChangeType.CELL_INST_ADD, getName());
             if (oldParentCellWasNull && cellType != null) {
-                cellType.incrementInstanceCount();
+                cellType.incrementNonHierInstantiationCount();
             }
         }
     }
@@ -221,11 +221,11 @@ public class EDIFCellInst extends EDIFPropertyObject {
      */
     public void setCellTypeRaw(EDIFCell cellType) {
         if (parentCell != null && this.cellType != null) {
-            this.cellType.decrementInstanceCount();
+            this.cellType.decrementNonHierInstantiationCount();
         }
         this.cellType = cellType;
         if (parentCell != null && cellType != null) {
-            cellType.incrementInstanceCount();
+            cellType.incrementNonHierInstantiationCount();
         }
         setViewref(cellType != null ? cellType.getEDIFView() : null);
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -69,7 +69,7 @@ public class EDIFCellInst extends EDIFPropertyObject {
     public EDIFCellInst(EDIFCellInst inst, EDIFCell parentCell) {
         super((EDIFPropertyObject)inst);
         this.parentCell = parentCell;
-        this.cellType = inst.cellType;
+        setCellType(inst.cellType);
         setViewref(new EDIFName(inst.viewref));
     }
 
@@ -205,7 +205,11 @@ public class EDIFCellInst extends EDIFPropertyObject {
      * @param cellType the cellType to set
      */
     public void setCellTypeRaw(EDIFCell cellType) {
+        if (this.cellType != null) {
+            this.cellType.decrementInstanceCount();
+        }
         this.cellType = cellType;
+        this.cellType.incrementInstanceCount();
         setViewref(cellType != null ? cellType.getEDIFView() : null);
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -68,7 +68,7 @@ public class EDIFCellInst extends EDIFPropertyObject {
      */
     public EDIFCellInst(EDIFCellInst inst, EDIFCell parentCell) {
         super((EDIFPropertyObject)inst);
-        this.parentCell = parentCell;
+        setParentCell(parentCell);
         setCellType(inst.cellType);
         setViewref(new EDIFName(inst.viewref));
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -299,9 +299,9 @@ public class EDIFCellInst extends EDIFPropertyObject {
 
 
     /**
-     * True if this is the only instantiation of its cell.
+     * True if this cell instance is attached to a parent cell, and is the only instantiation of its cell.
      */
     public boolean isUniquified() {
-        return cellType.isUniquified();
+        return parentCell != null && cellType.isUniquified();
     }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
@@ -335,8 +335,9 @@ public class EDIFHierCellInst {
      * True if all cells on this path are the only instantiations of its cell.
      */
     public boolean isUniquified() {
-        for (EDIFCellInst eci : cellInsts) {
-            if (!eci.isUniquified()) {
+        assert(isToplevelInst(cellInsts[0]));
+        for (int i = 1; i < cellInsts.length; i++) {
+            if (!cellInsts[i].isUniquified()) {
                 return false;
             }
         }

--- a/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
@@ -330,4 +330,16 @@ public class EDIFHierCellInst {
         }
         return new EDIFHierCellInst(copyInsts);
     }
+
+    /**
+     * True if all cells on this path are the only instantiations of its cell.
+     */
+    public boolean isUniquified() {
+        for (EDIFCellInst eci : cellInsts) {
+            if (!eci.isUniquified()) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
@@ -336,7 +336,7 @@ public class EDIFHierCellInst {
      */
     public boolean isUniquified() {
         assert(isToplevelInst(cellInsts[0]));
-        for (int i = 1; i < cellInsts.length; i++) {
+        for (int i = cellInsts.length - 1; i > 0; i--) {
             if (!cellInsts[i].isUniquified()) {
                 return false;
             }

--- a/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierCellInst.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.

--- a/test/shared/com/xilinx/rapidwright/support/RapidWrightDCP.java
+++ b/test/shared/com/xilinx/rapidwright/support/RapidWrightDCP.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Eddie Hung, Xilinx Research Labs.

--- a/test/shared/com/xilinx/rapidwright/support/RapidWrightDCP.java
+++ b/test/shared/com/xilinx/rapidwright/support/RapidWrightDCP.java
@@ -36,6 +36,10 @@ public class RapidWrightDCP {
         return Design.readCheckpoint(getPath(name));
     }
 
+    public static Design loadDCP(String name, boolean skipXdef) {
+        return Design.readCheckpoint(getPath(name), skipXdef);
+    }
+
     public static Path getPath(String name) {
         return dirPath.resolve(name);
     }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
@@ -37,7 +37,7 @@ public class TestEDIFCell {
             "bnn.dcp",
     })
     public void testIsUniquified(String path) {
-        Design design = RapidWrightDCP.loadDCP(path);
+        Design design = RapidWrightDCP.loadDCP(path, true);
         EDIFNetlist netlist = design.getNetlist();
 
         for (EDIFLibrary library : netlist.getLibraries()) {
@@ -58,6 +58,5 @@ public class TestEDIFCell {
         EDIFCell picoblazeTop = netlist.getCell("picoblaze_top");
         Assertions.assertFalse(picoblazeTop.isUniquified());
         Assertions.assertEquals(4, picoblazeTop.getInstanceCount());
-
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
@@ -85,11 +85,11 @@ public class TestEDIFCell {
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
 
         // Check that creating an EDIFCellInst without a parent cell does not increment instance count
-        new EDIFCellInst("picoblaze_1_13", picoblazeTop, null);
+        EDIFCellInst eci = new EDIFCellInst("picoblaze_1_13", picoblazeTop, null);
         Assertions.assertTrue(picoblazeTop.isUniquified());
 
-        // Check that creating an EDIFCellInst *with* a parent cell *does* increment instance count
-        new EDIFCellInst("picoblaze_1_13", picoblazeTop, topCell);
+        // But adding it to a parent cell *does* increment instance count
+        topCell.addCellInst(eci);
         Assertions.assertFalse(picoblazeTop.isUniquified());
 
         // Establish that the "processor" instance's cell type is only instantiated once
@@ -101,7 +101,9 @@ public class TestEDIFCell {
         Assertions.assertEquals(1, kcpsm6.getInstanceCount());
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
         Assertions.assertEquals(0, picoblazeTop.getInstanceCount());
-        Assertions.assertEquals(0, kcpsm6.getInstanceCount());
+        // Note that the "processor" cellType is still instantiated once, even though its parent
+        // "picoblaze_top" is no longer attached to the netlist
+        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
 
         // Add one back again
         new EDIFCellInst("picoblaze_0_12", picoblazeTop, topCell);

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
@@ -64,9 +64,9 @@ public class TestEDIFCell {
         Assertions.assertFalse(picoblazeTop.isUniquified());
 
         // Test that removing a EDIFCellInst reduces the instance count
-        Assertions.assertEquals(4, picoblazeTop.getInstanceCount());
+        Assertions.assertEquals(4, picoblazeTop.getNonHierInstantiationCount());
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_13"));
-        Assertions.assertEquals(3, picoblazeTop.getInstanceCount());
+        Assertions.assertEquals(3, picoblazeTop.getNonHierInstantiationCount());
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_12"));
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
         Assertions.assertTrue(picoblazeTop.isUniquified());
@@ -94,27 +94,27 @@ public class TestEDIFCell {
 
         // Establish that the "processor" instance's cell type is only instantiated once
         EDIFCell kcpsm6 = netlist.getCell("kcpsm6"); // Cell type of "processor" instance
-        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
+        Assertions.assertEquals(1, kcpsm6.getNonHierInstantiationCount());
 
         // Remove all remaining instances
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_12"));
-        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
+        Assertions.assertEquals(1, kcpsm6.getNonHierInstantiationCount());
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
-        Assertions.assertEquals(0, picoblazeTop.getInstanceCount());
+        Assertions.assertEquals(0, picoblazeTop.getNonHierInstantiationCount());
         // Note that the "processor" cellType is still instantiated once, even though its parent
         // "picoblaze_top" is no longer attached to the netlist
-        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
+        Assertions.assertEquals(1, kcpsm6.getNonHierInstantiationCount());
 
         // Add one back again
         new EDIFCellInst("picoblaze_0_12", picoblazeTop, topCell);
         Assertions.assertTrue(picoblazeTop.isUniquified());
-        Assertions.assertEquals(1, picoblazeTop.getInstanceCount());
-        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
+        Assertions.assertEquals(1, picoblazeTop.getNonHierInstantiationCount());
+        Assertions.assertEquals(1, kcpsm6.getNonHierInstantiationCount());
 
         // And another
         new EDIFCellInst("picoblaze_0_13", picoblazeTop, topCell);
         Assertions.assertFalse(picoblazeTop.isUniquified());
-        Assertions.assertEquals(2, picoblazeTop.getInstanceCount());
-        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
+        Assertions.assertEquals(2, picoblazeTop.getNonHierInstantiationCount());
+        Assertions.assertEquals(1, kcpsm6.getNonHierInstantiationCount());
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
@@ -70,7 +70,24 @@ public class TestEDIFCell {
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_12"));
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
         Assertions.assertTrue(picoblazeTop.isUniquified());
-
         assertAllCellsAreUniquified(netlist);
+
+        // Check that creating an EDIFCellInst without a parent cell does not increment instance count
+        new EDIFCellInst("picoblaze_1_13", picoblazeTop, null);
+        Assertions.assertTrue(picoblazeTop.isUniquified());
+
+        // Check that creating an EDIFCellInst *with* a parent cell *does* increment instance count
+        new EDIFCellInst("picoblaze_1_13", picoblazeTop, topCell);
+        Assertions.assertFalse(picoblazeTop.isUniquified());
+
+        // Remove all remaining instances
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_12"));
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
+        Assertions.assertEquals(0, picoblazeTop.getInstanceCount());
+        // Even though the "picoblaze_top" cell is no longer instantiated,
+        // should we expect its cell instances to also not increment the
+        // instance count of its cells?
+        EDIFCell kcpsm6 = netlist.getCell("kcpsm6"); // Cell type of "processor" instance
+        Assertions.assertEquals(0, kcpsm6.getInstanceCount());
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
@@ -71,6 +71,18 @@ public class TestEDIFCell {
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
         Assertions.assertTrue(picoblazeTop.isUniquified());
         assertAllCellsAreUniquified(netlist);
+    }
+
+    @Test
+    public void testIsUniquifiedRemoveAndAdd() {
+        Design design = RapidWrightDCP.loadDCP("picoblaze4_ooc_X6Y60_X6Y65_X10Y60_X10Y65.dcp");
+        EDIFNetlist netlist = design.getNetlist();
+        EDIFCell topCell = netlist.getTopCell();
+        EDIFCell picoblazeTop = netlist.getCell("picoblaze_top");
+
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_13"));
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_12"));
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
 
         // Check that creating an EDIFCellInst without a parent cell does not increment instance count
         new EDIFCellInst("picoblaze_1_13", picoblazeTop, null);
@@ -80,14 +92,27 @@ public class TestEDIFCell {
         new EDIFCellInst("picoblaze_1_13", picoblazeTop, topCell);
         Assertions.assertFalse(picoblazeTop.isUniquified());
 
+        // Establish that the "processor" instance's cell type is only instantiated once
+        EDIFCell kcpsm6 = netlist.getCell("kcpsm6"); // Cell type of "processor" instance
+        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
+
         // Remove all remaining instances
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_12"));
+        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
         Assertions.assertEquals(0, picoblazeTop.getInstanceCount());
-        // Even though the "picoblaze_top" cell is no longer instantiated,
-        // should we expect its cell instances to also not increment the
-        // instance count of its cells?
-        EDIFCell kcpsm6 = netlist.getCell("kcpsm6"); // Cell type of "processor" instance
         Assertions.assertEquals(0, kcpsm6.getInstanceCount());
+
+        // Add one back again
+        new EDIFCellInst("picoblaze_0_12", picoblazeTop, topCell);
+        Assertions.assertTrue(picoblazeTop.isUniquified());
+        Assertions.assertEquals(1, picoblazeTop.getInstanceCount());
+        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
+
+        // And another
+        new EDIFCellInst("picoblaze_0_13", picoblazeTop, topCell);
+        Assertions.assertFalse(picoblazeTop.isUniquified());
+        Assertions.assertEquals(2, picoblazeTop.getInstanceCount());
+        Assertions.assertEquals(1, kcpsm6.getInstanceCount());
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCell.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Eddie Hung, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestEDIFCell {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "picoblaze_ooc_X10Y235.dcp",
+            "optical-flow.dcp",
+            "bnn.dcp",
+    })
+    public void testIsUniquified(String path) {
+        Design design = RapidWrightDCP.loadDCP(path);
+        EDIFNetlist netlist = design.getNetlist();
+
+        for (EDIFLibrary library : netlist.getLibraries()) {
+            if (library.isHDIPrimitivesLibrary()) {
+                continue;
+            }
+            for (EDIFCell cell : library.getCells()) {
+                Assertions.assertTrue(cell.isUniquified());
+            }
+        }
+    }
+
+    @Test
+    public void testIsUniquifiedFalse() {
+        Design design = RapidWrightDCP.loadDCP("picoblaze4_ooc_X6Y60_X6Y65_X10Y60_X10Y65.dcp");
+        EDIFNetlist netlist = design.getNetlist();
+        Assertions.assertTrue(netlist.getTopCell().isUniquified());
+        EDIFCell picoblazeTop = netlist.getCell("picoblaze_top");
+        Assertions.assertFalse(picoblazeTop.isUniquified());
+        Assertions.assertEquals(4, picoblazeTop.getInstanceCount());
+
+    }
+}

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCellInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCellInst.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Eddie Hung, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+
+public class TestEDIFCellInst {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "picoblaze_ooc_X10Y235.dcp",
+            "optical-flow.dcp",
+            "bnn.dcp",
+    })
+    public void testIsUniquified(String path) {
+        Design design = RapidWrightDCP.loadDCP(path, true);
+        EDIFNetlist netlist = design.getNetlist();
+
+        for (EDIFLibrary library : netlist.getLibraries()) {
+            if (library.isHDIPrimitivesLibrary()) {
+                continue;
+            }
+            for (EDIFCell cell : library.getCells()) {
+                for (EDIFCellInst eci : cell.getCellInsts()) {
+                    Assertions.assertTrue(eci.isUniquified() || eci.getCellType().getLibrary().isHDIPrimitivesLibrary());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testIsUniquifiedFalse() {
+        Design design = RapidWrightDCP.loadDCP("picoblaze4_ooc_X6Y60_X6Y65_X10Y60_X10Y65.dcp");
+        EDIFNetlist netlist = design.getNetlist();
+        Assertions.assertTrue(netlist.getTopCell().isUniquified());
+
+        for (String name : Arrays.asList(
+                "picoblaze_0_12",
+                "picoblaze_0_13",
+                "picoblaze_1_12",
+                "picoblaze_1_13"
+        )) {
+            EDIFCellInst eci = netlist.getTopCell().getCellInst(name);
+            Assertions.assertFalse(eci.isUniquified());
+        }
+
+        EDIFCell picoblazeTop = netlist.getCell("picoblaze_top");
+        Assertions.assertFalse(picoblazeTop.isUniquified());
+        for (String name : Arrays.asList(
+                "processor",
+                "your_program"
+        )) {
+            EDIFCellInst eci = picoblazeTop.getCellInst(name);
+            // Only checks that this cell instance is unique (e.g. that there is only
+            // one instantiation) but does not check that any parents on a full
+            // hierarchical path (e.g. "picoblaze_{0,1}_{12,13}/processor") is also
+            // unique --- use EDIFHierCellInst.isUniquified() for that
+            Assertions.assertTrue(eci.isUniquified());
+        }
+    }
+}

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCellInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCellInst.java
@@ -95,8 +95,8 @@ public class TestEDIFCellInst {
         EDIFCellInst eci = new EDIFCellInst("picoblaze_1_13", picoblazeTop, null);
         Assertions.assertFalse(eci.isUniquified());
 
-        // Check that creating an EDIFCellInst *with* a parent cell *does* increment instance count
-        eci = new EDIFCellInst("picoblaze_1_13", picoblazeTop, topCell);
+        // But adding it to a parent cell *does* increment instance count
+        topCell.addCellInst(eci);
         Assertions.assertFalse(eci.isUniquified());
         Assertions.assertSame(eci, topCell.getCellInst("picoblaze_1_13"));
         // ... and removing the other cell instantiation makes this one unique

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCellInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCellInst.java
@@ -90,5 +90,17 @@ public class TestEDIFCellInst {
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_12"));
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
         Assertions.assertTrue(topCell.getCellInst("picoblaze_0_12").isUniquified());
+
+        // Check that creating an EDIFCellInst without a parent cell does not make it unique
+        EDIFCellInst eci = new EDIFCellInst("picoblaze_1_13", picoblazeTop, null);
+        Assertions.assertFalse(eci.isUniquified());
+
+        // Check that creating an EDIFCellInst *with* a parent cell *does* increment instance count
+        eci = new EDIFCellInst("picoblaze_1_13", picoblazeTop, topCell);
+        Assertions.assertFalse(eci.isUniquified());
+        Assertions.assertSame(eci, topCell.getCellInst("picoblaze_1_13"));
+        // ... and removing the other cell instantiation makes this one unique
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_12"));
+        Assertions.assertTrue(eci.isUniquified());
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCellInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCellInst.java
@@ -83,5 +83,12 @@ public class TestEDIFCellInst {
             // unique --- use EDIFHierCellInst.isUniquified() for that
             Assertions.assertTrue(eci.isUniquified());
         }
+
+        // Test that removing all but one instance makes the remaining one unique
+        EDIFCell topCell = netlist.getTopCell();
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_13"));
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_12"));
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
+        Assertions.assertTrue(topCell.getCellInst("picoblaze_0_12").isUniquified());
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Jakob Wenzel, Xilinx Research Labs.

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
@@ -120,5 +120,14 @@ public class TestEDIFHierCellInst {
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_13"));
         Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_12"));
         Assertions.assertTrue(netlist.getHierCellInstFromName("picoblaze_1_13/processor").isUniquified());
+
+        // Check that creating an EDIFCellInst *with* a parent cell *does* increment instance count
+        EDIFCell picoblazeTop = netlist.getCell("picoblaze_top");
+        new EDIFCellInst("picoblaze_0_12", picoblazeTop, topCell);
+        EDIFHierCellInst ehci = netlist.getHierCellInstFromName("picoblaze_0_12/processor");
+        Assertions.assertFalse(ehci.isUniquified());
+        // ... and removing the other cell instantiation makes this one unique
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_13"));
+        Assertions.assertTrue(ehci.isUniquified());
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFHierCellInst.java
@@ -107,11 +107,18 @@ public class TestEDIFHierCellInst {
                 "picoblaze_1_12",
                 "picoblaze_1_13",
                 "picoblaze_1_13/processor",
-                "picoblaze_1_13/processor/active_interrupt_lut",
-                "picoblaze_1_13/processor/active_interrupt_lut/LUT5"
+                "picoblaze_1_13/processor/active_interrupt_lut",        // This is a LUT6_2 macro
+                "picoblaze_1_13/processor/active_interrupt_lut/LUT5"    // This is a LUT5 primitive
         )) {
             EDIFHierCellInst ehci = netlist.getHierCellInstFromName(path);
             Assertions.assertFalse(ehci.isUniquified());
         }
+
+        // Test that removing all but one instance makes the remaining one unique
+        EDIFCell topCell = netlist.getTopCell();
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_12"));
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_0_13"));
+        Assertions.assertNotNull(topCell.removeCellInst("picoblaze_1_12"));
+        Assertions.assertTrue(netlist.getHierCellInstFromName("picoblaze_1_13/processor").isUniquified());
     }
 }


### PR DESCRIPTION
Add the ability to determine if an `EDIFHierCellInst` is unique across the netlist, with a view to enabling algorithms (such as #910) to decide whether it is safe to modify.

To answer the `EDIFHierCellInst.isUniquified()` question, we need to know whether all `EDIFCellInst`-s that make up `EDIFHierCellInst` are themselves individually unique (folded, non-hierarchical) instantiations across the netlist.

To answer this `EDIFCellInst.isUniquified()` question, we need to track how many `EDIFCellInst`s exist for each `EDIFCell` which is also implemented in this PR.

Take for example the hierarchical path:
```
top/foo/bar/baz
```
To determine if it's safe to modify the `baz` instantiation (i.e. to change its parameters/LUT masks, or to change its port connections) we must determine that its parent `bar` instantiation is unique, followed by its parent `foo` instantiation being unique (and assume that `top` must be unique).