### PR TITLE
Fix PolynomialGenerator and TestDCPSave tests

### DIFF
--- a/src/com/xilinx/rapidwright/examples/PolynomialGenerator.java
+++ b/src/com/xilinx/rapidwright/examples/PolynomialGenerator.java
@@ -216,6 +216,10 @@ public class PolynomialGenerator {
         return operators;
     }
 
+    public static void releaseOperators() {
+        operators = null;
+    }
+
     public static int sliceyOther;
     public static boolean setSliceY = false;
 
@@ -383,6 +387,8 @@ public class PolynomialGenerator {
         t.stop().start("Build Operator Tree");
 
         buildOperatorTree(p, d, results);
+
+        releaseOperators();
 
         d.addXDCConstraint(ConstraintGroup.LATE, "create_clock -name "+CLK_NAME+" -period 1.291 [get_ports "+CLK_NAME+"]");
         d.addXDCConstraint(ConstraintGroup.LATE, "set_property HD.CLK_SRC BUFGCE_X0Y18 [get_ports "+CLK_NAME+"]");

--- a/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
@@ -101,6 +101,6 @@ public class TestDCPSave {
         Path dcpPath = tempDir.resolve("tmp.dcp");
         design.writeCheckpoint(dcpPath, edfPath, null);
 
-        VivadoToolsHelper.assertFullyRouted(design);
+        VivadoToolsHelper.assertFullyRouted(dcpPath);
     }
 }


### PR DESCRIPTION
* `PolynomialGenerator` to release `operators` cache after it's done, freeing up memory
* `TestDCPSave.testWriteCheckpointPreWrittenEDIF()` to check the written-out DCP file, rather than trying to write out the `Design` again.