### PR TITLE
[Interchange] Exports DeviceResources Routing (Wires and Nodes) Info in Multiple Messages

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesExample.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesExample.java
@@ -45,7 +45,8 @@ public class DeviceResourcesExample {
         }
 
         CodePerfTracker t = new CodePerfTracker("Device Resources Dump: " + args[0]);
-        t.useGCToTrackMemory(true);
+        t.setReportingCurrOSMemUsage(true);
+        t.setTrackOSMemUsage(true);
 
         // Create device resource file if it doesn't exist
         String capnProtoFileName = args[0] + ".device";
@@ -56,10 +57,10 @@ public class DeviceResourcesExample {
         DeviceResourcesWriter.writeDeviceResourcesFile(args[0], device, t, capnProtoFileName, skipRouteResources);
         Device.releaseDeviceReferences();
 
-        t.start("Verify file");
         // Verify device resources
-        DeviceResourcesVerifier.verifyDeviceResources(capnProtoFileName, args[0]);
+        DeviceResourcesVerifier.verifyDeviceResources(capnProtoFileName, args[0], t);
 
-        t.stop().printSummary();
+        t.printSummary();
+        System.out.println("Device resources file '" + capnProtoFileName + "' written successfully");
     }
 }

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -24,6 +24,8 @@
 package com.xilinx.rapidwright.interchange;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.channels.ReadableByteChannel;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,6 +57,7 @@ import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Grade;
 import com.xilinx.rapidwright.device.IOStandard;
+import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.PIPType;
 import com.xilinx.rapidwright.device.Package;
@@ -66,6 +69,7 @@ import com.xilinx.rapidwright.device.SitePIP;
 import com.xilinx.rapidwright.device.SiteTypeEnum;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.TileTypeEnum;
+import com.xilinx.rapidwright.device.Wire;
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFDesign;
@@ -90,6 +94,7 @@ import com.xilinx.rapidwright.interchange.DeviceResources.Device.TileType;
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist;
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist.Direction;
 import com.xilinx.rapidwright.interchange.LogicalNetlist.Netlist.PropertyMap;
