### PR TITLE
[RWRoute,PhysNetlistReader] Set logical driver on PIPs

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -526,25 +526,29 @@ public class PhysNetlistReader {
 
             // Nets with more than one routed source (e.g. A_O and AMUX) should have
             // the first primary source PIP marked as a logical driver
-            SitePinInst altSource = net.getAlternateSource();
-            if (altSource != null) {
-                SitePinInst source = net.getSource();
-                assert(source.getTile() == altSource.getTile());
+            if (net.getType() == NetType.WIRE) {
+                SitePinInst altSource = net.getAlternateSource();
+                if (altSource != null) {
+                    assert(!net.isClockNet());
 
-                DesignTools.updatePinsIsRouted(net);
-                if (source.isRouted() && altSource.isRouted()) {
-                    Tile sourceTile = altSource.getTile();
-                    for (PIP pip : net.getPIPs()) {
-                        if (pip.getTile() != sourceTile) {
-                            continue;
-                        }
-                        if (pip.isRouteThru()) {
-                            continue;
-                        }
-                        SitePin sp = pip.getStartNode().getSitePin();
-                        if (sp.getPinName().equals(source.getName())) {
-                            pip.setIsLogicalDriver(true);
-                            break;
+                    SitePinInst source = net.getSource();
+                    assert(source.getTile() == altSource.getTile());
+
+                    DesignTools.updatePinsIsRouted(net);
+                    if (source.isRouted() && altSource.isRouted()) {
+                        Tile sourceTile = altSource.getTile();
+                        for (PIP pip : net.getPIPs()) {
+                            if (pip.getTile() != sourceTile) {
+                                continue;
+                            }
+                            if (pip.isRouteThru()) {
+                                continue;
+                            }
+                            SitePin sp = pip.getStartNode().getSitePin();
+                            if (sp.getPinName().equals(source.getName())) {
+                                pip.setIsLogicalDriver(true);
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1451,7 +1451,7 @@ public class RWRoute{
     /**
      * Checks if there are PIP overlaps among routed nets.
      */
-    private void checkPIPsUsage() {
+    protected void checkPIPsUsage() {
         Map<PIP, Set<Net>> pipsUsage = new HashMap<>();
         for (Net net : design.getNets()) {
             for (PIP pip:net.getPIPs()) {

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1423,6 +1423,7 @@ public class RWRoute{
         for (Entry<Net,NetWrapper> e : nets.entrySet()) {
             NetWrapper netWrapper = e.getValue();
             Net net = netWrapper.getNet();
+            assert(net.getType() == NetType.WIRE && !net.isClockNet());
 
             SitePinInst source = net.getSource();
             SitePinInst altSource = net.getAlternateSource();

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1431,9 +1431,9 @@ public class RWRoute{
             Set<PIP> newPIPs = new HashSet<>();
             for (Connection connection:netWrapper.getConnections()) {
                 List<PIP> pips = RouterHelper.getConnectionPIPs(connection);
-                if (setLogicalDriver) {
+                if (setLogicalDriver && connection.getSource() == source) {
                     // When multiple sources are used (e.g. A_O and AMUX) then
-                    // mark the first source as a logical driver
+                    // mark the first primary source PIP as a logical driver
                     PIP pipFromSource = pips.get(pips.size() - 1);
                     assert(!pipFromSource.getStartNode().getSitePin().isInput());
                     pipFromSource.setIsLogicalDriver(true);


### PR DESCRIPTION
For nets with multiple source pins (e.g. `A_O` and `AMUX`) set the logical driver flag on the first PIP leaving the primary source.