### PR TITLE
[DCP] Test Design.writeCheckpoint() when using existing EDIF

### DIFF
--- a/test/shared/com/xilinx/rapidwright/util/VivadoToolsHelper.java
+++ b/test/shared/com/xilinx/rapidwright/util/VivadoToolsHelper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Eddie Hung, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.util;
+
+import com.xilinx.rapidwright.design.Design;
+import org.junit.jupiter.api.Assertions;
+
+public class VivadoToolsHelper {
+    public static void assertFullyRouted(Design design) {
+        if (!FileTools.isVivadoOnPath()) {
+            return;
+        }
+
+        ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(design);
+        Assertions.assertTrue(rrs.isFullyRouted());
+    }
+}

--- a/test/shared/com/xilinx/rapidwright/util/VivadoToolsHelper.java
+++ b/test/shared/com/xilinx/rapidwright/util/VivadoToolsHelper.java
@@ -25,6 +25,8 @@ package com.xilinx.rapidwright.util;
 import com.xilinx.rapidwright.design.Design;
 import org.junit.jupiter.api.Assertions;
 
+import java.nio.file.Path;
+
 public class VivadoToolsHelper {
     public static void assertFullyRouted(Design design) {
         if (!FileTools.isVivadoOnPath()) {
@@ -32,6 +34,15 @@ public class VivadoToolsHelper {
         }
 
         ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(design);
+        Assertions.assertTrue(rrs.isFullyRouted());
+    }
+
+    public static void assertFullyRouted(Path dcp) {
+        if (!FileTools.isVivadoOnPath()) {
+            return;
+        }
+
+        ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(dcp);
         Assertions.assertTrue(rrs.isFullyRouted());
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022, 2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -24,6 +24,11 @@ package com.xilinx.rapidwright.design;
 
 import java.nio.file.Path;
 
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.util.VivadoTools;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -32,15 +37,19 @@ import com.xilinx.rapidwright.device.SiteTypeEnum;
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFLibrary;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestDCPSave {
 
-    @Test
-    public void testDCPSave(@TempDir Path tempDir) {
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testDCPSave(boolean detachNetlist, @TempDir Path tempDir) {
         // Taken from example provided by https://github.com/nqdtan in #548
         Design d = new Design("test", "xcvc1902-vsvd1760-2MP-e-S");
-        EDIFLibrary plib = d.getNetlist().getHDIPrimitivesLibrary();
-        EDIFCell top = d.getNetlist().getTopCell();
+        EDIFNetlist n = d.getNetlist();
+        EDIFLibrary plib = n.getHDIPrimitivesLibrary();
+        EDIFCell top = n.getTopCell();
         EDIFCell ec0 = new EDIFCell(plib, "LUT6CY");
         EDIFCell ec1 = new EDIFCell(plib, "LUTCY1");
         EDIFCell ec2 = new EDIFCell(plib, "LUTCY2");
@@ -71,7 +80,26 @@ public class TestDCPSave {
         c2.addPinMapping("A4", "I3");
         c2.addPinMapping("A5", "I4");
         c2.addPinMapping("O5", "O");
-        
-        d.writeCheckpoint(tempDir.resolve("tmp.dcp"));        
+
+        if (detachNetlist) {
+            EDIFTools.writeEDIFFile(tempDir.resolve("tmp.edf"), n, d.getPartName());
+            d.detachNetlist();
+            d.writeCheckpoint(tempDir.resolve("tmp.dcp"), tempDir.resolve("tmp.edf"));
+        } else {
+            d.writeCheckpoint(tempDir.resolve("tmp.dcp"));
+        }
+    }
+
+    @Test
+    public void testWriteCheckpointPreWrittenEDIF(@TempDir Path tempDir) {
+        Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
+
+        Path edfPath = tempDir.resolve("tmp.edf");
+        EDIFTools.writeEDIFFile(edfPath, design.getNetlist(), design.getPartName());
+        design.detachNetlist();
+        Path dcpPath = tempDir.resolve("tmp.dcp");
+        design.writeCheckpoint(dcpPath, edfPath);
+
+        Assertions.assertTrue(VivadoTools.reportRouteStatus(dcpPath).isFullyRouted());
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
@@ -84,7 +84,7 @@ public class TestDCPSave {
         if (detachNetlist) {
             EDIFTools.writeEDIFFile(tempDir.resolve("tmp.edf"), n, d.getPartName());
             d.detachNetlist();
-            d.writeCheckpoint(tempDir.resolve("tmp.dcp"), tempDir.resolve("tmp.edf"));
+            d.writeCheckpoint(tempDir.resolve("tmp.dcp"), tempDir.resolve("tmp.edf"), null);
         } else {
             d.writeCheckpoint(tempDir.resolve("tmp.dcp"));
         }
@@ -98,7 +98,7 @@ public class TestDCPSave {
         EDIFTools.writeEDIFFile(edfPath, design.getNetlist(), design.getPartName());
         design.detachNetlist();
         Path dcpPath = tempDir.resolve("tmp.dcp");
-        design.writeCheckpoint(dcpPath, edfPath);
+        design.writeCheckpoint(dcpPath, edfPath, null);
 
         Assertions.assertTrue(VivadoTools.reportRouteStatus(dcpPath).isFullyRouted());
     }

--- a/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
@@ -28,6 +28,7 @@ import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.util.VivadoTools;
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -100,6 +101,6 @@ public class TestDCPSave {
         Path dcpPath = tempDir.resolve("tmp.dcp");
         design.writeCheckpoint(dcpPath, edfPath, null);
 
-        Assertions.assertTrue(VivadoTools.reportRouteStatus(dcpPath).isFullyRouted());
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/tools/TestLUTTools.java
+++ b/test/src/com/xilinx/rapidwright/design/tools/TestLUTTools.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -40,6 +40,7 @@ import com.xilinx.rapidwright.rwroute.RWRoute;
 import com.xilinx.rapidwright.rwroute.TestRWRoute;
 import com.xilinx.rapidwright.support.LargeTest;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -165,7 +166,7 @@ public class TestLUTTools {
             }
             TestRWRoute.assertAllSourcesRoutedFlagSet(design);
             TestRWRoute.assertAllPinsRouted(design);
-            TestRWRoute.assertVivadoFullyRouted(design);
+            VivadoToolsHelper.assertFullyRouted(design);
         } finally {
             System.setProperty("rapidwright.rwroute.lutPinSwapping.deferIntraSiteRoutingUpdates", "false");
         }

--- a/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
+++ b/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Eddie Hung, Advanced Micro Devices, Inc.
@@ -40,13 +40,12 @@ import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.router.Router;
-import com.xilinx.rapidwright.rwroute.TestRWRoute;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.util.FileTools;
 import com.xilinx.rapidwright.util.ReportRouteStatusResult;
 import com.xilinx.rapidwright.util.VivadoTools;
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -467,7 +466,7 @@ public class TestECOTools {
         Assertions.assertEquals(net0, lut1.getSitePinFromLogicalPin("I0", null).getNet());
         Assertions.assertNotEquals(net0, lut1.getSitePinFromLogicalPin("O", null).getNet());
 
-        TestRWRoute.assertVivadoFullyRouted(d);
+        VivadoToolsHelper.assertFullyRouted(d);
     }
 
     @Test

--- a/test/src/com/xilinx/rapidwright/examples/TestSLRCrosserGenerator.java
+++ b/test/src/com/xilinx/rapidwright/examples/TestSLRCrosserGenerator.java
@@ -25,13 +25,10 @@ package com.xilinx.rapidwright.examples;
 
 import java.nio.file.Path;
 
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
-import com.xilinx.rapidwright.util.FileTools;
-import com.xilinx.rapidwright.util.VivadoTools;
 
 /**
  * Created on: Mar 25, 2024
@@ -52,7 +49,7 @@ public class TestSLRCrosserGenerator {
 
         String[] args = new String[] { "-j", "512", "-k", "256", "-o", outputDCP.toString() };
         SLRCrosserGenerator.main(args);
-        Assumptions.assumeTrue(FileTools.isVivadoOnPath());
-        Assertions.assertTrue(VivadoTools.reportRouteStatus(outputDCP).isFullyRouted());
+
+        VivadoToolsHelper.assertFullyRouted(outputDCP);
     }
 }

--- a/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Eddie Hung, Xilinx Research Labs.
@@ -48,6 +48,7 @@ import com.xilinx.rapidwright.rwroute.RWRoute;
 import com.xilinx.rapidwright.rwroute.TestRWRoute;
 import com.xilinx.rapidwright.support.LargeTest;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -333,7 +334,7 @@ public class TestPhysNetlistWriter {
             DesignTools.updatePinsIsRouted(outputDesign);
             TestRWRoute.assertAllSourcesRoutedFlagSet(outputDesign);
             TestRWRoute.assertAllPinsRouted(outputDesign);
-            TestRWRoute.assertVivadoFullyRouted(outputDesign);
+            VivadoToolsHelper.assertFullyRouted(outputDesign);
         } finally {
             System.setProperty("rapidwright.rwroute.lutPinSwapping.deferIntraSiteRoutingUpdates", "false");
             System.setProperty("rapidwright.physNetlistWriter.simulateSwappedLutPins", "false");

--- a/test/src/com/xilinx/rapidwright/router/TestSATRouter.java
+++ b/test/src/com/xilinx/rapidwright/router/TestSATRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Eddie Hung, Advanced Micro Devices, Inc.
@@ -27,8 +27,7 @@ import com.xilinx.rapidwright.design.Net;
 import com.xilinx.rapidwright.design.blocks.PBlock;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.util.FileTools;
-import com.xilinx.rapidwright.util.VivadoTools;
-import org.junit.jupiter.api.Assertions;
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -54,8 +53,6 @@ public class TestSATRouter {
 
         satRouter.applyRoutingResult();
 
-        if (FileTools.isVivadoOnPath()) {
-            Assertions.assertTrue(VivadoTools.reportRouteStatus(design).isFullyRouted());
-        }
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -83,15 +84,6 @@ public class TestRWRoute {
         }
     }
 
-    public static void assertVivadoFullyRouted(Design design) {
-        if (!FileTools.isVivadoOnPath()) {
-            return;
-        }
-
-        ReportRouteStatusResult rrs = VivadoTools.reportRouteStatus(design);
-        Assertions.assertTrue(rrs.isFullyRouted());
-    }
-
     public static void assertAllPinsRouted(Design design) {
         for (Net net : design.getNets()) {
             if (net.getSource() == null && !net.isStaticNet()) {
@@ -139,7 +131,7 @@ public class TestRWRoute {
         RWRoute.routeDesignFullNonTimingDriven(design);
         assertAllSourcesRoutedFlagSet(design);
         assertAllPinsRouted(design);
-        assertVivadoFullyRouted(design);
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 
     /**
@@ -156,7 +148,7 @@ public class TestRWRoute {
         RWRoute.routeDesignWithUserDefinedArguments(design, new String[] {"--nonTimingDriven", "--lutPinSwapping"});
         assertAllSourcesRoutedFlagSet(design);
         assertAllPinsRouted(design);
-        assertVivadoFullyRouted(design);
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 
     @ParameterizedTest
@@ -170,7 +162,7 @@ public class TestRWRoute {
         RWRoute.routeDesignWithUserDefinedArguments(design, new String[] {"--nonTimingDriven", "--lutRoutethru"});
         assertAllSourcesRoutedFlagSet(design);
         assertAllPinsRouted(design);
-        assertVivadoFullyRouted(design);
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 
     /**
@@ -189,7 +181,7 @@ public class TestRWRoute {
         RWRoute.routeDesignFullTimingDriven(design);
         assertAllSourcesRoutedFlagSet(design);
         assertAllPinsRouted(design);
-        assertVivadoFullyRouted(design);
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 
     /**
@@ -206,7 +198,7 @@ public class TestRWRoute {
         RWRoute.routeDesignFullNonTimingDriven(design);
         assertAllSourcesRoutedFlagSet(design);
         assertAllPinsRouted(design);
-        assertVivadoFullyRouted(design);
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 
     /**
@@ -228,7 +220,7 @@ public class TestRWRoute {
         for (Net net : routed.getModifiedNets()) {
             assertAllPinsRouted(net);
         }
-        assertVivadoFullyRouted(design);
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 
     /**
@@ -250,7 +242,7 @@ public class TestRWRoute {
         for (Net net : routed.getModifiedNets()) {
             assertAllPinsRouted(net);
         }
-        assertVivadoFullyRouted(design);
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 
     void testSingleConnectionHelper(String partName,


### PR DESCRIPTION
An upcoming release will support the ability to write out the EDIF netlist prior to detaching, without compromising the ability to write out a DCP checkpoint:
```
EDIFTools.writeEDIFFile(design.getNetlist(), <EDIF path>, ...);
design.detachNetlist();
design.writeCheckpoint(<DCP path>, <EDIF path>, ...);
```