### PR TITLE
BlockPlacer2: Fix off by one error in selecting module instance to move

### DIFF
--- a/src/com/xilinx/rapidwright/placer/blockplacer/BlockPlacer2.java
+++ b/src/com/xilinx/rapidwright/placer/blockplacer/BlockPlacer2.java
@@ -566,8 +566,8 @@ public abstract class BlockPlacer2<ModuleT, ModuleInstT extends AbstractModuleIn
         for (int inner_iterate = 0; inner_iterate< maxInnerIteration; inner_iterate++) {
         //for (int inner_iterate = 0; inner_iterate< (10*rangeLimit); inner_iterate++) {
         //for (int inner_iterate = 0; inner_iterate< (dev.getColumns()*dev.getRows()); inner_iterate++) {
-            //ModuleInstT selectedHD = hardMacros.get(rand.nextInt(hardMacros.size()-1));
-            ModuleInstT selectedHD = weighted.get(rand.nextInt(weighted.size()-1));
+            //ModuleInstT selectedHD = hardMacros.get(rand.nextInt(hardMacros.size()));
+            ModuleInstT selectedHD = weighted.get(rand.nextInt(weighted.size()));
 
 
             if (PARANOID) {


### PR DESCRIPTION
I have identified an off by one error in the `BlockPlacer2` when we try to select a module instance to move: The upper bound for `Random.nextInt` is exclusive, but we subtract 1 anyway. Therefore we never select the very last module instance in the list of module instances. It will just stay at its initial placement position forever (unless it gets pushed away by overlapping with another instance).

This issue seems to have been there since the very beginning of RapidWright: https://github.com/Xilinx/RapidWright/blob/17af8990400fd86b79bf5e3284d3ba746aa643bc/com/xilinx/rapidwright/placer/blockplacer/BlockPlacer2.java#L401

@clavin-xlnx: This might explain some bad placement results we've seen in the past.