### PR TITLE
[RWRoute] Preserve [A-H]_O node when [A-H]MUX used as static src

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -506,9 +506,8 @@ public class RWRoute{
 
             preserveNet(staticNet, false);
 
-            // When a [B-H]MUX pin is used as a static source, also preserve the [B-H]_O pin
+            // When a [A-H]MUX pin is used as a static source, also preserve the [A-H]_O pin
             // so that it can't be used by other static nets, nor as a LUT routethru
-            // Assume that AMUX can always supply GND
             for (SitePinInst spi : staticNet.getPins()) {
                 if (!spi.isOutPin()) {
                     continue;
@@ -522,10 +521,8 @@ public class RWRoute{
                 String pinName = spi.getName();
                 if (pinName.endsWith("MUX")) {
                     char lutLetter = pinName.charAt(0);
-                    if (lutLetter != 'A') {
-                        Node oNode = si.getSite().getConnectedNode(lutLetter + "_O");
-                        routingGraph.preserve(oNode, staticNet);
-                    }
+                    Node oNode = si.getSite().getConnectedNode(lutLetter + "_O");
+                    routingGraph.preserve(oNode, staticNet);
                 } else {
                     assert(pinName.endsWith("_O"));
                 }

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -514,7 +514,7 @@ public class RWRoute{
                 }
 
                 SiteInst si = spi.getSiteInst();
-                if (!Utils.isSLICE((si))) {
+                if (!Utils.isSLICE(si)) {
                     continue;
                 }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -506,8 +506,9 @@ public class RWRoute{
 
             preserveNet(staticNet, false);
 
-            // When a [A-H]MUX pin is used as a static source, also preserve the [A-H]_O pin
+            // When a [B-H]MUX pin is used as a static source, also preserve the [B-H]_O pin
             // so that it can't be used by other static nets, nor as a LUT routethru
+            // Assume that AMUX can always supply GND
             for (SitePinInst spi : staticNet.getPins()) {
                 if (!spi.isOutPin()) {
                     continue;
@@ -521,8 +522,10 @@ public class RWRoute{
                 String pinName = spi.getName();
                 if (pinName.endsWith("MUX")) {
                     char lutLetter = pinName.charAt(0);
-                    Node oNode = si.getSite().getConnectedNode(lutLetter + "_O");
-                    routingGraph.preserve(oNode, staticNet);
+                    if (lutLetter != 'A') {
+                        Node oNode = si.getSite().getConnectedNode(lutLetter + "_O");
+                        routingGraph.preserve(oNode, staticNet);
+                    }
                 } else {
                     assert(pinName.endsWith("_O"));
                 }


### PR DESCRIPTION
This prevents `*_O` and `*MUX` from being used for two different static sources, and also prevents *`_O` from being later used as a LUT routethru (support for which was added in #932).

Along the lines of https://github.com/Xilinx/RapidWright/pull/953 which unwound modification of intra-site routing for static nets.