### PR TITLE
[PhysNetlistReader] Fix checkConstantRoutingAndNetNaming()

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
@@ -253,7 +253,7 @@ public class EDIFHierPortInst {
     }
 
     /**
-     * FOr Ports that represent connections to inner cells, get the connected Net that is connected within the cell
+     * For ports that represent connections to inner cells, get the connected Net that is connected within the cell
      */
     public EDIFHierNet getInternalNet() {
 
@@ -263,5 +263,9 @@ public class EDIFHierPortInst {
         }
         return new EDIFHierNet(hierarchicalInst.getChild(portInst.getCellInst()), internalNet);
 
+    }
+
+    public EDIFCell getParentCell() {
+        return hierarchicalInst.getCellType();
     }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1454,6 +1454,14 @@ public class EDIFNetlist extends EDIFName {
     }
 
     /**
+     * Traverses the netlist and produces a list of all primitive leaf hierarchical cell instances.
+     * @return A list of all primitive leaf hierarchical cell instances.
+     */
+    public List<EDIFHierCellInst> getAllLeafHierCellInstances() {
+        return getAllLeafDescendants(getTopHierCellInst());
+    }
+
+    /**
      * Get the physical pins all parent nets (as returned by {@link #getParentNet(EDIFHierNet)}).
      *
      * No special handling for static nets is performed. Therefore, only the local connectivity is visible. To see

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.


### PR DESCRIPTION
Previously, the `checkConstantRoutingAndNetNaming()` builds a mapping between hierarchical-cell-pin-name to physical-net. Later, `checkNetTypeFromCellNet()` does a lookup from a non-hierarchical-cell-pin name to find its corresponding physical-net. 

Fix it so that `checkNetTypeFromCellNet()` is hierarchy-aware.