### PR TITLE
DesignTools.createMissingSitePinInsts() to infer SitePinInsts more smartly

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2001,15 +2001,15 @@ public class DesignTools {
 
     /**
      * Looks in the site instance for BEL pins connected to this site pin.
-     * @param pin The SitePinInst to examine for connected BEL pins
+     * @param pin The BELPin to examine for connected BEL pins.
+     * @param si The SiteInst to examine for connected cells.
      * @param action Perform this action on each connected BELPin.
      */
-    private static void foreachConnectedBELPin(SitePinInst pin, Consumer<BELPin> action) {
-        SiteInst si = pin.getSiteInst();
+    private static void foreachConnectedBELPin(BELPin pin, SiteInst si, Consumer<BELPin> action) {
         if (si == null) {
             return;
         }
-        for (BELPin p : pin.getBELPin().getSiteConns()) {
+        for (BELPin p : pin.getSiteConns()) {
             if (p.getBEL().getBELClass() == BELClass.RBEL) {
                 SitePIP pip = si.getUsedSitePIP(p.getBELName());
                 if (pip == null) continue;
@@ -2031,14 +2031,14 @@ public class DesignTools {
     }
 
     /**
-     * Looks in the site instance for cells connected to this site pin.
-     * @param pin The SitePinInst to examine for connected cells
-     * @return Set of connected cells to this pin
+     * Looks in the site instance for cells connected to this BEL pin and SiteInst.
+     * @param pin The BELPin to examine for connected cells.
+     * @param si The SiteInst to examine for connected cells.
+     * @return Set of connected cells to this pin.
      */
-    public static Set<Cell> getConnectedCells(SitePinInst pin) {
+    public static Set<Cell> getConnectedCells(BELPin pin, SiteInst si) {
         final Set<Cell> cells = new HashSet<>();
-        SiteInst si = pin.getSiteInst();
-        foreachConnectedBELPin(pin, (p) -> {
+        foreachConnectedBELPin(pin, si, (p) -> {
             Cell c = si.getCell(p.getBELName());
             if (c != null) {
                 cells.add(c);
@@ -2048,14 +2048,33 @@ public class DesignTools {
     }
 
     /**
+     * Looks in the site instance for cells connected to this site pin.
+     * @param pin The SitePinInst to examine for connected cells.
+     * @return Set of connected cells to this pin.
+     */
+    public static Set<Cell> getConnectedCells(SitePinInst pin) {
+        return getConnectedCells(pin.getBELPin(), pin.getSiteInst());
+    }
+
+    /**
+     * Looks in the site instance for BEL pins connected to this BEL pin and SiteInst.
+     * @param pin The SitePinInst to examine for connected BEL pins.
+     * @param si The SiteInst to examine for connected cells.
+     * @return Set of BEL pins to this site pin.
+     */
+    public static Set<BELPin> getConnectedBELPins(BELPin pin, SiteInst si) {
+        final Set<BELPin> pins = new HashSet<>();
+        foreachConnectedBELPin(pin, si, pins::add);
+        return pins;
+    }
+
+    /**
      * Looks in the site instance for BEL pins connected to this site pin.
-     * @param pin The SitePinInst to examine for connected BEL pins
-     * @return Set of BEL pins to this site pin
+     * @param pin The SitePinInst to examine for connected BEL pins.
+     * @return Set of BEL pins to this site pin.
      */
     public static Set<BELPin> getConnectedBELPins(SitePinInst pin) {
-        Set<BELPin> pins = new HashSet<>();
-        foreachConnectedBELPin(pin, pins::add);
-        return pins;
+        return getConnectedBELPins(pin.getBELPin(), pin.getSiteInst());
     }
 
     /**


### PR DESCRIPTION
For cases where the `EDIFNetlist`'s physical pins is null (e.g. encrypted cells) then only create an output `SitePinInst` if it is driven by a `Cell`.

This prevents the problem of additional `SitePinInst`s being added to a `Net` when a routethru is necessary to reach a `Cell` (e.g. LUT routethru to get to `CARRY8`). More details in this thread: https://github.com/Xilinx/fpga24_routing_contest/discussions/59#discussioncomment-8054698