### PR TITLE
[PhysNetlistWriter] Infer direction of IOB's PAD.PAD BEL pin

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -369,11 +369,9 @@ public class PhysNetlistWriter {
                         Series series = siteInst.getDesign().getDevice().getSeries();
                         SitePIP sitePIP;
                         if (series == Series.UltraScalePlus || series == Series.UltraScale) {
-                            BEL padout = siteInst.getBEL("PADOUT");
-                            sitePIP = siteInst.getSitePIP(padout.getPin("IN"));
+                            sitePIP = siteInst.getSitePIP("PADOUT", "IN");
                         } else if (series == Series.Series7) {
-                            BEL oused = siteInst.getBEL("IUSED");
-                            sitePIP = siteInst.getSitePIP(oused.getPin("0"));
+                            sitePIP = siteInst.getSitePIP("IUSED", "0");
                         } else {
                             throw new RuntimeException("Unsupported series " + series);
                         }

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -369,7 +369,12 @@ public class PhysNetlistWriter {
                         Series series = siteInst.getDesign().getDevice().getSeries();
                         SitePIP sitePIP;
                         if (series == Series.UltraScalePlus || series == Series.UltraScale) {
-                            sitePIP = siteInst.getSitePIP("PADOUT", "IN");
+                            BEL padout = siteInst.getBEL("PADOUT");
+                            if (padout == null) {
+                                // HPIOB_SNGL site types do not contain this SitePIP; ignore
+                                continue;
+                            }
+                            sitePIP = siteInst.getSitePIP(padout.getPin("IN"));
                         } else if (series == Series.Series7) {
                             sitePIP = siteInst.getSitePIP("IUSED", "0");
                         } else {


### PR DESCRIPTION
The IOB BEL pin `PAD.PAD` is a bidirectional pin, owing to the fact that IOBs are configurable between being an input or an output *(or even bidirectional)*.

Now I haven't got a bidir testcase handy, but at least for input configurations its necessary that the `PAD.PAD` pin is an output that serves as a routing source.

To determine if it should be treated as an output pin, look at whether the following site PIP is enabled:
* `PADOUT` for the UltraScale/UltraScale+ series
* `IUSED` for the 7 series