### PR TITLE
[DeviceResourcesWriter] Output resource timings for US+

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -78,7 +78,7 @@ import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist.PropertyMap;
 import com.xilinx.rapidwright.rwroute.RouterHelper;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.timing.DelayModel;
-import com.xilinx.rapidwright.timing.DelayModelBuilder;
+import com.xilinx.rapidwright.timing.TimingModel;
 import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
 import com.xilinx.rapidwright.timing.delayestimator.InterconnectInfo;
 import com.xilinx.rapidwright.util.Pair;
@@ -116,6 +116,7 @@ public class DeviceResourcesWriter {
 
     private static DelayEstimatorBase delayEstimator;
     private static DelayModel intrasiteAndLogicDelayModel;
+    private static TimingModel timingModel;
 
     public static void populateSiteEnumerations(SiteInst siteInst, Site site) {
         if (!siteTypes.containsKey(siteInst.getSiteTypeEnum())) {
@@ -290,8 +291,9 @@ public class DeviceResourcesWriter {
             // Timing model only supports UltraScalePlus currently
             boolean useUTurnNodes = true;
             delayEstimator = new DelayEstimatorBase(device, new InterconnectInfo(), useUTurnNodes, 0);
-            String seriesName = design.getDevice().getSeries().name().toLowerCase();
-            intrasiteAndLogicDelayModel = DelayModelBuilder.getDelayModel(seriesName);
+            TimingModel timingModel = new TimingModel(design.getDevice());
+            timingModel.build();
+            intrasiteAndLogicDelayModel = timingModel.getDelayModel();
         }
 
         t.start("populateEnums");

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -116,7 +116,6 @@ public class DeviceResourcesWriter {
 
     private static DelayEstimatorBase delayEstimator;
     private static DelayModel intrasiteAndLogicDelayModel;
-    private static TimingModel timingModel;
 
     public static void populateSiteEnumerations(SiteInst siteInst, Site site) {
         if (!siteTypes.containsKey(siteInst.getSiteTypeEnum())) {

--- a/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
+++ b/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Keith Rothman, Google, Inc.

--- a/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
+++ b/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.timing.DelayModel;
-import com.xilinx.rapidwright.timing.DelayModelBuilder;
 import org.capnproto.MessageBuilder;
 import org.capnproto.StructList;
 

--- a/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
+++ b/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
@@ -27,12 +27,18 @@ import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.BELPin;
+import com.xilinx.rapidwright.timing.DelayModel;
+import com.xilinx.rapidwright.timing.DelayModelBuilder;
 import org.capnproto.MessageBuilder;
 import org.capnproto.StructList;
 
@@ -711,7 +717,14 @@ public class EnumerateCellBelMapping {
         return siteMap;
     }
 
-    public static void populateCellBelPin(StringEnumerator allStrings, Map<SiteTypeEnum, List<Site>> siteMap, CellBelMapping.Builder mapping, EDIFCell topLevelCell, EDIFCell cell, Design design) {
+    public static void populateCellBelPin(StringEnumerator allStrings,
+                                          Map<SiteTypeEnum, List<Site>> siteMap,
+                                          CellBelMapping.Builder mapping,
+                                          EDIFCell topLevelCell,
+                                          EDIFCell cell,
+                                          Design design,
+                                          DeviceResources.Device.Builder devBuilder,
+                                          DelayModel intrasiteAndLogicDelayModel) {
         mapping.setCell(allStrings.getIndex(cell.getName()));
         EDIFCellInst cellInst = new EDIFCellInst("test", cell, topLevelCell);
         Cell physCell = design.createCell("test", cellInst);
@@ -732,6 +745,14 @@ public class EnumerateCellBelMapping {
         cellInst = null;
 
         EnumerateCellBelMapping data = new EnumerateCellBelMapping();
+
+        class PinDelayEntry {
+            BELPin firstPin;
+            BELPin secondPin;
+            int delayPs;
+            SiteTypeEnum site;
+        }
+        List<PinDelayEntry> pinDelays = (intrasiteAndLogicDelayModel != null) ?  new ArrayList<>() : null;
 
         for (Map.Entry<SiteTypeEnum, String> possibleSite : entries) {
             SiteTypeEnum siteType = possibleSite.getKey();
@@ -774,6 +795,41 @@ public class EnumerateCellBelMapping {
                         design.removeSiteInst(siteInst);
                         topLevelCell.removeCellInst("test");
                         design.getTopEDIFCell().removeCellInst("test");
+
+                        // Extract pin-to-pin logic delays
+                        if (intrasiteAndLogicDelayModel != null) {
+                            Short belIdx = intrasiteAndLogicDelayModel.getBELIndex(bel);
+                            if (belIdx != null) {
+                                BEL belObject = physCell.getBEL();
+                                BELPin[] belPins = belObject.getPins();
+                                int highestInput = belObject.getHighestInputIndex();
+                                for (int i = 0; i <= highestInput; i++) {
+                                    BELPin ipin = belPins[i];
+                                    int o;
+                                    if (ipin.isClock()) {
+                                        // For clock pins, also check against other inputs to extract setup time
+                                        o = 0;
+                                    } else {
+                                        o = highestInput + 1;
+                                    }
+                                    for (; o < belPins.length; o++) {
+                                        if (o == i) {
+                                            continue;
+                                        }
+                                        BELPin opin = belPins[o];
+                                        Short delayPs = intrasiteAndLogicDelayModel.getLogicDelay(belIdx, ipin.getName(), opin.getName());
+                                        if (delayPs != null && delayPs != 0) {
+                                            PinDelayEntry e = new PinDelayEntry();
+                                            e.firstPin = ipin;
+                                            e.secondPin = opin;
+                                            e.delayPs = delayPs;
+                                            e.site = siteType;
+                                            pinDelays.add(e);
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     } else {
                         data.addInstance(siteType, site, bel, pinMapping, parameters);
                     }
@@ -782,9 +838,56 @@ public class EnumerateCellBelMapping {
         }
 
         data.writeMapping(allStrings, mapping);
+
+        // Write out all unique pin-pin logic delays
+        if (intrasiteAndLogicDelayModel != null) {
+            Map<SiteTypeEnum, Integer> siteType2index = new EnumMap<>(SiteTypeEnum.class);
+            Map<SiteTypeEnum, Map<BELPin, Integer>> siteType2belPin2index = new EnumMap<>(SiteTypeEnum.class);
+
+            // First, re-parse the siteTypeList to extract site-type and bel-pin indices
+            StructList.Reader<DeviceResources.Device.SiteType.Reader> siteTypesReader = devBuilder.asReader().getSiteTypeList();
+            int siteTypeIndex = 0;
+            for (DeviceResources.Device.SiteType.Reader st : siteTypesReader) {
+                SiteTypeEnum siteType = SiteTypeEnum.valueOf(allStrings.get(st.getName()));
+                siteType2index.put(siteType, siteTypeIndex++);
+                Map<BELPin, Integer> belPin2index = new HashMap<>();
+                List<Site> siteList = siteMap.get(siteType);
+                Site site = siteList.get(0);
+                int belPinIndex = 0;
+                for (DeviceResources.Device.BELPin.Reader bpr : st.getBelPins()) {
+                    String bel = allStrings.get(bpr.getBel());
+                    String pin = allStrings.get(bpr.getName());
+                    BELPin bp = site.getBELPin(bel, pin);
+                    belPin2index.put(bp, belPinIndex++);
+                }
+                siteType2belPin2index.put(siteType, belPin2index);
+            }
+
+            StructList.Builder<DeviceResources.Device.PinsDelay.Builder> pinDelaysBuilder = mapping.initPinsDelay(pinDelays.size());
+            Iterator<DeviceResources.Device.PinsDelay.Builder> pinDelaysIt = pinDelaysBuilder.iterator();
+            for (PinDelayEntry e : pinDelays) {
+                DeviceResources.Device.PinsDelay.Builder pd = pinDelaysIt.next();
+                Map<BELPin, Integer> belPin2index = siteType2belPin2index.get(e.site);
+                pd.initFirstPin().setPin(belPin2index.get(e.firstPin));
+                pd.initSecondPin().setPin(belPin2index.get(e.secondPin));
+                pd.initCornerModel().initSlow().initSlow().initMax().setMax(e.delayPs * 1e-12f);
+                DeviceResources.Device.PinsDelayType type;
+                if (e.firstPin.isClock()) {
+                    if (e.secondPin.isInput()) {
+                        type = DeviceResources.Device.PinsDelayType.SETUP;
+                    } else {
+                        type = DeviceResources.Device.PinsDelayType.CLK2Q;
+                    }
+                } else {
+                    type = DeviceResources.Device.PinsDelayType.COMB;
+                }
+                pd.setPinsDelayType(type);
+                pd.setSite(siteType2index.get(e.site));
+            }
+        }
     }
 
-    public static void populateAllPinMappings(String part, Device device, DeviceResources.Device.Builder devBuilder, StringEnumerator allStrings) {
+    public static void populateAllPinMappings(String part, Device device, DeviceResources.Device.Builder devBuilder, StringEnumerator allStrings, DelayModel intrasiteAndLogicDelayModel) {
         Design design = new Design("top", part);
 
         EDIFLibrary prims = Design.getPrimitivesLibrary(design.getDevice().getName());
@@ -820,7 +923,7 @@ public class EnumerateCellBelMapping {
         StructList.Builder<CellBelMapping.Builder> cellMapping = devBuilder.initCellBelMap(count);
         for (EDIFCell cell : prims.getCells()) {
             if (!macroCells.contains(cell.getName())) {
-                populateCellBelPin(allStrings, siteMap, cellMapping.get(i), topLevelCell, cell, design);
+                populateCellBelPin(allStrings, siteMap, cellMapping.get(i), topLevelCell, cell, design, devBuilder, intrasiteAndLogicDelayModel);
                 i += 1;
             }
         }
@@ -844,7 +947,7 @@ public class EnumerateCellBelMapping {
 
         MessageBuilder message = new MessageBuilder();
         DeviceResources.Device.Builder devBuilder = message.initRoot(DeviceResources.Device.factory);
-        populateAllPinMappings(args[0], device, devBuilder, allStrings);
+        populateAllPinMappings(args[0], device, devBuilder, allStrings, null);
 
         t.stop().printSummary();
     }

--- a/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
+++ b/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
@@ -876,6 +876,7 @@ public class EnumerateCellBelMapping {
                     if (e.secondPin.isInput()) {
                         type = DeviceResources.Device.PinsDelayType.SETUP;
                     } else {
+                        assert(e.secondPin.isOutput());
                         type = DeviceResources.Device.PinsDelayType.CLK2Q;
                     }
                 } else {

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -580,15 +580,17 @@ public class RouterHelper {
      * @param node The node in question.
      * @return The delay of the node.
      */
-    public static short computeNodeDelay(DelayEstimatorBase estimator, Node node, boolean includeSegmentation, boolean includeDiscontinuity) {
+    public static short computeNodeDelay(DelayEstimatorBase estimator, Node node, boolean includeBase, boolean includeDiscontinuity) {
         if (RouteNode.isExitNode(node)) {
-            return estimator.getDelayOf(node, includeSegmentation, includeDiscontinuity);
+            return estimator.getDelayOf(node, includeBase, includeDiscontinuity);
         }
         return 0;
     }
 
     public static short computeNodeDelay(DelayEstimatorBase estimator, Node node) {
-        return computeNodeDelay(estimator, node, true, true);
+        boolean includeBase = true;
+        boolean includeDiscontinuity = true;
+        return computeNodeDelay(estimator, node, includeBase, includeDiscontinuity);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -580,11 +580,15 @@ public class RouterHelper {
      * @param node The node in question.
      * @return The delay of the node.
      */
-    public static short computeNodeDelay(DelayEstimatorBase estimator, Node node) {
+    public static short computeNodeDelay(DelayEstimatorBase estimator, Node node, boolean includeSegmentation, boolean includeDiscontinuity) {
         if (RouteNode.isExitNode(node)) {
-            return estimator.getDelayOf(node);
+            return estimator.getDelayOf(node, includeSegmentation, includeDiscontinuity);
         }
         return 0;
+    }
+
+    public static short computeNodeDelay(DelayEstimatorBase estimator, Node node) {
+        return computeNodeDelay(estimator, node, true, true);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2021 Ghent University.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Yun Zhou, Ghent University.

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -188,6 +188,7 @@ public class TimingAndWirelengthReport{
         DesignTools.createMissingSitePinInsts(design);
         RWRouteConfig config = new RWRouteConfig(new String[0]);
         config.setTimingDriven(true);
+        config.setUseUTurnNodes(true);
         final boolean isPartialRouting = false;
         TimingAndWirelengthReport reporter = new TimingAndWirelengthReport(design, config, isPartialRouting);
         reporter.computeStatisticsAndReport();

--- a/src/com/xilinx/rapidwright/timing/DelayModel.java
+++ b/src/com/xilinx/rapidwright/timing/DelayModel.java
@@ -25,8 +25,6 @@
 package com.xilinx.rapidwright.timing;
 
 
-import java.util.List;
-
 import com.xilinx.rapidwright.device.SiteTypeEnum;
 
 
@@ -79,7 +77,7 @@ public interface DelayModel {
      * @return Logic delay in ps. Return -1 if the connection does not exist.
      * @throws  IllegalArgumentException if the given bel is not recognized by the model.
      */
-    public short getLogicDelay(short belIdx, String frBelPin, String toBelPin, int encodedConfig);
+    public Short getLogicDelay(short belIdx, String frBelPin, String toBelPin, int encodedConfig);
 
     /**
      * Get the delay between input and output pins of a bel.
@@ -90,7 +88,7 @@ public interface DelayModel {
      * @return Logic delay in ps. Return -1 if the connection does not exist.
      * @throws  IllegalArgumentException if the given bel is not recognized by the model.
      */
-     public short getLogicDelay(short belIdx, String frBelPin, String toBelPin);
+     public Short getLogicDelay(short belIdx, String frBelPin, String toBelPin);
 
      /**
       * TODO - Revisit this as part of the DelayModel
@@ -105,7 +103,7 @@ public interface DelayModel {
       * @param belName Name of the BEL
       * @return The unique BEL timing model index
       */
-     public short getBELIndex(String belName);
+     public Short getBELIndex(String belName);
 }
 
 

--- a/src/com/xilinx/rapidwright/timing/DelayModel.java
+++ b/src/com/xilinx/rapidwright/timing/DelayModel.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2019-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022, 2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Pongstorn Maidee, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/timing/DelayModelBuilder.java
+++ b/src/com/xilinx/rapidwright/timing/DelayModelBuilder.java
@@ -37,7 +37,7 @@ import java.util.List;
  * Never construct DelayModel directly. DelayModelBuilder guarantees that there is at most one DelayModel
  * ie., DelayModelBuilder returns the existing model.
  */
-class DelayModelBuilder {
+public class DelayModelBuilder {
 
     // Adding new mode or source requires appending them to the end of valid_mode or valid_source.
     // Never change the order of existing entries.

--- a/src/com/xilinx/rapidwright/timing/DelayModelBuilder.java
+++ b/src/com/xilinx/rapidwright/timing/DelayModelBuilder.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2019-2022, Xilinx, Inc.
- * Copyright (c) 2022, 2024, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Pongstorn Maidee, Xilinx Research Labs.
@@ -37,7 +37,7 @@ import java.util.List;
  * Never construct DelayModel directly. DelayModelBuilder guarantees that there is at most one DelayModel
  * ie., DelayModelBuilder returns the existing model.
  */
-public class DelayModelBuilder {
+class DelayModelBuilder {
 
     // Adding new mode or source requires appending them to the end of valid_mode or valid_source.
     // Never change the order of existing entries.

--- a/src/com/xilinx/rapidwright/timing/DelayModelBuilder.java
+++ b/src/com/xilinx/rapidwright/timing/DelayModelBuilder.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2019-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022, 2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Pongstorn Maidee, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/timing/SmallDelayModel.java
+++ b/src/com/xilinx/rapidwright/timing/SmallDelayModel.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2019-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022, 2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Pongstorn Maidee, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/timing/SmallDelayModel.java
+++ b/src/com/xilinx/rapidwright/timing/SmallDelayModel.java
@@ -58,7 +58,7 @@ public class SmallDelayModel implements DelayModel {
         return configCodeMap.getOrDefault(value, 0);
     }
 
-    public short getBELIndex(String belName) {
+    public Short getBELIndex(String belName) {
         return bel2IdxMap.get(belName);
     }
 
@@ -67,7 +67,7 @@ public class SmallDelayModel implements DelayModel {
      */
     public Short getIntraSiteDelay(SiteTypeEnum siteTypeName, String frBelPin, String toBelPin) {
         boolean verbose = false;
-        Short delay = null;
+        Short delay;
         Short idx = site2IdxMap.get(siteTypeName.name());
         if (idx == null) {
             return null;
@@ -78,7 +78,6 @@ public class SmallDelayModel implements DelayModel {
             String key = idx + frBelPin + toBelPin;
             delay = intraSiteDelays.get(key);
             if (delay == null) {
-                delay = -2;
                 if (verbose) {
                     System.out.println("WARNING in SmallDelayModel: Unknown connection to getIntraSiteDelay."
                             + "  site/belName " + siteTypeName + "  frBelPin " + frBelPin + "  toBelPin " + toBelPin);
@@ -91,15 +90,16 @@ public class SmallDelayModel implements DelayModel {
     /**
      *  Implement the method with the same signature defined in DelayModel interface.
      */
-    public short getLogicDelay(short belIdx, String frBelPin, String toBelPin) {
+    public Short getLogicDelay(short belIdx, String frBelPin, String toBelPin) {
         return getLogicDelay(belIdx, frBelPin, toBelPin, 0);
     }
 
     /**
      *  Implement the method with the same signature defined in DelayModel interface.
      */
-    public short getLogicDelay(short belIdx, String frBelPin, String toBelPin, int encodedConfig) {
-        Short delay = -2;
+    public Short getLogicDelay(short belIdx, String frBelPin, String toBelPin, int encodedConfig) {
+        boolean verbose = false;
+        Short delay = null;
 
         // Certain that the following combination do not cause duplication. Otherwise, separators must be added.
         String key = belIdx + frBelPin + toBelPin;
@@ -113,6 +113,11 @@ public class SmallDelayModel implements DelayModel {
                     delay = (short) entry[0];
                     break;
                 }
+            }
+        } else {
+            if (verbose) {
+                System.out.println("WARNING in SmallDelayModel: Unknown connection to getLogicDelay."
+                        + "  belIdx " + belIdx + "  frBelPin " + frBelPin + "  toBelPin " + toBelPin);
             }
         }
         return delay;

--- a/src/com/xilinx/rapidwright/timing/delayestimator/DelayEstimatorBase.java
+++ b/src/com/xilinx/rapidwright/timing/delayestimator/DelayEstimatorBase.java
@@ -119,15 +119,15 @@ public class DelayEstimatorBase<T extends InterconnectInfo> implements java.io.S
         return 0;
     }
 
-    public short getDelayOf(Node exitNode, boolean includeSegmentation, boolean includeDiscontinuity) {
+    public short getDelayOf(Node exitNode, boolean includeBase, boolean includeDiscontinuity) {
         TermInfo termInfo = getTermInfo(exitNode);
 
         // Don't put this in calcTimingGroupDelay because it is called many times to estimate delay.
-        if (termInfo.ng == T.NodeGroupType.CLE_IN) {
+        if (includeBase && termInfo.ng == T.NodeGroupType.CLE_IN) {
             return inputSitePinDelay.getOrDefault(exitNode.getWireName(), (short) 0);
         }
 
-        return calcNodeGroupDelay(termInfo.ng, termInfo.begin(), termInfo.end(), includeSegmentation, includeDiscontinuity);
+        return calcNodeGroupDelay(termInfo.ng, termInfo.begin(), termInfo.end(), includeBase, includeDiscontinuity);
     }
 
 
@@ -429,13 +429,13 @@ public class DelayEstimatorBase<T extends InterconnectInfo> implements java.io.S
      * @return delay of the tg. When useUTurnNodes was set to false, return Short.MAX_VALUE/2 if the node graph is a U-turn.
      *         to indicate the node graph should be ignored.
      */
-    short calcNodeGroupDelay(T.NodeGroupType tg, short begLoc, short endLoc, boolean includeSegmentation, boolean includeDiscontinuity) {
-        short segDelay = (includeSegmentation) ? calcNodeSegmentationDelay(tg) : 0;
+    short calcNodeGroupDelay(T.NodeGroupType tg, short begLoc, short endLoc, boolean includeBase, boolean includeDiscontinuity) {
+        short segDelay = (includeBase) ? calcNodeBaseDelay(tg) : 0;
         short disDelay = (includeDiscontinuity) ? calcNodeDiscontinuityDelay(tg, begLoc, endLoc) : 0;
         return (short) (segDelay + disDelay);
     }
 
-    short calcNodeSegmentationDelay(T.NodeGroupType tg) {
+    short calcNodeBaseDelay(T.NodeGroupType tg) {
         float k0 = K0.get(tg.orientation()).get(tg.type());
         float k1 = K1.get(tg.orientation()).get(tg.type());
         short l  = L .get(tg.orientation()).get(tg.type());

--- a/src/com/xilinx/rapidwright/timing/delayestimator/DelayEstimatorBase.java
+++ b/src/com/xilinx/rapidwright/timing/delayestimator/DelayEstimatorBase.java
@@ -119,6 +119,17 @@ public class DelayEstimatorBase<T extends InterconnectInfo> implements java.io.S
         return 0;
     }
 
+    public short getDelayOf(Node exitNode, boolean includeSegmentation, boolean includeDiscontinuity) {
+        TermInfo termInfo = getTermInfo(exitNode);
+
+        // Don't put this in calcTimingGroupDelay because it is called many times to estimate delay.
+        if (termInfo.ng == T.NodeGroupType.CLE_IN) {
+            return inputSitePinDelay.getOrDefault(exitNode.getWireName(), (short) 0);
+        }
+
+        return calcNodeGroupDelay(termInfo.ng, termInfo.begin(), termInfo.end(), includeSegmentation, includeDiscontinuity);
+    }
+
 
     /**
      * Get delay of the node group of the given exit node.
@@ -127,14 +138,7 @@ public class DelayEstimatorBase<T extends InterconnectInfo> implements java.io.S
      * @return delay in ps
      */
     public short getDelayOf(Node exitNode) {
-        TermInfo termInfo = getTermInfo(exitNode);
-
-        // Don't put this in calcTimingGroupDelay because it is called many times to estimate delay.
-        if (termInfo.ng == T.NodeGroupType.CLE_IN) {
-            return inputSitePinDelay.getOrDefault(exitNode.getWireName(), (short) 0);
-        }
-
-        return calcNodeGroupDelay(termInfo.ng, termInfo.begin(), termInfo.end());
+        return getDelayOf(exitNode, true, true);
     }
 
     /**
@@ -206,7 +210,7 @@ public class DelayEstimatorBase<T extends InterconnectInfo> implements java.io.S
     }
 
 
-    private TermInfo getTermInfo(Node node) {
+    public TermInfo getTermInfo(Node node) {
 
         String nodeType = node.getWireName();
         // Based on its name, WW1_E should go be horizontal single. However, it go to the north like NN1_E.
@@ -425,7 +429,20 @@ public class DelayEstimatorBase<T extends InterconnectInfo> implements java.io.S
      * @return delay of the tg. When useUTurnNodes was set to false, return Short.MAX_VALUE/2 if the node graph is a U-turn.
      *         to indicate the node graph should be ignored.
      */
-    short calcNodeGroupDelay(T.NodeGroupType tg, short begLoc, short endLoc) {
+    short calcNodeGroupDelay(T.NodeGroupType tg, short begLoc, short endLoc, boolean includeSegmentation, boolean includeDiscontinuity) {
+        short segDelay = (includeSegmentation) ? calcNodeSegmentationDelay(tg) : 0;
+        short disDelay = (includeDiscontinuity) ? calcNodeDiscontinuityDelay(tg, begLoc, endLoc) : 0;
+        return (short) (segDelay + disDelay);
+    }
+
+    short calcNodeSegmentationDelay(T.NodeGroupType tg) {
+        float k0 = K0.get(tg.orientation()).get(tg.type());
+        float k1 = K1.get(tg.orientation()).get(tg.type());
+        short l  = L .get(tg.orientation()).get(tg.type());
+        return (short) (k0 + k1 * l);
+    }
+
+    short calcNodeDiscontinuityDelay(T.NodeGroupType tg, short begLoc, short endLoc) {
         int size = (tg.orientation() == T.Orientation.HORIZONTAL) ? numCol : numRow;
         short d = 0;
         List<Short> dArray = distArrays.get(tg.orientation()).get(tg.type());
@@ -451,11 +468,7 @@ public class DelayEstimatorBase<T extends InterconnectInfo> implements java.io.S
             }
         }
 
-        float k0 = K0.get(tg.orientation()).get(tg.type());
-        float k1 = K1.get(tg.orientation()).get(tg.type());
         float k2 = K2.get(tg.orientation()).get(tg.type());
-        short l  = L .get(tg.orientation()).get(tg.type());
-
-        return (short) (k0 + k1 * l + k2 * d);
+        return (short) (k2 * d);
     }
 }

--- a/src/com/xilinx/rapidwright/timing/delayestimator/DelayEstimatorBase.java
+++ b/src/com/xilinx/rapidwright/timing/delayestimator/DelayEstimatorBase.java
@@ -210,7 +210,7 @@ public class DelayEstimatorBase<T extends InterconnectInfo> implements java.io.S
     }
 
 
-    public TermInfo getTermInfo(Node node) {
+    private TermInfo getTermInfo(Node node) {
 
         String nodeType = node.getWireName();
         // Based on its name, WW1_E should go be horizontal single. However, it go to the north like NN1_E.

--- a/src/com/xilinx/rapidwright/timing/delayestimator/DelayEstimatorBase.java
+++ b/src/com/xilinx/rapidwright/timing/delayestimator/DelayEstimatorBase.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2021-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Pongstorn Maidee, Xilinx Research Labs.

--- a/test/src/com/xilinx/rapidwright/interchange/TestCellBELMappings.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestCellBELMappings.java
@@ -23,22 +23,23 @@
 
 package com.xilinx.rapidwright.interchange;
 
-import org.capnproto.MessageBuilder;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.interchange.DeviceResources.Device.CellBelMapping;
 import com.xilinx.rapidwright.interchange.DeviceResources.Device.CellBelPinEntry;
 import com.xilinx.rapidwright.interchange.DeviceResources.Device.ParameterCellBelPinMaps;
+import org.capnproto.MessageBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestCellBELMappings {
 
-    @Test
-    public void testCellBELPinMappings() {
+    @ParameterizedTest
+    @ValueSource(strings = {"xcau10p", "xc7a15t"})
+    public void testCellBELPinMappings(String deviceName) {
         StringEnumerator allStrings = new StringEnumerator();
         MessageBuilder message = new MessageBuilder();
-        Device device = Device.getDevice(TestDeviceResources.TEST_DEVICE);
+        Device device = Device.getDevice(deviceName);
         DeviceResources.Device.Builder devBuilder = message.initRoot(DeviceResources.Device.factory);
         EnumerateCellBelMapping.populateAllPinMappings(device.getName(), device, devBuilder, allStrings);
 

--- a/test/src/com/xilinx/rapidwright/interchange/TestCellBELMappings.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestCellBELMappings.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.

--- a/test/src/com/xilinx/rapidwright/interchange/TestCellBELMappings.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestCellBELMappings.java
@@ -41,7 +41,7 @@ public class TestCellBELMappings {
         MessageBuilder message = new MessageBuilder();
         Device device = Device.getDevice(deviceName);
         DeviceResources.Device.Builder devBuilder = message.initRoot(DeviceResources.Device.factory);
-        EnumerateCellBelMapping.populateAllPinMappings(device.getName(), device, devBuilder, allStrings);
+        EnumerateCellBelMapping.populateAllPinMappings(device.getName(), device, devBuilder, allStrings, null);
 
         boolean foundIDDRS = false;
         boolean foundIDDRR = false;

--- a/test/src/com/xilinx/rapidwright/interchange/TestDeviceResources.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestDeviceResources.java
@@ -23,28 +23,25 @@
 
 package com.xilinx.rapidwright.interchange;
 
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.tests.CodePerfTracker;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
-import com.xilinx.rapidwright.device.Device;
-import com.xilinx.rapidwright.tests.CodePerfTracker;
-
 public class TestDeviceResources {
 
-    public static final String TEST_DEVICE = "xc7a15t";
-
-    @Test
-    public void testDeviceResources(@TempDir Path tempDir) throws IOException {
-        Path capnProtoFile = tempDir.resolve(TEST_DEVICE + ".device");
-        Device device = Device.getDevice(TEST_DEVICE);
+    @ParameterizedTest
+    @ValueSource(strings = {"xcau10p", "xc7a15t"})
+    public void testDeviceResources(String deviceName, @TempDir Path tempDir) throws IOException {
+        Path capnProtoFile = tempDir.resolve(deviceName + ".device");
+        Device device = Device.getDevice(deviceName);
         DeviceResourcesWriter.writeDeviceResourcesFile(
-                TEST_DEVICE, device, CodePerfTracker.SILENT, capnProtoFile.toString());
+                deviceName, device, CodePerfTracker.SILENT, capnProtoFile.toString());
         Device.releaseDeviceReferences();
-        DeviceResourcesVerifier.verifyDeviceResources(capnProtoFile.toString(), TEST_DEVICE);
+        DeviceResourcesVerifier.verifyDeviceResources(capnProtoFile.toString(), deviceName);
     }
-
-
 }

--- a/test/src/com/xilinx/rapidwright/interchange/TestDeviceResources.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestDeviceResources.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022, 2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.


### PR DESCRIPTION
Max delay timings for the following UltraScale+ resources, as described initially by [Maidee et al. -- An Open-source Lightweight Timing Model for RapidWright](http://www.rapidwright.io/docs/_downloads/FPT19-TimingModel.pdf) and subsequently implemented in RapidWright: 
1. PIPs (referencing a delay in seconds at `Device.pipTimings.internalDelay.slow.slow.max.max`, capturing the "base" *k0+k1\*L(TG)* component of paper's Equation 1)
2. Nodes (referencing the additional delay in seconds made up of `Device.nodeTimings.capacitance` * `Device.nodeTimings.resistance`, capturing the "discontinuity" *k2\*d(TG)* component of paper's Equation 1; see footnote A)
3. SitePIP delays (`SitePIP.delay.slow.slow.max.max` in seconds)
4. Cell delays (`CellBelMapping.pinsDelay.cornerModel.slow.slow.max.max` in seconds)

Footnote A -- due to there not being a delay field in [`NodeTiming`](https://github.com/chipsalliance/fpga-interchange-schema/blob/c985b4648e66414b250261c1ba4cbe45a2971b1c/interchange/DeviceResources.capnp#L649-L653), the discontinuity delay of specific nodes (i.e. those that cross BRAM/URAM/DSP/IO/etc. columns) is captured using the product of the `NodeTiming.capacitance` and `NodeTiming.resistance` fields (*T=RC*) for a value in second. In this implementation, *C* is fixed to 1e-12 meaning that *R* represents the delay in picoseconds.

Since bidirectional PIPs (e.g. `INT_X0Y0/INT.INT_NODE_IMUX_5_INT_OUT0<<->>BYPASS_E8`) can only reference one delay value, only the forward delay (`INT_NODE_*->>BYPASS_E8`) is captured.