### PR TITLE
[RWRoute] Fix logical driver flag setting for DCP write

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -525,7 +525,7 @@ public class PhysNetlistReader {
             stubWires.clear();
 
             // Nets with more than one routed source (e.g. A_O and AMUX) should have
-            // the first primary source PIP marked as a logical driver
+            // the first PIP driven by either source marked as a logical driver
             if (net.getType() == NetType.WIRE) {
                 SitePinInst altSource = net.getAlternateSource();
                 if (altSource != null) {

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1432,18 +1432,25 @@ public class RWRoute{
             Set<PIP> newPIPs = new HashSet<>();
             for (Connection connection:netWrapper.getConnections()) {
                 List<PIP> pips = RouterHelper.getConnectionPIPs(connection);
-                if (setLogicalDriver && connection.getSource() == source) {
-                    // When multiple sources are used (e.g. A_O and AMUX) then
-                    // mark the first primary source PIP as a logical driver
-                    PIP pipFromSource = pips.get(pips.size() - 1);
-                    assert(!pipFromSource.getStartNode().getSitePin().isInput());
-                    pipFromSource.setIsLogicalDriver(true);
-                    setLogicalDriver = false;
-                }
                 newPIPs.addAll(pips);
             }
 
             net.setPIPs(newPIPs);
+            if (setLogicalDriver) {
+                for (PIP pip : net.getPIPs()) {
+                    // When multiple sources are used (e.g. A_O and AMUX) then
+                    // mark the first primary source PIP as a logical driver
+                    Node startNode = pip.getStartNode();
+                    if (startNode != null) {
+                        SitePin sp = startNode.getSitePin();
+                        if (sp != null && !sp.isInput()) {
+                            pip.setIsLogicalDriver(true);
+                            setLogicalDriver = false;
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         checkPIPsUsage();


### PR DESCRIPTION
The DCP writer depends on nets with a logical driver flag (used only for nets that use multiple site output pins for the same logical routing tree) to be the first source `PIP` in the list of pips on the `Net`.  These changes modify the addition of this flag in RWRoute such that it adheres to this convention.