### PR TITLE
[DesignTools.makeBlackBox()] Fixes routing issues in makeBlackBox()

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3943,11 +3943,11 @@ public class DesignTools {
                 if (c.getBEL().isFF()) {
                     String belName = c.getBELName();
                     char letter = belName.charAt(0);
-                    if (si.getCell(letter + "6LUT") == null && si.getCell(letter + "5LUT") == null) {
-                        boolean isFF2 = belName.charAt(belName.length() - 1) == '2';
-                        String sitePinName = letter + (isFF2 ? "_I" : "X");
-                        Node n = si.getSite().getConnectedNode(sitePinName);
-                        if (used.contains(n)) {
+                    boolean isFF2 = belName.charAt(belName.length() - 1) == '2';
+                    String sitePinName = letter + (isFF2 ? "_I" : "X");
+                    Node n = si.getSite().getConnectedNode(sitePinName);
+                    if (used.contains(n)) {
+                        if (si.getCell(letter + "6LUT") == null && si.getCell(letter + "5LUT") == null) {
                             // Add a 'user-routethru' cell to make input path available
                             BELPin input = c.getBEL().getPin("D");
                             Net net = si.getNetFromSiteWire(input.getSiteWireName());
@@ -3972,6 +3972,10 @@ public class DesignTools {
                                             si.getSite(), lutInput.getBEL(), "I0", "O");
                                 }
                             }
+                        } else {
+                            throw new RuntimeException(
+                                    "ERROR: Unable to insert a LUT1 routethru to route an input path for the FF "
+                                            + c.getName() + " placed on " + si.getSiteName() + "/" + belName);
                         }
                     }
                 }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3946,7 +3946,7 @@ public class DesignTools {
                         String sitePinName = letter + (isFF2 ? "_I" : "X");
                         Node n = si.getSite().getConnectedNode(sitePinName);
                         if (used.contains(n)) {
-                            // Add a routethru cell to make input path available
+                            // Add a 'user-routethru' cell to make input path available
                             BELPin input = c.getBEL().getPin("D");
                             Net net = si.getNetFromSiteWire(input.getSiteWireName());
                             if (net == null) {

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3904,14 +3904,16 @@ public class DesignTools {
     /**
      * This adds PROHIBIT constraints to the design (via .XDC) that will prohibit
      * the use of BEL sites in the same half SLICE if there are any other cells
-     * placed in it. This is used for shell creation when an existing placed and
-     * routed implementation is desired to be preserved but to allow additional
-     * logic to be placed and routed on top of it without an area (pblock)
-     * constraint.
+     * placed in it. It also detects unroutable situations on flip flop inputs and
+     * inserts LUT1-routethrus into the netlist. It will also add PROHIBIT
+     * constraints onto flip flop sites that are unroutable. This is used for shell
+     * creation when an existing placed and routed implementation is desired to be
+     * preserved but to allow additional logic to be placed and routed on top of it
+     * without an area (pblock) constraint.
      * 
      * @param design The design to which the constraints are added.
      */
-    public static void prohibitPartialHalfSlices(Design design) {
+    public static void prepareShellBlackBoxForRouting(Design design) {
         List<String> bels = new ArrayList<>();
 
         // Keep track of used nodes to detect unroutable situations

--- a/src/com/xilinx/rapidwright/eco/ECOTools.java
+++ b/src/com/xilinx/rapidwright/eco/ECOTools.java
@@ -342,7 +342,7 @@ public class ECOTools {
         // Modify the physical netlist
         EDIFCell ecGnd = netlist.getHDIPrimitive(Unisim.GND);
         EDIFCell ecVcc = netlist.getHDIPrimitive(Unisim.VCC);
-        for (EDIFHierNet ehn : netToPortInsts.keySet()) {
+        nextNet: for (EDIFHierNet ehn : netToPortInsts.keySet()) {
             Net newPhysNet = null;
 
             // Find the one and only source pin
@@ -366,6 +366,9 @@ public class ECOTools {
                         newPhysNet = design.getGndNet();
                     } else if (eci.equals(ecVcc)) {
                         newPhysNet = design.getVccNet();
+                    } else if (!eci.isPrimitive() && eci.isLeafCellOrBlackBox()) {
+                        // It's a black box or possibly an encrypted cell
+                        continue nextNet;
                     } else {
                         throw new RuntimeException("ERROR: Cell corresponding to pin '" + sourceEhpi + "' not found.");
                     }

--- a/src/com/xilinx/rapidwright/eco/ECOTools.java
+++ b/src/com/xilinx/rapidwright/eco/ECOTools.java
@@ -1156,7 +1156,6 @@ public class ECOTools {
             throw new RuntimeException("ERROR: Unable to create new inline cell to be placed on " 
                 + site + "/" + bel);
         }
-        cell.addProperty("INIT", "O=I0");
 
         EDIFPortInst newInput = new EDIFPortInst(refCell.getPort(logInput), null, newInst);
         EDIFPortInst newOutput = new EDIFPortInst(refCell.getPort(logOutput), null, newInst);

--- a/src/com/xilinx/rapidwright/eco/ECOTools.java
+++ b/src/com/xilinx/rapidwright/eco/ECOTools.java
@@ -1156,6 +1156,7 @@ public class ECOTools {
             throw new RuntimeException("ERROR: Unable to create new inline cell to be placed on " 
                 + site + "/" + bel);
         }
+        cell.addProperty("INIT", "O=I0");
 
         EDIFPortInst newInput = new EDIFPortInst(refCell.getPort(logInput), null, newInst);
         EDIFPortInst newOutput = new EDIFPortInst(refCell.getPort(logOutput), null, newInst);

--- a/src/com/xilinx/rapidwright/util/MakeBlackBox.java
+++ b/src/com/xilinx/rapidwright/util/MakeBlackBox.java
@@ -50,7 +50,7 @@ public class MakeBlackBox {
         }
 
         // Necessary to make the design place-able by Vivado later
-        DesignTools.prohibitPartialHalfSlices(input);
+        DesignTools.prepareShellBlackBoxForRouting(input);
 
         t.stop().start("Write DCP");
         input.writeCheckpoint(args[1], CodePerfTracker.SILENT);


### PR DESCRIPTION
When creating a shell DCP as in the [Reuse Timing-closed Logic As A Shell](https://www.rapidwright.io/docs/ReusingTimingClosedLogicAsAShell.html) tutorial, sometimes certain designs will experience unroutable situations (or antennas) resulting from certain Vivado behaviors and the implementation state of the shell DCP.  This PR fixes at least some of those issues:
1. Previously, when `Net` objects needed to be renamed, some of the `SitePIP` objects were removed inadvertently.  This resolves this issue by using `Net.rename()` rather than `DesignTools.updateNetName()` which does not preserve the site pip routing.
2. There is a rare scenario when a black box is created and one of its outputs drives a flip-flop in a SLICE and the default site input bypass pin `[A-H][X|_I]` is being consumed by a fixed bounce node part of unrelated route.  In the previous context, it was likely driven by a LUT and thus the bypass input pin was not needed.  However when converting this connection input to be used as a shell, it is uncertain that a driver could be placed in the LUT site.  To rectify this issue and still preserve the existing routing in the shell, a `LUT1` is inserted into the netlist to provide a 'user-routethru' (Vivado does not handle a regular routethru inserted into the site).  This allows routing on the bypass pin to be preserved and also allow routing to the input of the flip flop.  This PR uses functionality introduced in #917 to achieve this behavior.
3. After black box creation, some BEL sites, specifically FF sites can be unusable because all their routing exit mux nodes are consumed.  This is somewhat rare, but the Vivado placer does not identify these scenarios and the BEL sites require a `PROHIBIT` in order for the Vivado placer to avoid placing flip flops into those locations.  This update detects those unused flip flop BELs that are unroutable and adds a `PROHIBIT` to them.

This PR also modifies `ECOTools.connectNet()` to allow for a connection to be driven by a black box.