### PR TITLE
[GlobalSignalRouter] No intra site routing for new static source pins

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -442,7 +442,9 @@ public class GlobalSignalRouting {
                             "net '" + spi.getNet().getName() + "'");
                 }
             }
-            SitePinInst spi = currNet.createPin(sitePin.getPinName(), si);
+            SitePinInst spi = new SitePinInst(sitePin.getPinName(), si);
+            boolean updateSiteRouting = false;
+            currNet.addPin(spi, updateSiteRouting);
             spi.setRouted(true);
         }
 

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2021 Ghent University.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Yun Zhou, Ghent University.
@@ -24,13 +24,11 @@
 
 package com.xilinx.rapidwright.rwroute;
 
-import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
 import com.xilinx.rapidwright.design.NetType;
 import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
-import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.ClockRegion;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.IntentCode;

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -532,7 +532,6 @@ public class GlobalSignalRouting {
 
             String sitePinName;
             if (wireName.endsWith("_O")) {
-                // Fall through
                 sitePinName = wireName.substring(wireName.length() - 3);
             } else if (wireName.endsWith("MUX")) {
                 char lutLetter = wireName.charAt(wireName.length() - 4);

--- a/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
@@ -98,7 +98,7 @@ public class TestGlobalSignalRouting {
 
         GlobalSignalRouting.routeStaticNet(design.getGndNet(), gns, design, routeThruHelper);
         gndPins = design.getGndNet().getPins();
-        Assertions.assertEquals(1952, gndPins.stream().filter((spi) -> spi.isOutPin()).count());
+        Assertions.assertEquals(1858, gndPins.stream().filter((spi) -> spi.isOutPin()).count());
         Assertions.assertEquals(22760, gndPins.stream().filter((spi) -> !spi.isOutPin()).count());
 
         GlobalSignalRouting.routeStaticNet(design.getVccNet(), gns, design, routeThruHelper);

--- a/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
@@ -86,8 +86,10 @@ public class TestGlobalSignalRouting {
 
         RWRoute.preprocess(design);
 
-        List<SitePinInst> gndPins = design.getGndNet().getPins();
-        List<SitePinInst> vccPins = design.getVccNet().getPins();
+        Net gndNet = design.getGndNet();
+        Net vccNet = design.getVccNet();
+        List<SitePinInst> gndPins = gndNet.getPins();
+        List<SitePinInst> vccPins = vccNet.getPins();
         // Note: these numbers are slightly different from RWRoute since RWRoute.routeStaticNets()
         //       uses RouterHelper.invertPossibleGndPinsToVccPins()
         Assertions.assertEquals(22760, gndPins.size());
@@ -96,14 +98,16 @@ public class TestGlobalSignalRouting {
         Function<Node, NodeStatus> gns = (n) -> NodeStatus.AVAILABLE;
         RouteThruHelper routeThruHelper = new RouteThruHelper(design.getDevice());
 
-        GlobalSignalRouting.routeStaticNet(design.getGndNet(), gns, design, routeThruHelper);
-        gndPins = design.getGndNet().getPins();
+        GlobalSignalRouting.routeStaticNet(gndNet, gns, design, routeThruHelper);
+        gndPins = gndNet.getPins();
         Assertions.assertEquals(1858, gndPins.stream().filter((spi) -> spi.isOutPin()).count());
         Assertions.assertEquals(22760, gndPins.stream().filter((spi) -> !spi.isOutPin()).count());
+        Assertions.assertEquals(39827, gndNet.getPIPs().size());
 
-        GlobalSignalRouting.routeStaticNet(design.getVccNet(), gns, design, routeThruHelper);
-        vccPins = design.getVccNet().getPins();
+        GlobalSignalRouting.routeStaticNet(vccNet, gns, design, routeThruHelper);
+        vccPins = vccNet.getPins();
         Assertions.assertEquals(0, vccPins.stream().filter((spi) -> spi.isOutPin()).count());
         Assertions.assertEquals(19402, vccPins.stream().filter((spi) -> !spi.isOutPin()).count());
+        Assertions.assertEquals(23280, vccNet.getPIPs().size());
     }
 }


### PR DESCRIPTION
To be conservative, do not allow GlobalSignalRouter to update any intra-site routing, including those sitewires corresponding to site pins.

This means that we can no longer fracture existing user LUTs (placed at `[A-H]6LUT`) so that the `[A-H]5LUT` can serve as a static source, losing some of the routability benefits provided by https://github.com/Xilinx/RapidWright/pull/914, but in return being more robust.

Quantifying this loss in `TestGlobalSignalRouting.testRouteStaticNet()` operating on `optical-flow.dcp`:
* Number of static ground sources before: 1952, now: 1858 (-4.8%)
* Number of static ground PIPs before: 39777, now: 39827 (+0.13%)