### PR TITLE
LUTTools.swapLutPinsFromPIPs() to warn when site pin not found

### DIFF
--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -717,7 +717,11 @@ public class LUTTools {
                     continue;
                 }
                 SitePinInst newSpi = si.getSitePinInst(newSitePinName);
-                if (!siteToLutSpis.get(site).remove(newSpi)) {
+                List<SitePinInst> spis = siteToLutSpis.get(site);
+                if (spis == null) {
+                    System.out.println("WARNING: SitePin " + newSitePin + " visited by PIP " + pip +
+                            " is not a SitePinInst on net " + net + ". Ignoring.");
+                } else if (!spis.remove(newSpi)) {
                     // spi is not already on this net
                     unmatchedSitePins.add(newSitePin);
                 }


### PR DESCRIPTION
Warn and ignore, rather than die cryptically with an NPE.