+import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.Pair;
 
 public class DeviceResourcesVerifier {
@@ -130,7 +135,9 @@ public class DeviceResourcesVerifier {
         expect(pin.getBEL().getName(), allStrings.get(belPin.getBel()));
     }
 
-    public static boolean verifyDeviceResources(String devResFileName, String deviceName) throws IOException {
+    public static boolean verifyDeviceResources(String devResFileName, String deviceName, CodePerfTracker t)
+            throws IOException {
+        t.start("*Verify  Init");
         allStrings = new StringEnumerator();
         verifiedSiteTypes = new HashSet<SiteTypeEnum>();
 
@@ -143,11 +150,13 @@ public class DeviceResourcesVerifier {
         DeviceResources.Device.Reader dReader = null;
         ReaderOptions readerOptions = new ReaderOptions(1024L * 1024L * 1024L * 64L, 64);
         MessageReader readMsg = null;
-        readMsg = Interchange.readInterchangeFile(devResFileName, readerOptions);
+        ReadableByteChannel rbc = Interchange.getReadableByteChannel(devResFileName);
+
+        readMsg = Interchange.readMessageFromChannel(rbc, readerOptions);
 
         dReader = readMsg.getRoot(DeviceResources.Device.factory);
 
-        boolean containsRoutingResources = dReader.getNodes().size() > 0;
+        boolean containsMultiMessageRoutingResources = !dReader.hasNodes();
         
         int strCount = dReader.getStrList().size();
         TextList.Reader reader = dReader.getStrList();
@@ -155,6 +164,8 @@ public class DeviceResourcesVerifier {
             String str = reader.get(i).toString();
             allStrings.addObject(str);
         }
+
+        t.stop().start("*Verify  Tiles & Sites");
 
         // Create a lookup map for tile types
         Map<String,TileType.Reader> tileTypeMap = new HashMap<String, TileType.Reader>();
@@ -477,13 +488,15 @@ public class DeviceResourcesVerifier {
             }
         }
 
+        t.stop().start("*Verify  Libraries");
+
         Netlist.Reader primLibs = dReader.getPrimLibs();
         LogNetlistReader netlistReader = new LogNetlistReader(allStrings, new HashMap<String, String>() {{
                     put(LogNetlistWriter.DEVICE_PRIMITIVES_LIB, EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME);
                 }}
             );
         EDIFNetlist primsAndMacros = netlistReader.readLogNetlist(primLibs,
-                /*skipTopStuff=*/true, /*expandMacros=*/false);
+                /* skipTopStuff= */true, /* expandMacros= */false, CodePerfTracker.SILENT);
 
         Set<String> libsFound = new HashSet<String>();
         libsFound.addAll(primsAndMacros.getLibrariesMap().keySet());
@@ -617,16 +630,87 @@ public class DeviceResourcesVerifier {
             }
         }
 
+        t.stop().start("*Verify  CellBelPins");
         verifyCellBelPinMaps(allStrings, dReader, design);
+        t.stop().start("*Verify  Packages");
         verifyPackages(allStrings, dReader, device);
+        t.stop();
 
-        if (containsRoutingResources) {
-            ConstantDefinitions.verifyConstants(allStrings, device, design, siteTypes, dReader.getConstants(), tileTypeEnumMap);            
+        if (containsMultiMessageRoutingResources) {
+            t.start("*Verify  Constants");
+            ConstantDefinitions.verifyConstants(allStrings, device, design, siteTypes, 
+                    dReader.getConstants(), tileTypeEnumMap);
+            t.stop().start("*Verify  Nodes & Wires");
+            verifyWireAndNodeMultiMessage(device, allStrings, rbc, readerOptions);
+            t.stop();
         }
 
-
+        rbc.close();
         return true;
     }
+    
+    private static void verifyWireAndNodeMultiMessage(Device device, StringEnumerator allStrings,
+            ReadableByteChannel rbc, ReaderOptions options) {
+        int numOfMessages = device.getRows();
+        
+        for (int row = 0; row < numOfMessages; row++) {
+            LongEnumerator allWires = new LongEnumerator();
+            DeviceResources.Device.Reader deviceReader = null;
+            try {
+                MessageReader mReader = Interchange.readMessageFromChannel(rbc, options);
+                deviceReader = mReader.getRoot(DeviceResources.Device.factory);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            StructList.Reader<DeviceResources.Device.Wire.Reader> wires = deviceReader.getWires();
+            StructList.Reader<DeviceResources.Device.Node.Reader> nodeList = deviceReader.getNodes();
+
+            int wireIdx = 0;
+            int nodeIdx = 0;
+            for (Tile tile : device.getTiles()[row]) {
+                for (int i = 0; i < tile.getWireCount(); i++) {
+                    Wire wire = new Wire(tile, i);
+                    long key = DeviceResourcesWriter.makeKey(wire.getTile(), wire.getWireIndex());
+                    Integer test = allWires.maybeGetIndex(key);
+                    if (test == null) {
+                        allWires.addObject(key);
+                        DeviceResources.Device.Wire.Reader readWire = wires.get(wireIdx++);
+                        expect(tile.getName(), allStrings.get(readWire.getTile()));
+                        expect(wire.getWireName(), allStrings.get(readWire.getWire()));
+                        expect(wire.getIntentCode().ordinal(), readWire.getType());                        
+                    }
+
+                    Node node = Node.getNode(wire);
+                    if (node != null && node.getTile() == tile && node.getWireIndex() == i) {
+                        Wire[] nodeWires = node.getAllWiresInNode();
+                        for (Wire w : nodeWires) {
+                            long nodeWireKey = DeviceResourcesWriter.makeKey(w.getTile(), w.getWireIndex());
+                            test = allWires.maybeGetIndex(nodeWireKey);
+                            if (test == null) {
+                                allWires.addObject(nodeWireKey);
+                                DeviceResources.Device.Wire.Reader readWire = wires.get(wireIdx++);
+                                expect(w.getTile().getName(), allStrings.get(readWire.getTile()));
+                                expect(w.getWireName(), allStrings.get(readWire.getWire()));
+                                expect(w.getIntentCode().ordinal(), readWire.getType());
+                            }
+                        }
+                        DeviceResources.Device.Node.Reader readNode = nodeList.get(nodeIdx++);
+                        PrimitiveList.Int.Reader readNodeWires = readNode.getWires();
+                        expect(nodeWires.length, readNodeWires.size());
+                        for (int j = 0; j < nodeWires.length; j++) {
+                            int wireKey = readNodeWires.get(j);
+                            Long wireEntry = allWires.get(wireKey);
+                            int tIdx = (int) (wireEntry >>> 32);
+                            int wIdx = (int) (wireEntry & 0xFFFFFFFF);
+                            expect(nodeWires[j].getTile().getUniqueAddress(), tIdx);
+                            expect(nodeWires[j].getWireIndex(), wIdx);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
 
     private static HashSet<SiteTypeEnum> verifiedSiteTypes;
 

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -24,6 +24,8 @@
 package com.xilinx.rapidwright.interchange;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -297,10 +299,17 @@ public class DeviceResourcesWriter {
         t.stop().start("Tiles");
         writeAllTilesToBuilder(device, devBuilder, tileTypeIndicies);
 
-        t.stop().start("Wires&Nodes");
-        writeAllWiresAndNodesToBuilder(device, devBuilder, skipRouteResources);
+        if (skipRouteResources) {
+            // Let's set wires and nodes to size 0
+            devBuilder.initWires(0);
+            devBuilder.initNodes(0);
+        } else {
+            // We'll add them as multiple messages after the main device message, one row of
+            // tiles' worth of wires and nodes at a time. We'll leave the wires and node
+            // field as an indicator that more messages will be present.
+        }
 
-        t.stop().start("Prims&Macros");
+        t.stop().start("Prims & Macros");
         // Create an EDIFNetlist populated with just primitive and macro libraries
         EDIFLibrary prims = Design.getPrimitivesLibrary(device.getName());
         EDIFLibrary macros = Design.getMacroPrimitives(series);
@@ -469,8 +478,15 @@ public class DeviceResourcesWriter {
         t.stop().start("Strings");
         writeAllStringsToBuilder(devBuilder);
 
-        t.stop().start("Write File");
-        Interchange.writeInterchangeFile(fileName, message);
+        t.stop().start("Write Device (single message)");
+        WritableByteChannel wbc = Interchange.getWritableByteChannel(fileName);
+        Interchange.writeMessageToChannel(wbc, message);
+
+        if (!skipRouteResources) {
+            t.stop().start("Write Wires & Nodes (multi-message)");
+            writeAllWiresAndNodesToMultipleMessages(device, wbc);
+        }
+        wbc.close();
         t.stop();
     }
 
@@ -809,10 +825,71 @@ public class DeviceResourcesWriter {
 
     }
 
-    private static long makeKey(Tile tile, int wire) {
+    protected static long makeKey(Tile tile, int wire) {
         long key = wire;
         key = (((long)tile.getUniqueAddress()) << 32) | key;
         return key;
+    }
+
+    public static void writeAllWiresAndNodesToMultipleMessages(Device device, WritableByteChannel wbc) {
+        // Write one message for each row of tiles in the device
+        int numOfMessages = device.getRows();
+
+        for (int m = 0; m < numOfMessages; m++) {
+            MessageBuilder message = new MessageBuilder();
+            DeviceResources.Device.Builder devBuilder = message.initRoot(DeviceResources.Device.factory);
+
+            LongEnumerator allWires = new LongEnumerator();
+            ArrayList<Long> allNodes = new ArrayList<>();
+
+            for (Tile tile : device.getTiles()[m]) {
+                for (int i = 0; i < tile.getWireCount(); i++) {
+                    Wire wire = new Wire(tile, i);
+                    allWires.addObject(makeKey(wire.getTile(), wire.getWireIndex()));
+
+                    Node node = wire.getNode();
+                    if (node != null && node.getTile() == tile && node.getWireIndex() == i) {
+                        allNodes.add(makeKey(node.getTile(), node.getWireIndex()));
+                        Wire[] nodeWires = node.getAllWiresInNode();
+                        for (Wire w : nodeWires) {
+                            allWires.addObject(makeKey(w.getTile(), w.getWireIndex()));
+                        }
+                    }
+                }
+            }
+
+            StructList.Builder<DeviceResources.Device.Wire.Builder> wireBuilders = devBuilder
+                    .initWires(allWires.size());
+
+            for (int i = 0; i < allWires.size(); i++) {
+                DeviceResources.Device.Wire.Builder wireBuilder = wireBuilders.get(i);
+                long wireKey = allWires.get(i);
+                Wire wire = new Wire(device.getTile((int) (wireKey >>> 32)), (int) (wireKey & 0xffffffff));
+                // Wire wire = allWires.get(i);
+                wireBuilder.setTile(allStrings.getIndex(wire.getTile().getName()));
+                wireBuilder.setWire(allStrings.getIndex(wire.getWireName()));
+                wireBuilder.setType(wire.getIntentCode().ordinal());
+            }
+
+            StructList.Builder<DeviceResources.Device.Node.Builder> nodeBuilders = devBuilder
+                    .initNodes(allNodes.size());
+            for (int i = 0; i < allNodes.size(); i++) {
+                DeviceResources.Device.Node.Builder nodeBuilder = nodeBuilders.get(i);
+                long nodeKey = allNodes.get(i);
+                Node node = Node.getNode(device.getTile((int) (nodeKey >>> 32)), (int) (nodeKey & 0xffffffff));
+                Wire[] wires = node.getAllWiresInNode();
+                PrimitiveList.Int.Builder wBuilders = nodeBuilder.initWires(wires.length);
+                for (int k = 0; k < wires.length; k++) {
+                    wBuilders.set(k, allWires.maybeGetIndex(makeKey(wires[k].getTile(), wires[k].getWireIndex())));
+                }
+            }
+
+            try {
+                Interchange.writeMessageToChannel(wbc, message);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
     }
 
     public static void writeAllWiresAndNodesToBuilder(Device device, DeviceResources.Device.Builder devBuilder,
@@ -862,6 +939,7 @@ public class DeviceResourcesWriter {
             }
         }
     }
+
     private static void populatePackages(StringEnumerator allStrings, Device device, DeviceResources.Device.Builder devBuilder) {
         Set<String> packages = device.getPackages();
         List<String> packagesList = new ArrayList<String>();

--- a/test/src/com/xilinx/rapidwright/interchange/TestDeviceResources.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestDeviceResources.java
@@ -43,7 +43,7 @@ public class TestDeviceResources {
         DeviceResourcesWriter.writeDeviceResourcesFile(
                 TEST_DEVICE, device, CodePerfTracker.SILENT, capnProtoFile.toString());
         Device.releaseDeviceReferences();
-        DeviceResourcesVerifier.verifyDeviceResources(capnProtoFile.toString(), TEST_DEVICE);
+        DeviceResourcesVerifier.verifyDeviceResources(capnProtoFile.toString(), TEST_DEVICE, CodePerfTracker.SILENT);
     }
 
 


### PR DESCRIPTION
Since RapidWright has exported Interchange data as a single message, there has been a limitation on exporting the routing information (specifically `Node` and `Wire` objects) because of the high number of these objects exceeded the message size limitations of Cap'n Proto.  

This PR attempts to resolve this issue by exporting the entire device first (without routing data) as a single message and then exporting multiple messages following.  After the initial device message, there is one message for each row of tiles in the device ( `Device.getRows()` in RapidWright or `get_property ROWS [get_parts [get_property PART [current_project]]]` in Vivado).  All of the `Wire` and `Node` objects that exist or are based in that row of tiles are included in the message.  

For example, if you were exporting the `xcvp1902` device (currently the largest device), there would be 1457 Cap'n Proto messages total in the file (1 device, 1456 routing).  In this scheme, the `DeviceResources.Device` object is the top level for both types of messages.  In the device message, the fields [`wires`](https://github.com/chipsalliance/fpga-interchange-schema/blob/c985b4648e66414b250261c1ba4cbe45a2971b1c/interchange/DeviceResources.capnp#L103) and [`nodes`](https://github.com/chipsalliance/fpga-interchange-schema/blob/c985b4648e66414b250261c1ba4cbe45a2971b1c/interchange/DeviceResources.capnp#L104) are set to `null` to signify that messages will come later to populate those fields.  In the routing messages, only the `wires` and `nodes` fields are populated with the wires and nodes that exist in that row of tiles.  If the device resources file is to be generated without routing resources, only one device message is written to the file and the `wires` and `nodes` entries will have a size of 0.

A verification step was added to verify these new messages could be read and that the wires and nodes match the RapidWright device model.  For large devices (like the xcvp1902, the verification process can take up to an hour or more depending on the host).  Also, it will require more Java heap memory and  `-Xmx32736m` (32GB) is a recommended option to the JVM.
