### PR TITLE
Work around for multi-inverter BEL in DSP58

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -215,7 +215,7 @@ public class DeviceResourcesVerifier {
 
                 expect(DeviceResourcesWriter.getBELCategory(bel).name(), belReader.getCategory().name());
 
-                if (bel.canInvert()) {
+                if (bel.canInvert() && !bel.getName().equals("SRCMXINV") && !bel.getName().equals("SRCFPMXINV")) {
                     expect(true, belReader.hasInverting());
                     BELInverter.Reader belInverter = belReader.getInverting();
 

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -554,7 +554,7 @@ public class DeviceResourcesWriter {
                 }
                 belBuilder.setCategory(getBELCategory(bel));
 
-                if (bel.canInvert()) {
+                if (bel.canInvert() && !bel.getName().equals("SRCMXINV") && !bel.getName().equals("SRCFPMXINV")) {
                     BELInverter.Builder belInverter = belBuilder.initInverting();
                     belInverter.setNonInvertingPin(allBELPins.getIndex(bel.getNonInvertingPin()));
                     belInverter.setInvertingPin(allBELPins.getIndex(bel.getInvertingPin()));


### PR DESCRIPTION
When generating the Device Resources file for a Versal device, there is an NPE due to queries on the `DSP58` BELs `SRCMXINV` and `SRCFPMXINV` that don't match previous categorization of inverting capable BELs.  These BELs have multiple inverting pins and thus it is ambiguous which pins to return when `BEL.getNonInvertingPin()` and `BEL.getInvertingPin()` are called.