### PR TITLE
[PhysNetlistWriter] Fix stubs on static nets

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -40,6 +40,7 @@ import com.xilinx.rapidwright.device.SitePIPStatus;
 import com.xilinx.rapidwright.interchange.PhysicalNetlist.PhysNetlist;
 import com.xilinx.rapidwright.interchange.PhysicalNetlist.PhysNetlist.CellPlacement;
 import com.xilinx.rapidwright.interchange.PhysicalNetlist.PhysNetlist.MultiCellPinMapping;
+import com.xilinx.rapidwright.interchange.PhysicalNetlist.PhysNetlist.NetType;
 import com.xilinx.rapidwright.interchange.PhysicalNetlist.PhysNetlist.PhysBelPin;
 import com.xilinx.rapidwright.interchange.PhysicalNetlist.PhysNetlist.PhysCell;
 import com.xilinx.rapidwright.interchange.PhysicalNetlist.PhysNetlist.PhysCellType;
@@ -291,13 +292,13 @@ public class PhysNetlistWriter {
         physNet.setName(strings.getIndex(net.getName()));
         switch (net.getType()) {
         case GND:
-            physNet.setType(PhysNetlist.NetType.GND);
+            physNet.setType(NetType.GND);
             break;
         case VCC:
-            physNet.setType(PhysNetlist.NetType.VCC);
+            physNet.setType(NetType.VCC);
             break;
         default:
-            physNet.setType(PhysNetlist.NetType.SIGNAL);
+            physNet.setType(NetType.SIGNAL);
         }
 
         // We need to traverse the net inside sites to fully populate routing spec
@@ -461,8 +462,6 @@ public class PhysNetlistWriter {
 
         List<RouteBranchNode> sources;
         List<RouteBranchNode> stubs;
-        PhysNetlist.NetType type = physNet.getType();
-        final boolean isStaticNet = (type == PhysNetlist.NetType.GND || type == PhysNetlist.NetType.VCC);
 
         if (BUILD_ROUTING_GRAPH_ON_EXPORT) {
             sources = new ArrayList<>();
@@ -542,6 +541,9 @@ public class PhysNetlistWriter {
                 map.remove(curr.toString());
                 queue.addAll(curr.getBranches());
             }
+
+            NetType type = physNet.getType();
+            final boolean isStaticNet = (type == NetType.GND || type == NetType.VCC);
             for (RouteBranchNode rb : map.values()) {
                 if (rb.getParent() != null) {
                     // Not a stub if it's connected to something
@@ -551,6 +553,7 @@ public class PhysNetlistWriter {
                 if (isStaticNet && rb.getType() == RouteSegmentType.SITE_PIN && rb.getSitePin().isOutPin()) {
                     // Assume that output site pin stubs on static nets are static sources
                     // (e.g. LUT outputs)
+                    sources.add(rb);
                     continue;
                 }
 

--- a/src/com/xilinx/rapidwright/interchange/RouteBranchNode.java
+++ b/src/com/xilinx/rapidwright/interchange/RouteBranchNode.java
@@ -134,6 +134,10 @@ public class RouteBranchNode {
                 return !routethru;
             }
         }
+        if (type == RouteSegmentType.PIP) {
+            PIP pip = getPIP();
+            return pip.getStartNode().isTied();
+        }
         return false;
     }
 

--- a/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
@@ -356,7 +356,7 @@ public class TestPhysNetlistWriter {
     }
 
     @Test
-    public void testStaticSourceRBEL(@TempDir Path tempDir) throws IOException {
+    public void testStaticNets(@TempDir Path tempDir) throws IOException {
         Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
 
         String interchangePath = tempDir.resolve("design.phys").toString();
@@ -385,6 +385,8 @@ public class TestPhysNetlistWriter {
             }
         }
 
+        // Gnd net of this design has some stubs because its intra-site routing is a little
+        // out of sync due to the use of inverters (VCC -> GND) on BRAM control pins
         for (RouteBranch.Reader rb : gndNet.getStubs()) {
             RouteSegment.Reader rs = rb.getRouteSegment();
             if (rs.isBelPin()) {
@@ -396,5 +398,7 @@ public class TestPhysNetlistWriter {
             }
             Assertions.assertTrue(rb.hasBranches());
         }
+
+        Assertions.assertEquals(0, vccNet.getStubs().size());
     }
 }


### PR DESCRIPTION
Previously, the following stubs exist:
* On GND nets, the BELPin `SLICE_X?Y?/HARD0GND.0` would always be present for every slice in the design. Omit it as it's almost always unused (has no branches) and even if it was used, adds no value since it's an always-on static source.
* On static (mostly VCC) nets, PIPs that originate from a static source (e.g. `INT_X?Y?/VCC_WIRE`) were being recognized as stubs, when they should be sources.