### PR TITLE
[PhysNetlistWriter] Handle PORT cells in GTY tiles

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistWriter.java
@@ -392,8 +392,8 @@ public class PhysNetlistWriter {
                                 BEL obufdsBel = siteInst.getBEL("OBUFDS" + bel.getName().charAt(6) + "_GTYE4");
                                 assert(obufdsBel != null);
                                 Cell obufdsCell = siteInst.getCell(obufdsBel);
-                                bidirPinIsInput = (obufdsCell == null);
-                                bidirPinIsOutput = (obufdsCell != null);
+                                bidirPinIsInput = (obufdsCell != null);
+                                bidirPinIsOutput = (obufdsCell == null);
                             }
                         } else {
                             throw new RuntimeException("Unable to process PORT cell at site " + siteInst.getSiteName());


### PR DESCRIPTION
Observed in the `corundum_25g` benchmark of the [FPGA24 Routing Contest](https://xilinx.github.io/fpga24_routing_contest/) (which targets the `xcvu3p` device) it turns out there are a number of pads inside `GTY` tiles, namely:

* `IPAD[12]` pads in `GTYE4_CHANNEL` sites, which contain output BEL pins that were accidentally dropped from the written physical netlist.

* `REFCLK[01][NP]` pads in `GTYE4_COMMON` sites, which are bidir: 
![image](https://github.com/Xilinx/RapidWright/assets/90657806/c560f528-5f7a-4127-8055-fab30e53c6f3)
In this case, check to see if the `OBUFDS[01]_GTYE4` cell (lower left of the selected sitewire, not present in this example) is present to determine its direction.