### PR TITLE
[RWRoute] Preserve primary source nodes on connections

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -658,6 +658,9 @@ public class RWRoute{
                 }
                 if (sourceINTRnode == null && sourceINTNode != null) {
                     sourceINTRnode = getOrCreateRouteNode(sourceINTNode, RouteNodeType.PINFEED_O);
+                    // Always preserve the projected-to-INT source node, since it could
+                    // be a projection from LAGUNA/RXQ* -> RXD* (node for INT/LOGIC_OUTS_*)
+                    routingGraph.preserve(sourceINTNode, net);
                 }
                 if (altSourceINTRnode == null && altSourceINTNode != null) {
                     altSourceINTRnode = getOrCreateRouteNode(altSourceINTNode, RouteNodeType.PINFEED_O);


### PR DESCRIPTION
Consider a design that has
    1. A connection emanating from a Laguna flop output (LAGUNA/RXQ)
    2. A connection that considers using that same SLL to cross

It turns out that when routing 2, it would stumble across the LAGUNA/RXD node (which is the RXQ site pin projected to the INT tile) and throw an exception since it never exceeds to encounter a `RouteNodeType.PINFEED_O`, which is only set for source pins. For all other connections, it was impossible to push such a type onto the queue, but that's clearly not the case here.

RWRoute now preserves all source pins so that such nodes are excluded.