### PR TITLE
[EDIFPropertyValue] Fix getBooleanValue() NPE

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFPropertyValue.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPropertyValue.java
@@ -96,48 +96,56 @@ public class EDIFPropertyValue {
         if (type != EDIFValueType.INTEGER) {
             return null;
         }
+        return parseIntValue();
+    }
+
+    private Integer parseIntValue() {
         int radix = 10;
         boolean lastCharWasTick = false;
         boolean isSigned = value.contains("-");
-        for (int i=0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            if (lastCharWasTick) {
-                switch (c) {
-                    case 'b':
-                    case 'B':
-                        radix = 2;
-                        break;
-                    case 'o':
-                    case 'O':
-                        radix = 8;
-                        break;
-                    case 'd':
-                    case 'D':
-                        radix = 10;
-                        break;
-                    case 'h':
-                    case 'H':
-                        radix = 16;
-                        break;
-                    case 's':
-                    case 'S':
-                        isSigned = true;
-                        continue;
-                }
-                if (isSigned) {
-                    return Integer.parseInt(value.substring(i+1), radix);
-                }
-                return Integer.parseUnsignedInt(value.substring(i+1), radix);
+        try {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (lastCharWasTick) {
+                    switch (c) {
+                        case 'b':
+                        case 'B':
+                            radix = 2;
+                            break;
+                        case 'o':
+                        case 'O':
+                            radix = 8;
+                            break;
+                        case 'd':
+                        case 'D':
+                            radix = 10;
+                            break;
+                        case 'h':
+                        case 'H':
+                            radix = 16;
+                            break;
+                        case 's':
+                        case 'S':
+                            isSigned = true;
+                            continue;
+                    }
+                    if (isSigned) {
+                        return Integer.parseInt(value.substring(i + 1), radix);
+                    }
+                    return Integer.parseUnsignedInt(value.substring(i + 1), radix);
 
+                }
+                if (c == '\'') {
+                    lastCharWasTick = true;
+                }
             }
-            if (c == '\'') {
-                lastCharWasTick = true;
+            if (isSigned) {
+                return Integer.parseInt(value);
             }
+            return Integer.parseUnsignedInt(value);
+        } catch (NumberFormatException e) {
+            return null;
         }
-        if (isSigned) {
-            return Integer.parseInt(value);
-        }
-        return Integer.parseUnsignedInt(value);
     }
 
     /**
@@ -193,7 +201,10 @@ public class EDIFPropertyValue {
     }
 
     public boolean getBooleanValue() {
-        return !(value == null || value.length() == 0 || getIntValue() == 0 || value.toLowerCase().equals("false"));
+        Integer intValue;
+        return !(value == null || value.length() == 0 ||
+                ((intValue = parseIntValue()) != null && intValue == 0) ||
+                value.toLowerCase().equals("false"));
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFPropertyValue.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPropertyValue.java
@@ -99,53 +99,49 @@ public class EDIFPropertyValue {
         return parseIntValue();
     }
 
-    private Integer parseIntValue() {
+    private int parseIntValue() {
         int radix = 10;
         boolean lastCharWasTick = false;
         boolean isSigned = value.contains("-");
-        try {
-            for (int i = 0; i < value.length(); i++) {
-                char c = value.charAt(i);
-                if (lastCharWasTick) {
-                    switch (c) {
-                        case 'b':
-                        case 'B':
-                            radix = 2;
-                            break;
-                        case 'o':
-                        case 'O':
-                            radix = 8;
-                            break;
-                        case 'd':
-                        case 'D':
-                            radix = 10;
-                            break;
-                        case 'h':
-                        case 'H':
-                            radix = 16;
-                            break;
-                        case 's':
-                        case 'S':
-                            isSigned = true;
-                            continue;
-                    }
-                    if (isSigned) {
-                        return Integer.parseInt(value.substring(i + 1), radix);
-                    }
-                    return Integer.parseUnsignedInt(value.substring(i + 1), radix);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (lastCharWasTick) {
+                switch (c) {
+                    case 'b':
+                    case 'B':
+                        radix = 2;
+                        break;
+                    case 'o':
+                    case 'O':
+                        radix = 8;
+                        break;
+                    case 'd':
+                    case 'D':
+                        radix = 10;
+                        break;
+                    case 'h':
+                    case 'H':
+                        radix = 16;
+                        break;
+                    case 's':
+                    case 'S':
+                        isSigned = true;
+                        continue;
+                }
+                if (isSigned) {
+                    return Integer.parseInt(value.substring(i + 1), radix);
+                }
+                return Integer.parseUnsignedInt(value.substring(i + 1), radix);
 
-                }
-                if (c == '\'') {
-                    lastCharWasTick = true;
-                }
             }
-            if (isSigned) {
-                return Integer.parseInt(value);
+            if (c == '\'') {
+                lastCharWasTick = true;
             }
-            return Integer.parseUnsignedInt(value);
-        } catch (NumberFormatException e) {
-            return null;
         }
+        if (isSigned) {
+            return Integer.parseInt(value);
+        }
+        return Integer.parseUnsignedInt(value);
     }
 
     /**
@@ -201,10 +197,17 @@ public class EDIFPropertyValue {
     }
 
     public boolean getBooleanValue() {
-        Integer intValue;
-        return !(value == null || value.length() == 0 ||
-                ((intValue = parseIntValue()) != null && intValue == 0) ||
-                value.toLowerCase().equals("false"));
+        if (value == null || value.length() == 0) {
+            return false;
+        }
+
+        try {
+            return parseIntValue() != 0;
+        } catch (NumberFormatException e) {
+            // Fall through
+        }
+
+        return !value.toLowerCase().equals("false");
     }
 
     /**

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyValue.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyValue.java
@@ -1,0 +1,30 @@
+package com.xilinx.rapidwright.edif;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestEDIFPropertyValue {
+    @ParameterizedTest
+    @CsvSource({
+            "1'b1,INTEGER,true",
+            "1'b0,INTEGER,false",
+            "32'hDeAdBeEf,INTEGER,true",
+
+            "1'b1,STRING,true",
+            "1'b0,STRING,false",
+            "32'hDeAdBeEf,STRING,true",
+            "false,STRING,false",
+            "FaLsE,STRING,false",
+            "true,STRING,true",
+            "deadbeef,STRING,true",
+
+            "false,BOOLEAN,false",
+            "FALSE,BOOLEAN,false",
+            "true,BOOLEAN,true",
+    })
+    public void testGetBooleanValue(String value, EDIFValueType type, boolean expected) {
+        EDIFPropertyValue v = new EDIFPropertyValue(value, type);
+        Assertions.assertEquals(expected, v.getBooleanValue());
+    }
+}

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyValue.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyValue.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Eddie Hung, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.xilinx.rapidwright.edif;
 
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
`EDIFPropertyValue.getBooleanValue()` to try parse an integer even if it's a `STRING` type and not throw an NPE.