### PR TITLE
[DesignTools.makeBlackBox()] Remove flawed loop intended for encrypted cell removal

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1751,15 +1751,6 @@ public class DesignTools {
             }
             cells.add(c);
         }
-        // Find encrypted cells that need to be removed
-        if (d.getNetlist().getEncryptedCells().size() > 0) { 
-            String name = hierarchicalCell.getFullHierarchicalInstName();
-            for (Cell c : d.getCells()) {
-                if (c.getName().startsWith(name)) {
-                    cells.add(c);
-                }
-            }
-        }
 
         // Remove all placement and routing information related to the cell to be
         // blackboxed


### PR DESCRIPTION
In #1009, a bad loop was added in an attempt to remove cells that appeared to be in encrypted cells that were part of the black box.  This loop has a flaw in it in that any cells with similar names, but not in the black box can be removed accidentally.  This causes a failure on an internal test and so it is best removed for now.