### PR TITLE
[RWRoute] Consider all nets for timing-driven routing

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -277,7 +277,7 @@ public class RWRoute{
     }
 
     protected Collection<Net> getTimingNets() {
-        return indirectConnections.stream().map((c) -> c.getNetWrapper().getNet()).collect(Collectors.toSet());
+        return design.getNets();
     }
 
     protected TimingManager createTimingManager(ClkRouteTiming clkTiming, Collection<Net> timingNets) {


### PR DESCRIPTION
Rather than just consider nets used by `indirectConnections`, which would miss `directConnections` as well as any (exclusively) intra-site nets