### PR TITLE
[RWRoute] Don't swap dist RAMs on 'H' BELs since A and WA are shared 

### DIFF
--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -503,6 +503,12 @@ public class LUTTools {
                     continue;
                 }
 
+                // Either this is a LUT cell or a routethru ...
+                assert(cell.getType().startsWith("LUT") ||
+                       cell.isRoutethru() ||
+                       // ... or a distributed RAM cell not on a "H" BEL
+                       cell.getType().startsWith("RAM") && !bel.getName().startsWith("H"));
+
                 String oldPhysicalPinName = "A" + oldSinkSpi.getName().charAt(1);
                 String oldLogicalPinName = cell.getLogicalPinMapping(oldPhysicalPinName);
                 if (ps == null) {
@@ -626,12 +632,12 @@ public class LUTTools {
             Cell cell = ps.getCell();
             String oldSitePinName = cell.getSiteWireNameFromPhysicalPin(ps.getOldPhysicalName());
             SiteInst si = cell.getSiteInst();
-            SitePinInst p = si.getSitePinInst(oldSitePinName);
-            q.add(p);
-            if (p == null) {
+            SitePinInst pinToMove = si.getSitePinInst(oldSitePinName);
+            q.add(pinToMove);
+            if (pinToMove == null) {
                 continue;
             }
-            p.setSiteInst(null,true);
+            pinToMove.setSiteInst(null,true);
             // Removes pin mappings to prepare for new pin mappings
             cell.removePinMapping(ps.getOldPhysicalName());
             if (ps.getCompanionCell() != null) {
@@ -654,6 +660,8 @@ public class LUTTools {
             pinToMove.setPinName(ps.getNewNetPinName());
             pinToMove.setSiteInst(ps.getCell().getSiteInst());
         }
+
+        assert(q.isEmpty());
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -582,6 +582,12 @@ public class RWRoute{
                             numberOfSwappablePins = 0;
                             break;
                         }
+                        if (bel.getName().startsWith("H") && cell.getType().startsWith("RAM")) {
+                            // Similarly, disallow swapping of any RAMs on the "H" BELs since their
+                            // "A" and "WA" inputs are shared and require extra care to keep in sync
+                            numberOfSwappablePins = 0;
+                            break;
+                        }
                         if (belName.charAt(1) == '5') {
                             // Since a 5LUT cell exists, only allow bottom 5 pins to be swapped
                             numberOfSwappablePins = 5;


### PR DESCRIPTION
For distributed RAM cells placed onto a `H` BEL, its `A` (read address) and `WA` (write address) must be shared. Thus if we want to swap its `A`, we must also swap its `WA` in sync, which is beyond the our current `LUTTools` capabilities.

This does not affect distributed RAMs placed onto the `A`-`G` BELs since their `A` and `WA` are not shared -- we are still free to swap their `A` inputs (just as if they were read-only LUTs) and still prevented from swapping its `WA`, just as before.