### PR TITLE
Fix null netlist pointer on expanded macro children

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1713,6 +1713,8 @@ public class EDIFNetlist extends EDIFName {
                 if (child == null) {
                     EDIFCell childCopy = new EDIFCell(netlistPrims, inst.getCellType(), inst.getCellType().getName());
                     inst.setCellType(childCopy);
+                } else if (inst.getCellType() != child) {
+                    inst.setCellType(child);
                 }
             }
         }


### PR DESCRIPTION
For some macros, during expansion, some of their children are present in the netlist but don't have the proper pointer back to the main netlist object.  This ensure that the copy of the cell has the correct pointers.