### PR TITLE
Fix for design merging, including designs with encrypted cells

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -4214,7 +4214,6 @@ public class DesignTools {
             cell.makePrimitive();
         }
         n.removeUnusedCellsFromAllWorkLibraries();
-        n.getEncryptedCells().clear();
-        n.addEncryptedCells(netlists.stream().map(Object::toString).collect(Collectors.toList()));
+        n.setEncryptedCells(netlists.stream().map(Object::toString).collect(Collectors.toList()));
     }
 }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -4192,4 +4192,29 @@ public class DesignTools {
             updatePinsIsRouted(net);
         }
     }
+
+    /**
+     * Removes all the existing encrypted cell files from a design and replaces them
+     * with the provided lists and black boxes those cells. The provided files
+     * should be named after the cell type. This is useful in the scenarios where a
+     * design has many thousand of individual encrypted cell files that are time
+     * consuming to load. By providing a higher level of hierarchy cell definition,
+     * the number of individual loads can be reduced.
+     * 
+     * @param design   The design to modify.
+     * @param netlists The list of encrypted cell files (*.edn, *.edf, or *.dcp)
+     *                 that should be used instead.
+     */
+    public static void replaceEncryptedCells(Design design, List<Path> netlists) {
+        EDIFNetlist n = design.getNetlist();
+        for (Path p : netlists) {
+            String fileName = p.getFileName().toString();
+            String cellType = fileName.substring(0, fileName.lastIndexOf('.'));
+            EDIFCell cell = n.getCell(cellType);
+            cell.makePrimitive();
+        }
+        n.removeUnusedCellsFromAllWorkLibraries();
+        n.getEncryptedCells().clear();
+        n.addEncryptedCells(netlists.stream().map(Object::toString).collect(Collectors.toList()));
+    }
 }

--- a/src/com/xilinx/rapidwright/design/merge/MergeDesigns.java
+++ b/src/com/xilinx/rapidwright/design/merge/MergeDesigns.java
@@ -114,7 +114,7 @@ public class MergeDesigns {
         }
 
         design0.getNetlist().removeUnusedCellsFromAllWorkLibraries();
-
+        design0.getNetlist().resetParentNetMap();
         return design0;
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1886,7 +1886,7 @@ public class EDIFNetlist extends EDIFName {
         return encryptedCells != null ? encryptedCells : Collections.emptyList();
     }
 
-    protected void setEncryptedCells(List<String> encryptedCells) {
+    public void setEncryptedCells(List<String> encryptedCells) {
         if (encryptedCells == null || encryptedCells.isEmpty()) {
             this.encryptedCells = null;
         } else {

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1887,10 +1887,17 @@ public class EDIFNetlist extends EDIFName {
     }
 
     protected void setEncryptedCells(List<String> encryptedCells) {
-        this.encryptedCells = encryptedCells;
+        if (encryptedCells == null || encryptedCells.isEmpty()) {
+            this.encryptedCells = null;
+        } else {
+            this.encryptedCells = encryptedCells;
+        }
     }
 
     public void addEncryptedCells(List<String> encryptedCells) {
+        if (encryptedCells == null || encryptedCells.size() == 0) {
+            return;
+        }
         if (this.encryptedCells == null) {
             setEncryptedCells(encryptedCells);
             return;

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1019,7 +1019,7 @@ public class EDIFTools {
         lines.add("read_checkpoint {" + pathDCPFileName + "}");
         lines.add("set_property top "+edif.getName()+" [current_fileset]");
         lines.add("link_design -part " + partName);
-        Path tclFileName = FileTools.replaceExtension(pathDCPFileName.getFileName(), LOAD_TCL_SUFFIX);
+        Path tclFileName = FileTools.replaceExtension(pathDCPFileName, LOAD_TCL_SUFFIX);
         try {
             Files.write(tclFileName, lines);
         } catch (IOException e) {

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1011,9 +1011,11 @@ public class EDIFTools {
     public static void writeTclLoadScriptForPartialEncryptedDesigns(EDIFNetlist edif,
                                                             Path dcpFileName, String partName) {
         ArrayList<String> lines = new ArrayList<String>();
+        lines.add(EDIFNetlist.READ_EDIF_CMD + " { \\");
         for (String cellName : edif.getEncryptedCells()) {
-            lines.add(EDIFNetlist.READ_EDIF_CMD + " {" + cellName + "}");
+            lines.add(cellName + " \\");
         }
+        lines.add("}");
         Path pathDCPFileName = dcpFileName.toAbsolutePath();
 
         lines.add("read_checkpoint {" + pathDCPFileName + "}");

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1011,11 +1011,17 @@ public class EDIFTools {
     public static void writeTclLoadScriptForPartialEncryptedDesigns(EDIFNetlist edif,
                                                             Path dcpFileName, String partName) {
         ArrayList<String> lines = new ArrayList<String>();
-        lines.add(EDIFNetlist.READ_EDIF_CMD + " { \\");
         for (String cellName : edif.getEncryptedCells()) {
-            lines.add(cellName + " \\");
+            if (cellName.endsWith(".edn") || cellName.endsWith(".edf")) {
+                lines.add(EDIFNetlist.READ_EDIF_CMD + " {" + cellName + "}");
+            } else if (cellName.endsWith(".dcp")) {
+                lines.add("read_checkpoint {" + cellName + "}");
+            } else if (cellName.endsWith(".v")) {
+                lines.add("read_verilog {" + cellName + "}");
+            } else {
+                System.err.println("ERROR: Unrecognized or missing extension for encrypted cell file: " + cellName);
+            }
         }
-        lines.add("}");
         Path pathDCPFileName = dcpFileName.toAbsolutePath();
 
         lines.add("read_checkpoint {" + pathDCPFileName + "}");

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -305,7 +305,7 @@ public class VivadoTools {
 
     private static String createTclDCPLoadCommand(Path dcp, boolean encrypted) {
         if (encrypted) {
-            Path tclFileName = FileTools.replaceExtension(dcp.getFileName(), EDIFTools.LOAD_TCL_SUFFIX);
+            Path tclFileName = FileTools.replaceExtension(dcp, EDIFTools.LOAD_TCL_SUFFIX);
             return "source {" + tclFileName + "}; ";
         } else {
             return "open_checkpoint {" + dcp + "}; ";


### PR DESCRIPTION
Resets the parent net map after each merge to avoid stale references.  Also refactors how encrypted cells are loaded in the `_load.tcl` script (however, has no significant affect on runtime).  