### PR TITLE
Updates to support 2024.1 DCP writing

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.0-rc3.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.0-rc4.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.0-rc3-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.0-rc4-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.0-rc1.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.0-rc2.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.0-rc1-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.0-rc2-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.0.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.0-rc1.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.0-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.0-rc1-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.0-rc2.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.0-rc3.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.0-rc2-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.0-rc3-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2024.1.0-rc1-beta
+  RAPIDWRIGHT_VERSION: v2024.1.0-rc2-beta
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2024.1.0-beta
+  RAPIDWRIGHT_VERSION: v2024.1.0-rc1-beta
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2024.1.0-rc3-beta
+  RAPIDWRIGHT_VERSION: v2024.1.0-rc4-beta
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2024.1.0-rc2-beta
+  RAPIDWRIGHT_VERSION: v2024.1.0-rc3-beta
 
 jobs:
   build:

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -897,7 +897,7 @@ public class EDIFNetlist extends EDIFName {
      * @param name the hierarchical name
      * @return A pair of EdifHierCellInst and the unmatched portion of the name. The name may be null if we found a complete match
      */
-    private Pair<List<EDIFCellInst>, String> getHierObject(String name) {
+    public Pair<List<EDIFCellInst>, String> getHierObject(String name) {
         if (name.isEmpty()) return new Pair<>(Collections.singletonList(getTopCellInst()), null);
         String[] parts = name.split(EDIFTools.EDIF_HIER_SEP);
 

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -912,7 +912,7 @@ public class EDIFTools {
     }
 
     public static Path getEDIFParentDir(Path edifFileName) {
-        Path parent = edifFileName.getParent();
+        Path parent = edifFileName == null ? null : edifFileName.getParent();
         return parent == null ? Paths.get(System.getProperty("user.dir")) : parent;
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -37,6 +37,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -896,11 +897,27 @@ public class EDIFTools {
         return readEdifFile(edifFileName, Integer.MAX_VALUE);
     }
 
-    public static EDIFNetlist readEdifFile(Path edifFileName, int maxThreads) {
-        Path parent = edifFileName.getParent();
-        if (parent == null) {
-            parent = Paths.get(System.getProperty("user.dir"));
+    public static List<String> getEDNFiles(Path parent) {
+        String edifDirectoryName = parent.toAbsolutePath().toString();
+        File origDir = new File(edifDirectoryName);
+        String[] ednFiles = origDir.list(FileTools.getEDNFilenameFilter());
+        if (ednFiles != null && ednFiles.length > 0) {
+            edifDirectoryName = edifDirectoryName + File.separator;
+            for (int i = 0; i < ednFiles.length; i++) {
+                ednFiles[i] = edifDirectoryName + ednFiles[i];
+            }
+            return new ArrayList<>(Arrays.asList(ednFiles));
         }
+        return Collections.emptyList();
+    }
+
+    public static Path getEDIFParentDir(Path edifFileName) {
+        Path parent = edifFileName.getParent();
+        return parent == null ? Paths.get(System.getProperty("user.dir")) : parent;
+    }
+
+    public static EDIFNetlist readEdifFile(Path edifFileName, int maxThreads) {
+        Path parent = getEDIFParentDir(edifFileName);
         if (RW_ENABLE_EDIF_BINARY_CACHING) {
             Path bedif = parent.resolve(
                             edifFileName.getFileName().toString().replace(".edf", ".bedf"));
@@ -915,37 +932,9 @@ public class EDIFTools {
                 }
             }
         }
-        EDIFNetlist edif;
-        File edifFile = edifFileName.toFile();
-        String edifDirectoryName = parent.toAbsolutePath().toString();
-        if (edifDirectoryName == null) {
-            try {
-                File canEdifFile = edifFile.getCanonicalFile();
-                if (canEdifFile != null) {
-                    edifDirectoryName = canEdifFile.getParent();
-                }
-            } catch (IOException e) {
-                // Unable to determine EDIF source directory - not sure if
-                // this is worth throwing an error as we are only checking for EDN files
-                System.err.println("WARNING: Could not determine source directory for EDIF. "
-                    + "If it contained encrypted cells \n(present as .edn files), they will not "
-                    + "be passed to resulting DCP load script.");
-            }
-        }
-        edif = loadEDIFFile(edifFileName, maxThreads);
-        if (edifDirectoryName != null) {
-            File origDir = new File(edifDirectoryName);
-            edif.setOrigDirectory(edifDirectoryName);
-            String[] ednFiles = origDir.list(FileTools.getEDNFilenameFilter());
-            if (ednFiles != null && ednFiles.length > 0) {
-                edifDirectoryName = edifDirectoryName + File.separator;
-                for (int i=0; i < ednFiles.length; i++) {
-                    ednFiles[i] = edifDirectoryName + ednFiles[i];
-                }
-
-            }
-            edif.setEncryptedCells(new ArrayList<>(Arrays.asList(ednFiles)));
-        }
+        EDIFNetlist edif = loadEDIFFile(edifFileName, maxThreads);
+        edif.setOrigDirectory(parent.toAbsolutePath().toString());
+        edif.setEncryptedCells(getEDNFiles(parent));
         if (RW_ENABLE_EDIF_BINARY_CACHING) {
             Path bedif = parent.resolve(
                     edifFileName.getFileName().toString().replace(".edf", ".bedf"));

--- a/src/com/xilinx/rapidwright/util/ParallelismTools.java
+++ b/src/com/xilinx/rapidwright/util/ParallelismTools.java
@@ -183,6 +183,7 @@ public class ParallelismTools {
      * @param <T> Type returned by all tasks.
      * @return A Deque of Future objects corresponding to each task (in order).
      */
+    @SafeVarargs
     public static <T> Deque<Future<T>> invokeFirstSubmitRest(@NotNull Callable<T>... tasks) {
         Deque<Future<T>> futures = new ArrayDeque<>(tasks.length);
 

--- a/src/com/xilinx/rapidwright/util/Params.java
+++ b/src/com/xilinx/rapidwright/util/Params.java
@@ -34,6 +34,8 @@ public class Params {
 
     public static int RW_ZSTD_DEFAULT_COMPRESSION_LEVEL = 3;
 
+    public static String RW_WRITE_DCP_2024_1_NAME = "RW_WRITE_DCP_2024_1";
+
     /**
      * Flag to have RapidWright decompress gzipped EDIF files to disk prior to
      * parsing. This is a tradeoff where pre-decompression improves runtime over the
@@ -50,6 +52,13 @@ public class Params {
      */
     public static int RW_ZSTD_COMPRESSION_LEVEL = getParamOrDefaultIntSetting(RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK_NAME,
             RW_ZSTD_DEFAULT_COMPRESSION_LEVEL);
+
+    /**
+     * Flag to have RapidWright write out DCPs such that they will only be readable
+     * in Vivado 2024.1 and later. The advantage is that these DCPs will be read in
+     * faster and will provide better support for the largest devices.
+     */
+    public static boolean RW_WRITE_DCP_2024_1 = isParamSet(RW_WRITE_DCP_2024_1_NAME);
 
     /**
      * Checks if the named RapidWright parameter is set via an environment variable


### PR DESCRIPTION
Adds a new option (`Params.RW_WRITE_DCP_2024_1`) to write out DCPs in the 2024.1 format for faster reading by Vivado.  