### PR TITLE
[EDIFTokenizer] Account for byte size of UTF-8 characters correctly

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
@@ -165,8 +165,8 @@ public class EDIFTokenizer implements AutoCloseable {
         if (!isShortLived) {
             token = uniquifier.uniquifyName(token);
         }
-        byteOffset+= length;
-        available-= length;
+        byteOffset += length;
+        available -= length;
         if (available<0) {
             throw new EDIFParseException("Token probably too long or failed to fetch data in time: "+ token +" at "+byteOffset);
         }

--- a/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022, 2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Jakob Wenzel, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
@@ -203,9 +203,10 @@ public class EDIFTokenizer implements AutoCloseable {
         return token;
     }
 
-    private IOException tokenTooLong(int bufferOffset) {
+    private IOException tokenTooLong(int startOffset) {
         final long byteOffsetAtStart = this.byteOffset;
-        final String failingToken = getUniqueToken(bufferOffset, bufferOffset + 150, true);
+        final int endOffset = bufferAddressMask & (startOffset + 150);
+        final String failingToken = getUniqueToken(startOffset, endOffset, true);
         throw new TokenTooLongException("ERROR: String buffer overflow on byte offset " +
                 byteOffsetAtStart + " parsing token starting with "+ failingToken +"...\n\t Please revisit why this EDIF token "
                 + "is so long or increase the buffer in " + this.getClass().getCanonicalName());

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022, 2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Jakob Wenzel, Xilinx Research Labs.

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
@@ -69,10 +69,10 @@ public class TestEDIFParser {
      * List of byte offsets that cause interesting behaviour if we start parsing there
      */
     private static final List<ParseStart> interestingOffsets = Arrays.asList(
-      new ParseStart("Mismatch in First Evil Cell", 517L, false),
-      new ParseStart("Mismatch in Second Evil Cell", 849L, false),
-      new ParseStart("Totally Misaligned", 1045L, false),
-      new ParseStart("After Evil", 1111L, true),
+      new ParseStart("Mismatch in First Evil Cell", 577L, false),
+      new ParseStart("Mismatch in Second Evil Cell", 919L, false),
+      new ParseStart("Totally Misaligned", 1115L, false),
+      new ParseStart("After Evil", 1181L, true),
       new ParseStart("At EOF", FILE_SIZE-2, false)
     );
 

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFParser.java
@@ -85,10 +85,12 @@ public class TestEDIFParser {
     @ParameterizedTest(name="{0}")
     @MethodSource("testParallelArgs")
     public void testParallel(String ignoredDescription, List<ParseStart> offsets, int expectedSuccessfulThreads) throws IOException {
+        EDIFNetlist netlist;
         try (ParallelEDIFParserTestSpecificOffsets parser = new ParallelEDIFParserTestSpecificOffsets(input, 128, offsets)) {
-            parser.parseEDIFNetlist(new CodePerfTracker("parse edif"));
+            netlist = parser.parseEDIFNetlist(new CodePerfTracker("parse edif"));
             Assertions.assertEquals(expectedSuccessfulThreads, parser.getSuccessfulThreads());
         }
+        Assertions.assertTrue(netlist.getComments().contains("Here's some Unicode: àâæçéèêëœîïôùûÜüÿ"));
     }
 
     /**
@@ -125,10 +127,11 @@ public class TestEDIFParser {
 
     @Test
     public void loadEDIFSingleThreaded() throws IOException {
+        EDIFNetlist netlist;
         try (EDIFParser parser = new EDIFParser(input)) {
-            parser.parseEDIFNetlist();
+            netlist = parser.parseEDIFNetlist();
         }
-
+        Assertions.assertTrue(netlist.getComments().contains("Here's some Unicode: àâæçéèêëœîïôùûÜüÿ"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Correct fix for https://github.com/Xilinx/RapidWright/pull/961, where the previous inability to account for the size of Unicode characters caused the wrong offsets to be calculated and the wrong part of the buffer to be read/written to.