### PR TITLE
DesignComparator - compares place and route data

### DIFF
--- a/src/com/xilinx/rapidwright/design/compare/DesignComparator.java
+++ b/src/com/xilinx/rapidwright/design/compare/DesignComparator.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
@@ -55,8 +56,8 @@ public class DesignComparator {
     private int diffCount;
     /** Flag indicating if PIP flags should be compared (default: false) */
     private boolean comparePIPFlags = false;
-    /** Flag indicating if routing (PIPs) should be compared (default: true) */
-    private boolean comparePIPs = true;
+    /** Predicate indicating if routing (PIPs) should be compared for given Net (default: true) */
+    private Predicate<Net> comparePIPs = (net) -> true;
     /**
      * Flag indicating if placement information should be compared (default: true)
      */
@@ -182,23 +183,21 @@ public class DesignComparator {
     }
 
     /**
-     * Gets the comparePIPs flag indicating if a design's PIPs should be compared by
-     * DesignComparator.
-     * 
-     * @return True if the flag is set, false otherwise (default: true).
-     */
-    public boolean comparePIPs() {
-        return comparePIPs;
-    }
-
-    /**
-     * Sets a flag to tell the design comparator if PIP flags should also be
-     * compared.
+     * Sets a flag to tell the design comparator if PIP should be compared.
      * 
      * @param comparePIPs Desired flag value (default: true).
      */
     public void setComparePIPs(boolean comparePIPs) {
-        this.comparePIPs = comparePIPs;
+        this.comparePIPs = (net) -> comparePIPs;
+    }
+
+    /**
+     * Set the predicate for the design comparator if PIPs should be compared for the given Net.
+     *
+     * @param predicate Predicate.
+     */
+    public void setComparePIPs(Predicate<Net> predicate) {
+        this.comparePIPs = predicate;
     }
 
     /**
@@ -207,7 +206,7 @@ public class DesignComparator {
      * 
      * @return True if the flag is set, false otherwise (default: true).
      */
-    public boolean comparePlacement() {
+    public boolean getComparePlacement() {
         return comparePlacement;
     }
 
@@ -352,7 +351,7 @@ public class DesignComparator {
     public int compareNets(Net gold, Net test) {
         int init = getDiffCount();
 
-        if (!comparePIPs) {
+        if (!comparePIPs.test(gold) && !comparePIPs.test(test)) {
             return getDiffCount() - init;
         }
 

--- a/src/com/xilinx/rapidwright/design/compare/DesignComparator.java
+++ b/src/com/xilinx/rapidwright/design/compare/DesignComparator.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.design.compare;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import com.xilinx.rapidwright.design.Cell;
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.PIP;
+import com.xilinx.rapidwright.device.SitePIP;
+
+/**
+ * A physical design comparison helper class that will compare two designs'
+ * placement and routing information and keep track of the differences.
+ */
+public class DesignComparator {
+
+    /** Stored map of design differences detected and their specific instances */
+    private Map<DesignDiffType, List<DesignDiff>> diffMap;
+    /** Total running count of differences found */
+    private int diffCount;
+    /** Flag indicating if PIP flags should be compared (default: false) */
+    private boolean comparePIPFlags = false;
+    /** Flag indicating if routing (PIPs) should be compared (default: true) */
+    private boolean comparePIPs = true;
+    /**
+     * Flag indicating if placement information should be compared (default: true)
+     */
+    private boolean comparePlacement = true;
+
+    public DesignComparator() {
+        resetDiffCount();
+    }
+
+    /**
+     * Compares two designs placement and routing (according to flags, see
+     * {@link #comparePlacement}, {@link #comparePIPs}, and
+     * {@link #comparePIPFlags}). It will return the total number of differences
+     * encountered and an optional report can be created by subsequently calling
+     * {@link #printDiffReportSummary(PrintStream)} or
+     * {@link #printDiffReport(PrintStream)}.
+     * 
+     * Note that the number of differences are stored in the class and can be
+     * retrieved afterward by calling {@link #getDiffCount()}. Calling this method a
+     * second and subsequent times will reset the counter and tracked diffs.
+     * 
+     * @param gold The expected design or reference.
+     * @param test The design being compared with the reference.
+     * @return The total number of differences encountered.
+     */
+    public int compareDesigns(Design gold, Design test) {
+        resetDiffCount();
+        if (!gold.getPartName().equals(test.getPartName())) {
+            addDiff(DesignDiffType.DESIGN_PARTNAME, gold, test, null, "");
+        }
+        
+        if (comparePlacement) {
+            Map<String, SiteInst> goldMap = getSiteInstMap(gold);
+            Map<String, SiteInst> testMap = getSiteInstMap(test);
+
+            for (Entry<String, SiteInst> e : goldMap.entrySet()) {
+                SiteInst testSiteInst = testMap.remove(e.getKey());
+                if (testSiteInst == null) {
+                    addDiff(DesignDiffType.SITEINST_MISSING, e.getValue(), null, gold, "");
+                    continue;
+                }
+                compareSiteInsts(e.getValue(), testSiteInst);
+            }
+
+            for (Entry<String, SiteInst> e : testMap.entrySet()) {
+                addDiff(DesignDiffType.SITEINST_EXTRA, null, e.getValue(), test, "");
+            }
+        }
+
+        Map<String, Net> goldNetMap = getNetMap(gold);
+        Map<String, Net> testNetMap = getNetMap(test);
+
+        for (Entry<String, Net> e : goldNetMap.entrySet()) {
+            Net testNet = testNetMap.remove(e.getKey());
+            if (testNet == null) {
+                addDiff(DesignDiffType.NET_MISSING, e.getValue(), null, gold, "");
+                continue;
+            }
+            compareNets(e.getValue(), testNet);
+        }
+
+        for (Entry<String, Net> e : testNetMap.entrySet()) {
+            addDiff(DesignDiffType.NET_EXTRA, null, e.getValue(), test, "");
+        }
+
+        return getDiffCount();
+    }
+    
+    private Map<String,SiteInst> getSiteInstMap(Design design) {
+        Map<String,SiteInst> map = new HashMap<>();
+        for(SiteInst si : design.getSiteInsts()) {
+            String siteName = si.getSiteName();
+            if (siteName == null) {
+                System.out.println("WARNING: " + design.getName() 
+                    + " has at least one unplaced site instance: " + si.getName());
+            }
+            map.put(si.getSiteName(), si);
+        }
+        return map;
+    }
+
+    private Map<String, Net> getNetMap(Design design) {
+        Map<String, Net> map = new HashMap<>();
+        for (Net net : design.getNets()) {
+            map.put(net.getName(), net);
+        }
+        return map;
+    }
+
+    /**
+     * Gets the total number of differences encountered since the last call of
+     * {@link #compareDesigns(Design, Design)}.
+     * 
+     * @return Total number of design differences found.
+     */
+    public int getDiffCount() {
+        return diffCount;
+    }
+
+    public void resetDiffCount() {
+        diffCount = 0;
+        diffMap = new HashMap<>();
+    }
+
+    /**
+     * Gets the comparePIPFlags flag indicating if the routing flags on a design's
+     * PIPs should be compared by DesignComparator.
+     * 
+     * @return True if the flag is set, false otherwise (default: false).
+     */
+    public boolean comparePIPFlags() {
+        return comparePIPFlags;
+    }
+
+    /**
+     * Sets a flag to tell the design comparator if PIP flags should also be
+     * compared.
+     * 
+     * @param comparePIPFlags Desired flag value (default: false).
+     */
+    public void setComparePIPFlags(boolean comparePIPFlags) {
+        this.comparePIPFlags = comparePIPFlags;
+    }
+
+    /**
+     * Gets the comparePIPs flag indicating if a design's PIPs should be compared by
+     * DesignComparator.
+     * 
+     * @return True if the flag is set, false otherwise (default: true).
+     */
+    public boolean comparePIPs() {
+        return comparePIPs;
+    }
+
+    /**
+     * Sets a flag to tell the design comparator if PIP flags should also be
+     * compared.
+     * 
+     * @param comparePIPs Desired flag value (default: true).
+     */
+    public void setComparePIPs(boolean comparePIPs) {
+        this.comparePIPs = comparePIPs;
+    }
+
+    /**
+     * Gets the comparePlacement flag indicating if a design's placement (cells,
+     * sitepips, sitewire to net mappings) should be compared by DesignComparator.
+     * 
+     * @return True if the flag is set, false otherwise (default: true).
+     */
+    public boolean comparePlacement() {
+        return comparePlacement;
+    }
+
+    /**
+     * Sets the flag to tell the design comparator if placement (cell placements,
+     * sitePIPs, and site wire to net mappings) should be compared.
+     * 
+     * @param comparePlacement Desired flag value (default: true);
+     */
+    public void setComparePlacement(boolean comparePlacement) {
+        this.comparePlacement = comparePlacement;
+    }
+
+    public Map<DesignDiffType, List<DesignDiff>> getDiffMap() {
+        return diffMap;
+    }
+
+    public List<DesignDiff> getDiffList(DesignDiffType type) {
+        return diffMap.getOrDefault(type, Collections.emptyList());
+    }
+
+    private void addDiff(DesignDiffType type, Object gold, Object test, Object context, String notEqualString) {
+        List<DesignDiff> diffs = diffMap.computeIfAbsent(type, l -> new ArrayList<>());
+        diffs.add(new DesignDiff(type, gold, test, context, notEqualString));
+        diffCount++;
+    }
+
+    /**
+     * Compares two site instances for placement and site routing differences.
+     * Specifically it detects differences in three categories, (1) cell placements,
+     * (2) site PIPs, and (3) site wire to net mappings.
+     * 
+     * @param gold The expected or reference site instance.
+     * @param test The site instance being compared to the reference.
+     * @return The number of differences encountered while comparing the provided
+     *         site instances. This number also mutates the total diff count stored
+     *         in the class.
+     */
+    public int compareSiteInsts(SiteInst gold, SiteInst test) {
+        int init = getDiffCount();
+
+        if (!gold.getName().equals(test.getName())) {
+            addDiff(DesignDiffType.SITEINST_NAME, gold, test, null, "");
+        }
+
+        Map<String, Cell> goldMap = gold.getCellMap();
+        Map<String, Cell> testMap = new HashMap<>(test.getCellMap());
+
+        // Compare placed cells
+        for (Entry<String, Cell> e : goldMap.entrySet()) {
+            Cell testCell = testMap.remove(e.getKey());
+            if (testCell == null) {
+                addDiff(DesignDiffType.PLACED_CELL_MISSING, e.getValue(), null, gold, "");
+                continue;
+            }
+
+            if (!Objects.equals(e.getValue().getName(), testCell.getName())) {
+                addDiff(DesignDiffType.PLACED_CELL_NAME, e.getValue(), testCell, gold, "");
+            }
+
+            if (!Objects.equals(e.getValue().getType(), testCell.getType())) {
+                addDiff(DesignDiffType.PLACED_CELL_TYPE, e.getValue(), testCell, gold, "");
+            }
+        }
+        for (Entry<String, Cell> e : testMap.entrySet()) {
+            Cell extraCell = e.getValue();
+            addDiff(DesignDiffType.PLACED_CELL_EXTRA, null, extraCell, test, "");
+        }
+
+        
+        // SiteWire to Net mappings
+        Map<String, Net> goldSiteWireMap = gold.getSiteWireToNetMap();
+        Map<String, Net> testSiteWireMap = new HashMap<>(test.getSiteWireToNetMap());
+
+        for (Entry<String, Net> e : goldSiteWireMap.entrySet()) {
+            Net testNet = testSiteWireMap.remove(e.getKey());
+            if (testNet == null) {
+                addDiff(DesignDiffType.SITEWIRE_NET_MISSING, e.getKey(), null, gold, " should be Net " + e.getValue());
+                continue;
+            }
+            if (!e.getValue().getName().equals(testNet.getName())) {
+                addDiff(DesignDiffType.SITEWIRE_NET_NAME, e.getKey(), testNet, gold , "");
+            }
+        }
+        for (Entry<String, Net> e : testSiteWireMap.entrySet()) {
+            Net extraNet = e.getValue();
+            addDiff(DesignDiffType.SITEWIRE_NET_EXTRA, null, e.getKey(), test, " extra Net " + extraNet);
+        }
+        
+        // Active SitePIPs
+        Map<BEL, SitePIP> goldSitePIPs = getSitePIPMap(gold);
+        Map<BEL, SitePIP> testSitePIPs = getSitePIPMap(test);
+        
+        for (Entry<BEL, SitePIP> e : goldSitePIPs.entrySet()) {
+            SitePIP testPIP = testSitePIPs.remove(e.getKey());
+            if (testPIP == null) {
+                addDiff(DesignDiffType.SITEPIP_MISSING, e.getValue(), null, gold, "");
+                continue;
+            }
+            if (!e.getValue().getInputPinName().equals(testPIP.getInputPinName())) {
+                addDiff(DesignDiffType.SITEPIP_INPIN_NAME, e.getValue(), testPIP, gold, "");
+            }
+        }
+        for (Entry<BEL, SitePIP> e : testSitePIPs.entrySet()) {
+            addDiff(DesignDiffType.SITEPIP_EXTRA, null, e.getValue(), test, "");
+        }
+
+        return getDiffCount() - init;
+    }
+    
+    private Map<BEL, SitePIP> getSitePIPMap(SiteInst siteInst) {
+        Map<BEL, SitePIP> map = new HashMap<>();
+        for (SitePIP p : siteInst.getUsedSitePIPs()) {
+            SitePIP duplicate = map.put(p.getBEL(), p);
+            if (duplicate != null) {
+                System.out.println("WARNING: Multiple SitePIPs active on BEL " + p.getBELName() + " of Site "
+                        + siteInst.getSiteName());
+            }
+        }
+        return map;
+    }
+
+    private Map<String, PIP> getPIPMap(Net net) {
+        Map<String, PIP> map = new HashMap<>();
+        for (PIP p : net.getPIPs()) {
+            map.put(p.toString(), p);
+        }
+        return map;
+    }
+
+    /**
+     * Compares two nets for differences in routing (PIPs). Two flags can be set to
+     * affect its operation: {@link #setComparePIPs(boolean)} (default: true) and
+     * {@link #setComparePIPFlags(boolean)} (default: false).
+     * 
+     * @param gold The expected or reference net.
+     * @param test The net to be compared against the reference net.
+     * @return The number of differences encountered while comparing the provided
+     *         nets. This number also mutates the total diff count stored in the
+     *         class.
+     */
+    public int compareNets(Net gold, Net test) {
+        int init = getDiffCount();
+
+        if (!comparePIPs) {
+            return getDiffCount() - init;
+        }
+
+        Map<String, PIP> goldMap = getPIPMap(gold);
+        Map<String, PIP> testMap = getPIPMap(test);
+
+        for (Entry<String, PIP> e : goldMap.entrySet()) {
+            PIP testPIP = testMap.remove(e.getKey());
+            if (testPIP == null) {
+                addDiff(DesignDiffType.PIP_MISSING, e.getValue(), null, gold, "");
+                continue;
+            }
+
+            if (comparePIPFlags && !e.getValue().deepEquals(testPIP)) {
+                addDiff(DesignDiffType.PIP_FLAGS, e.getValue(), testPIP, gold, "");
+            }
+        }
+
+        for (Entry<String, PIP> e : testMap.entrySet()) {
+            addDiff(DesignDiffType.PIP_EXTRA, null, e.getValue(), test, "");
+        }
+        
+        return getDiffCount() - init;
+    }
+
+    /**
+     * Prints a summary total for each difference type found in the recent
+     * comparisons since the last time the diff counter was reset.
+     * 
+     * @param ps The desired print stream ('System.out', e.g. for immediate screen
+     *           printing).
+     */
+    public void printDiffReportSummary(PrintStream ps) {
+        ps.println("=============================================================================");
+        ps.println("= Design Diff Summary");
+        ps.println("=============================================================================");
+        int totalSanity = 0;
+        for (DesignDiffType type : DesignDiffType.values()) {
+            int typeDiffCount = diffMap.getOrDefault(type, Collections.emptyList()).size();
+            totalSanity += typeDiffCount;
+            ps.printf("%9d %s Diffs\n", typeDiffCount, type.name());
+        }
+        ps.println("-----------------------------------------------------------------------------");
+        assert (totalSanity == diffCount);
+        ps.printf("%9d Total Diffs\n\n", diffCount);
+    }
+
+    /**
+     * Prints an exhaustive list of diffs with specific contextual information about
+     * each difference. This also begins by invoking
+     * {@link #printDiffReportSummary(PrintStream)} first.
+     * 
+     * @param ps The desired print stream ('System.out', e.g. for immediate screen
+     *           printing).
+     */
+    public void printDiffReport(PrintStream ps) {
+        printDiffReportSummary(ps);
+
+        for (Entry<DesignDiffType, List<DesignDiff>> e : diffMap.entrySet()) {
+            ps.println(" *** " + e.getKey() + ": " + e.getValue().size() + " diffs");
+            for (DesignDiff diff : e.getValue()) {
+                ps.println("  " + diff.toString());
+            }
+
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/design/compare/DesignComparator.java
+++ b/src/com/xilinx/rapidwright/design/compare/DesignComparator.java
@@ -24,6 +24,7 @@ package com.xilinx.rapidwright.design.compare;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,10 +38,14 @@ import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.SitePIP;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.compare.EDIFNetlistComparator;
 
 /**
  * A physical design comparison helper class that will compare two designs'
- * placement and routing information and keep track of the differences.
+ * placement and routing information and keep track of the differences. Please
+ * see {@link EDIFNetlistComparator} to compare logical netlists
+ * ({@link EDIFNetlist}).
  */
 public class DesignComparator {
 
@@ -153,7 +158,7 @@ public class DesignComparator {
 
     public void resetDiffCount() {
         diffCount = 0;
-        diffMap = new HashMap<>();
+        diffMap = new EnumMap<>(DesignDiffType.class);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/design/compare/DesignDiff.java
+++ b/src/com/xilinx/rapidwright/design/compare/DesignDiff.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.design.compare;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SiteInst;
+
+/**
+ * Stores a design difference found from DesignComparator.
+ * 
+ */
+public class DesignDiff {
+
+    private DesignDiffType type;
+
+    private Object gold;
+
+    private Object test;
+
+    private Object contextParent;
+
+    private String notEqualString;
+
+    public DesignDiff(DesignDiffType type, Object gold, Object test, Object contextParent, String notEqualString) {
+        this.type = type;
+        this.gold = gold;
+        this.test = test;
+        this.contextParent = contextParent;
+        this.notEqualString = notEqualString;
+    }
+
+    public String getClassName() {
+        if (gold != null)
+            return gold.getClass().getSimpleName();
+        if (test != null)
+            return test.getClass().getSimpleName();
+        return null;
+    }
+
+    public String getContext() {
+        if (contextParent == null)
+            return "";
+        if (type.isSiteInstParentContext()) {
+            SiteInst si = (SiteInst) contextParent;
+            return " in SiteInst placed at : " + si.getSiteName();
+        }
+        if (type.isNetParentContext()) {
+            Net net = (Net) contextParent;
+            return " in Net called " + net.getName();
+        }
+        if (contextParent instanceof Design) {
+            return " in Design " + ((Design) contextParent).getName();
+        }
+        throw new RuntimeException("ERROR: Unhandled DesignDiffType: " + type);
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (type.isMissingType()) {
+            sb.append("Missing ");
+            sb.append(getClassName());
+            sb.append(" ");
+            sb.append(gold);
+            if (notEqualString.length() > 0) {
+                sb.append("(");
+                sb.append(notEqualString);
+                sb.append(")");
+            }
+        } else if (type.isExtraType()) {
+            sb.append("Extra ");
+            sb.append(getClassName());
+            sb.append(" ");
+            sb.append(test);
+        } else if (type.isNonNullMismatch()) {
+            sb.append("Mismatch found (" + notEqualString + "), expected ");
+            sb.append(gold);
+            sb.append(", but found ");
+            sb.append(test);
+        }
+        sb.append(getContext());
+
+        return sb.toString();
+    }
+}

--- a/src/com/xilinx/rapidwright/design/compare/DesignDiffType.java
+++ b/src/com/xilinx/rapidwright/design/compare/DesignDiffType.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.design.compare;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Types of design differences that are detected using DesignComparator.
+ *
+ */
+public enum DesignDiffType {
+
+    DESIGN_PARTNAME,
+    SITEINST_MISSING,
+    SITEINST_EXTRA,
+    SITEINST_NAME,
+    SITEINST_TYPE,
+    PLACED_CELL_MISSING, 
+    PLACED_CELL_EXTRA, 
+    PLACED_CELL_TYPE,
+    PLACED_CELL_NAME,
+    SITEPIP_MISSING,
+    SITEPIP_EXTRA,
+    SITEPIP_INPIN_NAME,
+    SITEWIRE_NET_MISSING,
+    SITEWIRE_NET_EXTRA,
+    SITEWIRE_NET_NAME,
+    NET_MISSING,
+    NET_EXTRA,
+    PIP_MISSING,
+    PIP_EXTRA,
+    PIP_FLAGS;
+    
+    
+    private boolean isMissingType;
+
+    private boolean isExtraType;
+
+    private boolean isNonNullMismatch;
+
+    private boolean isNameType;
+
+    private static Set<DesignDiffType> siteInstParentTypes = EnumSet.of(SITEINST_TYPE,
+            PLACED_CELL_MISSING, PLACED_CELL_EXTRA, PLACED_CELL_TYPE, PLACED_CELL_NAME,
+            SITEPIP_MISSING, SITEPIP_EXTRA, SITEPIP_INPIN_NAME, SITEWIRE_NET_MISSING, SITEWIRE_NET_EXTRA,
+            SITEWIRE_NET_NAME);
+
+    private static Set<DesignDiffType> netParentTypes = EnumSet.of(PIP_EXTRA, PIP_FLAGS, PIP_MISSING);
+
+    private DesignDiffType() {
+        this.isMissingType = this.name().endsWith("_MISSING");
+        this.isExtraType = this.name().endsWith("_EXTRA");
+        this.isNameType = this.name().endsWith("NAME");
+        this.isNonNullMismatch = !isMissingType && !isExtraType;
+    }
+
+    /**
+     * @return the isMissingType
+     */
+    public boolean isMissingType() {
+        return isMissingType;
+    }
+
+    /**
+     * @return the isExtraType
+     */
+    public boolean isExtraType() {
+        return isExtraType;
+    }
+
+    /**
+     * @return the isNonNullMismatch
+     */
+    public boolean isNonNullMismatch() {
+        return isNonNullMismatch;
+    }
+
+    /**
+     * @return the isNameType
+     */
+    public boolean isNameType() {
+        return isNameType;
+    }
+
+    public boolean isNetParentContext() {
+        return netParentTypes.contains(this);
+    }
+
+    public boolean isSiteInstParentContext() {
+        return siteInstParentTypes.contains(this);
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/compare/EDIFNetlistComparator.java
+++ b/src/com/xilinx/rapidwright/edif/compare/EDIFNetlistComparator.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 
+import com.xilinx.rapidwright.design.compare.DesignComparator;
 import com.xilinx.rapidwright.device.PartNameTools;
 import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.edif.EDIFCell;
@@ -55,7 +56,8 @@ import com.xilinx.rapidwright.tests.CodePerfTracker;
  * This is a helper class designed to compare two EDIFNetlists for differences.
  * It can filter out differences introduced by Vivado by reading in the EDIF and
  * writing out as a DCP. It can also generate a report file describing all the
- * differences found.
+ * differences found. Please see @link {@link DesignComparator} to compare the
+ * placement and routing information of a design.
  */
 public class EDIFNetlistComparator {
 

--- a/test/src/com/xilinx/rapidwright/design/compare/TestDesignComparator.java
+++ b/test/src/com/xilinx/rapidwright/design/compare/TestDesignComparator.java
@@ -35,7 +35,6 @@ import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.SitePIP;
 import com.xilinx.rapidwright.device.SiteTypeEnum;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
-import com.xilinx.rapidwright.util.Utils;
 
 /**
  * Tests various design diffs using DesignComparator.
@@ -46,8 +45,6 @@ public class TestDesignComparator {
     private void compareDesign(int expectedTotalDiffs, int specificDiff, DesignDiffType type, 
             DesignComparator dc, Design gold, Design test) {
         int diffs = dc.compareDesigns(gold, test);
-        if (expectedTotalDiffs == 10)
-            dc.printDiffReport(System.out);
         Assertions.assertEquals(expectedTotalDiffs, diffs);
         Assertions.assertEquals(specificDiff, dc.getDiffList(type).size());
     }
@@ -72,10 +69,11 @@ public class TestDesignComparator {
         SiteInst siteInst = null;
         for (SiteInst si : test.getSiteInsts()) {
             test2.addSiteInst(si);
-            if (Utils.isSLICE(si)) {
+            if (si.getSiteName().equals("SLICE_X142Y0")) {
                 siteInst = si;
             }
         }
+        Assertions.assertNotNull(siteInst);
 
         for (Net net : test.getNets()) {
             test2.addNet(net);

--- a/test/src/com/xilinx/rapidwright/design/compare/TestDesignComparator.java
+++ b/test/src/com/xilinx/rapidwright/design/compare/TestDesignComparator.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.design.compare;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.xilinx.rapidwright.design.Cell;
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.design.Unisim;
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.PIP;
+import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.device.SitePIP;
+import com.xilinx.rapidwright.device.SiteTypeEnum;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.util.Utils;
+
+/**
+ * Tests various design diffs using DesignComparator.
+ *
+ */
+public class TestDesignComparator {
+
+    private void compareDesign(int expectedTotalDiffs, int specificDiff, DesignDiffType type, 
+            DesignComparator dc, Design gold, Design test) {
+        int diffs = dc.compareDesigns(gold, test);
+        if (expectedTotalDiffs == 10)
+            dc.printDiffReport(System.out);
+        Assertions.assertEquals(expectedTotalDiffs, diffs);
+        Assertions.assertEquals(specificDiff, dc.getDiffList(type).size());
+    }
+
+
+    @Test
+    public void testDesignComparator() {
+        Design gold = RapidWrightDCP.loadDCP("picoblaze_2022.2.dcp");
+        Device device = gold.getDevice();
+
+        DesignComparator dc = new DesignComparator();
+        int diffs = dc.compareDesigns(gold, gold);
+        Assertions.assertEquals(0, diffs);
+
+        Design test = RapidWrightDCP.loadDCP("picoblaze_2022.2.dcp");
+        diffs = dc.compareDesigns(gold, test);
+        Assertions.assertEquals(0, diffs);
+
+        // Same device, different package
+        Design test2 = new Design(test.getName(), "xcvc1502-vsva2197-2MP-e-S");
+        test2.setNetlist(test.getNetlist());
+        SiteInst siteInst = null;
+        for (SiteInst si : test.getSiteInsts()) {
+            test2.addSiteInst(si);
+            if (Utils.isSLICE(si)) {
+                siteInst = si;
+            }
+        }
+
+        for (Net net : test.getNets()) {
+            test2.addNet(net);
+        }
+
+        compareDesign(1, 1, DesignDiffType.DESIGN_PARTNAME, dc, gold, test2);
+        
+        test2.removeSiteInst(siteInst, true);
+
+        compareDesign(2, 1, DesignDiffType.SITEINST_MISSING, dc, gold, test2);
+        
+        Site s = device.getSite("SLICE_X56Y0");
+        new SiteInst(s.getName(), test2, SiteTypeEnum.SLICEL, s);
+
+        compareDesign(3, 1, DesignDiffType.SITEINST_EXTRA, dc, gold, test2);
+
+        String oldName = siteInst.getName();
+        siteInst.setName("anotherNamedSiteInst");
+        test2.addSiteInst(siteInst);
+
+        compareDesign(3, 1, DesignDiffType.SITEINST_NAME, dc, gold, test2);
+
+        siteInst.setName(oldName);
+        Cell removedCell = siteInst.removeCell(siteInst.getBEL("AFF"));
+
+        compareDesign(3, 1, DesignDiffType.PLACED_CELL_MISSING, dc, gold, test2);
+
+        test2.createAndPlaceCell("extra", Unisim.FDRE, siteInst.getSiteName() + "/BFF");
+
+        compareDesign(4, 1, DesignDiffType.PLACED_CELL_EXTRA, dc, gold, test2);
+
+        test2.placeCell(removedCell, siteInst.getSite(), siteInst.getBEL("AFF"));
+        String oldType = removedCell.getType();
+        removedCell.setType("MISMATCHEDTYPE");
+
+        compareDesign(4, 1, DesignDiffType.PLACED_CELL_TYPE, dc, gold, test2);
+
+        removedCell.setType(oldType);
+        removedCell.updateName("NEWNAME");
+
+        compareDesign(4, 1, DesignDiffType.PLACED_CELL_NAME, dc, gold, test2);
+
+        SitePIP sitePIP = siteInst.getUsedSitePIP("CLKINV");
+        Net clk = siteInst.getNetFromSiteWire(sitePIP.getInputPin().getSiteWireName());
+        siteInst.unrouteIntraSiteNet(sitePIP.getInputPin(), sitePIP.getOutputPin());
+        siteInst.routeIntraSiteNet(clk, sitePIP.getInputPin(), sitePIP.getInputPin());
+        siteInst.routeIntraSiteNet(clk, sitePIP.getOutputPin(), sitePIP.getOutputPin());
+
+        compareDesign(5, 1, DesignDiffType.SITEPIP_MISSING, dc, gold, test2);
+
+        siteInst.addSitePIP("FFMUXC1", "D6");
+
+        compareDesign(6, 1, DesignDiffType.SITEPIP_EXTRA, dc, gold, test2);
+
+        sitePIP = siteInst.getUsedSitePIP("FFMUXA1");
+        Net net = siteInst.getNetFromSiteWire(sitePIP.getInputPin().getSiteWireName());
+        siteInst.unrouteIntraSiteNet(sitePIP.getInputPin(), sitePIP.getOutputPin());
+        siteInst.routeIntraSiteNet(net, sitePIP.getInputPin(), sitePIP.getInputPin());
+        siteInst.routeIntraSiteNet(net, sitePIP.getOutputPin(), sitePIP.getOutputPin());
+        siteInst.addSitePIP("FFMUXA1", "D6");
+
+        compareDesign(8, 1, DesignDiffType.SITEPIP_INPIN_NAME, dc, gold, test2);
+        Assertions.assertEquals(1, dc.getDiffList(DesignDiffType.SITEWIRE_NET_EXTRA).size());
+
+        siteInst.unrouteIntraSiteNet(sitePIP.getInputPin(), sitePIP.getInputPin());
+
+        compareDesign(9, 1, DesignDiffType.SITEWIRE_NET_MISSING, dc, gold, test2);
+
+        siteInst.routeIntraSiteNet(new Net("mismatch"), sitePIP.getInputPin(), sitePIP.getInputPin());
+
+        compareDesign(9, 1, DesignDiffType.SITEWIRE_NET_NAME, dc, gold, test2);
+
+        Assertions.assertTrue(net.hasPIPs());
+        test2.removeNet(net);
+
+        compareDesign(22, 1, DesignDiffType.NET_MISSING, dc, gold, test2);
+
+        Net extra = new Net("extraNet");
+        for (PIP p : net.getPIPs()) {
+            extra.addPIP(p);
+        }
+        test2.addNet(extra);
+
+        compareDesign(23, 1, DesignDiffType.NET_EXTRA, dc, gold, test2);
+
+        Assertions.assertTrue(extra.hasPIPs());
+        clk.addPIP(extra.getPIPs().get(0));
+
+        compareDesign(24, 1, DesignDiffType.PIP_EXTRA, dc, gold, test2);
+
+        clk.getPIPs().remove(clk.getPIPs().size() - 1);
+        clk.getPIPs().remove(clk.getPIPs().size() - 1);
+
+        compareDesign(24, 1, DesignDiffType.PIP_MISSING, dc, gold, test2);
+
+        if (dc.comparePIPFlags()) {
+            clk.getPIPs().get(clk.getPIPs().size() - 1).setIsStub(true);
+
+            compareDesign(25, 1, DesignDiffType.PIP_FLAGS, dc, gold, test2);
+        }
+    }
+}


### PR DESCRIPTION
A tool to help compare two design's place and routing data.  

Example usage:
```java
Design gold = Design.readCheckpoint("gold.dcp");
Design test = Design.readCheckpoint("test.dcp");
DesignComparator dc = new DesignComparator();
// Set desired flags, there are 3: 
//   1) dc.setComparePlacement(default: true)
//   2) dc.setComparePIPs(default: true)
//   3) dc.setComparePIPFlags(default:false)
int numOfDiffs = dc.compareDesigns(gold, test);
// Optionally print a summary
dc.printDiffReportSummary(System.out);
```