### PR TITLE
[Interchange] Reorders tile types and tiles to follow their Vivado index

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -339,6 +339,7 @@ public class DeviceResourcesVerifier {
             expect(tile.getTileTypeEnum().name(), tileTypeName);
             expect(tile.getRow(), tileReader.getRow());
             expect(tile.getColumn(), tileReader.getCol());
+            // Note: Tile.getUniqueAddress() is equivalent to the INDEX property on a Vivado Tile object
             expect(tile.getUniqueAddress(), i);
 
             // Verify Tile Types

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -160,7 +160,6 @@ public class DeviceResourcesVerifier {
         Map<String, TileType.Reader> tileTypeMap = new HashMap<String, TileType.Reader>();
         int tileTypeCount = dReader.getTileTypeList().size();
         Map<TileTypeEnum, TileType.Reader> tileTypeEnumMap = new HashMap<TileTypeEnum, TileType.Reader>();
-        Map<TileTypeEnum, Integer> tileTypeIndexMap = new HashMap<>();
         HashMap<String, StructList.Reader<DeviceResources.Device.PIP.Reader>> ttPIPMap = new HashMap<>();
         for (int i=0; i < tileTypeCount; i++) {
             TileType.Reader ttReader = dReader.getTileTypeList().get(i);
@@ -169,7 +168,6 @@ public class DeviceResourcesVerifier {
             TileTypeEnum tileTypeEnum = TileTypeEnum.valueOf(name);
             tileTypeEnumMap.put(tileTypeEnum, ttReader);
             ttPIPMap.put(name, ttReader.getPips());
-            tileTypeIndexMap.put(tileTypeEnum, i);
         }
 
         expect(device.getName(), dReader.getName().toString());
@@ -346,7 +344,6 @@ public class DeviceResourcesVerifier {
             // Verify Tile Types
             TileType.Reader tileType = tileTypeMap.get(tileTypeName);
             expect(tile.getTileTypeEnum().name(), allStrings.get(tileType.getName()));
-            expect(tile.getTileTypeIndex(), tileTypeIndexMap.get(TileTypeEnum.valueOf(tileTypeName)));
             expect(tile.getWireCount(), tileType.getWires().size());
             PrimitiveList.Int.Reader wiresReader = tileType.getWires();
             for (int j=0; j < tile.getWireCount(); j++) {

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -157,16 +157,19 @@ public class DeviceResourcesVerifier {
         }
 
         // Create a lookup map for tile types
-        Map<String,TileType.Reader> tileTypeMap = new HashMap<String, TileType.Reader>();
+        Map<String, TileType.Reader> tileTypeMap = new HashMap<String, TileType.Reader>();
+        int tileTypeCount = dReader.getTileTypeList().size();
         Map<TileTypeEnum, TileType.Reader> tileTypeEnumMap = new HashMap<TileTypeEnum, TileType.Reader>();
+        Map<TileTypeEnum, Integer> tileTypeIndexMap = new HashMap<>();
         HashMap<String, StructList.Reader<DeviceResources.Device.PIP.Reader>> ttPIPMap = new HashMap<>();
-        for (int i=0; i < dReader.getTileTypeList().size(); i++) {
+        for (int i=0; i < tileTypeCount; i++) {
             TileType.Reader ttReader = dReader.getTileTypeList().get(i);
             String name = allStrings.get(ttReader.getName());
             tileTypeMap.put(name, ttReader);
             TileTypeEnum tileTypeEnum = TileTypeEnum.valueOf(name);
             tileTypeEnumMap.put(tileTypeEnum, ttReader);
             ttPIPMap.put(name, ttReader.getPips());
+            tileTypeIndexMap.put(tileTypeEnum, i);
         }
 
         expect(device.getName(), dReader.getName().toString());
@@ -338,10 +341,12 @@ public class DeviceResourcesVerifier {
             expect(tile.getTileTypeEnum().name(), tileTypeName);
             expect(tile.getRow(), tileReader.getRow());
             expect(tile.getColumn(), tileReader.getCol());
+            expect(tile.getUniqueAddress(), i);
 
             // Verify Tile Types
             TileType.Reader tileType = tileTypeMap.get(tileTypeName);
             expect(tile.getTileTypeEnum().name(), allStrings.get(tileType.getName()));
+            expect(tile.getTileTypeIndex(), tileTypeIndexMap.get(TileTypeEnum.valueOf(tileTypeName)));
             expect(tile.getWireCount(), tileType.getWires().size());
             PrimitiveList.Int.Reader wiresReader = tileType.getWires();
             for (int j=0; j < tile.getWireCount(); j++) {

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -694,7 +694,7 @@ public class DeviceResourcesWriter {
 
         Map<TileTypeEnum, Integer> tileTypeIndicies = new HashMap<TileTypeEnum, Integer>();
 
-        // Order tile types by their TILE_TYPE_IDX
+        // Order tile types by their TILE_TYPE_IDX (may not be contiguous)
         Map<Integer, TileTypeEnum> tileTypeIndexMap = new TreeMap<>();
         for (Entry<TileTypeEnum,Tile> e : tileTypes.entrySet()) {
             tileTypeIndexMap.put(e.getValue().getTileTypeIndex(), e.getKey());

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.capnproto.MessageBuilder;
@@ -694,13 +695,14 @@ public class DeviceResourcesWriter {
         Map<TileTypeEnum, Integer> tileTypeIndicies = new HashMap<TileTypeEnum, Integer>();
 
         // Order tile types by their TILE_TYPE_IDX
-        TileTypeEnum[] tileTypeIndexArr = new TileTypeEnum[tileTypes.size()];
+        Map<Integer, TileTypeEnum> tileTypeIndexMap = new TreeMap<>();
         for (Entry<TileTypeEnum,Tile> e : tileTypes.entrySet()) {
-            tileTypeIndexArr[e.getValue().getTileTypeIndex()] = e.getKey();
+            tileTypeIndexMap.put(e.getValue().getTileTypeIndex(), e.getKey());
         }
 
-        for (int i = 0; i < tileTypes.size(); i++) {
-            TileTypeEnum type = tileTypeIndexArr[i];
+        int i = 0;
+        for (Entry<Integer, TileTypeEnum> e : tileTypeIndexMap.entrySet()) {
+            TileTypeEnum type = e.getValue();
             Tile tile = tileTypes.get(type);
             TileType.Builder tileType = tileTypesList.get(i);
             tileTypeIndicies.put(type, i);
@@ -783,6 +785,7 @@ public class DeviceResourcesWriter {
                     }
                 }
             }
+            i++;
         }
 
         return tileTypeIndicies;


### PR DESCRIPTION
This PR changes the export order of tiles ([`tileList`](https://github.com/chipsalliance/fpga-interchange-schema/blob/c985b4648e66414b250261c1ba4cbe45a2971b1c/interchange/DeviceResources.capnp#L102)) and tile types ([`tileTypeList`](https://github.com/chipsalliance/fpga-interchange-schema/blob/c985b4648e66414b250261c1ba4cbe45a2971b1c/interchange/DeviceResources.capnp#L101)) in Interchange `.device` files such that the order reflects the original Vivado-given index.  

**Tiles:** Each tile in a device is given a unique address or `INDEX` that is often computed by `TOTAL_DEVICE_COLUMNS*TILE_ROW + TILE_COLUMN`.  This PR now orders the tiles in the device resources file according to this index.

**Tile Types:** The Interchange has a Tile Type object, but Vivado annotates tile type information on the tile.  Vivado uses a `TILE_TYPE_IDX` to denote the order of the tile type.  This is mostly alphabetical order except the 0-indexed entry is the `NULL` type.

The device verifier is also modified to verify that the tile orders match once the file is parsed.  Since tile type indices are not declared in the interchange schema, the ordering is not verified. 