### PR TITLE
[LUTTools] LUT pin swapping fixes

### DIFF
--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -503,11 +503,14 @@ public class LUTTools {
                     continue;
                 }
 
-                // Either this is a LUT cell or a routethru ...
-                assert(cell.getType().startsWith("LUT") ||
-                       cell.isRoutethru() ||
-                       // ... or a distributed RAM cell not on a "H" BEL
-                       cell.getType().startsWith("RAM") && !bel.getName().startsWith("H"));
+                // Only consider LUT cell or a routethru ...
+                if (!cell.getType().startsWith("LUT") && !cell.isRoutethru() &&
+                        // ... or distributed RAM cells not on a "H" BEL
+                        (!cell.getType().startsWith("RAM") || bel.getName().startsWith("H"))) {
+                    // SRL cells do not support pin swapping
+                    assert(cell.getType().startsWith("SRL"));
+                    continue;
+                }
 
                 String oldPhysicalPinName = "A" + oldSinkSpi.getName().charAt(1);
                 String oldLogicalPinName = cell.getLogicalPinMapping(oldPhysicalPinName);

--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2018-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.


### PR DESCRIPTION
* `DesignTools.swapMultipleLutPins()` to ignore `SRL*` cells (since shift registers cannot have their pins swapped)
* `DesignTools.swapSingleLutPins()` to also swap alt pin mappings (populated for intra-site LUT routethrus, e.g. to get to a FF)