### PR TITLE
[PhysNetlistReader] Warn and omit if PIP not found

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PIPCache.java
+++ b/src/com/xilinx/rapidwright/interchange/PIPCache.java
@@ -101,6 +101,10 @@ public class PIPCache {
 
             return tile.getPIP(wire0Idx, wire1Idx);
         });
+
+        if (pip == null) {
+            return null;
+        }
         PIP newPIP = new PIP(pip);
         newPIP.setTile(tile);
         return newPIP;

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -569,14 +569,22 @@ public class PhysNetlistReader {
                 }
 
                 PIP pip = getPIP(tile, pReader.getWire0(), pReader.getWire1());
-                pip.setIsPIPFixed(pReader.getIsFixed());
-                pip.setIsReversed(!pReader.getForward());
+                if (pip == null) {
+                    String wire0 = strings.get(pReader.getWire0());
+                    String wire1 = strings.get(pReader.getWire1());
+                    System.err.println("WARNING: PIP for tile " + strings.get(pReader.getTile()) +
+                            " from wire " + wire0 + " to wire " + wire1 + " not found; " +
+                            " omitting from net " + net.getName());
+                } else {
+                    pip.setIsPIPFixed(pReader.getIsFixed());
+                    pip.setIsReversed(!pReader.getForward());
 
-                if (stubWires.remove(pip.getEndWire())) {
-                    pip.setIsStub(true);
+                    if (stubWires.remove(pip.getEndWire())) {
+                        pip.setIsStub(true);
+                    }
+
+                    net.addPIP(pip);
                 }
-
-                net.addPIP(pip);
                 break;
             }
             case BEL_PIN:{

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -573,7 +573,7 @@ public class PhysNetlistReader {
                     String wire0 = strings.get(pReader.getWire0());
                     String wire1 = strings.get(pReader.getWire1());
                     System.err.println("WARNING: PIP for tile " + strings.get(pReader.getTile()) +
-                            " from wire " + wire0 + " to wire " + wire1 + " not found; " +
+                            " from wire " + wire0 + " to wire " + wire1 + " not found;" +
                             " omitting from net " + net.getName());
                 } else {
                     pip.setIsPIPFixed(pReader.getIsFixed());


### PR DESCRIPTION
Be a little more tolerant of invalid PIPs that have valid tiles and valid wires, but no PIP exists between them.