### PR TITLE
[EDIFTools] writeTclLoadScriptForPartialEncryptedDesigns abspath

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1019,7 +1019,7 @@ public class EDIFTools {
         lines.add("read_checkpoint {" + pathDCPFileName + "}");
         lines.add("set_property top "+edif.getName()+" [current_fileset]");
         lines.add("link_design -part " + partName);
-        Path tclFileName = FileTools.replaceExtension(pathDCPFileName.getFileName(), LOAD_TCL_SUFFIX);
+        Path tclFileName = FileTools.replaceExtension(pathDCPFileName, LOAD_TCL_SUFFIX);
         try {
             Files.write(tclFileName, lines);
         } catch (IOException e) {


### PR DESCRIPTION
Write `*_load.tcl` into same dir as DCP rather than into current working dir