### PR TITLE
[DesignTools] makeBlackbox() to use phys netlist not logical

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1556,6 +1556,10 @@ public class DesignTools {
                     case PORT: {
                         // We found a site pin, add it to solution set
                         sitePinNames.add(pin.getName());
+                        if (belPin.isInput() && pin.isInput()) {
+                            // This is an input BEL pin that feeds an output site pin, mark it as an internal sink
+                            internalSinks.add(pin);
+                        }
                         break;
                     }
                     case BEL: {

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2464,18 +2464,20 @@ public class DesignTools {
             }
             return pin;
         }
-        // Looks like the approach above failed (site may not be routed), try logical path
+        // Looks like the approach above failed (site may not be routed), try logical path if netlist exists
         Net net = sitePinInst.getNet();
         if (net == null) return null;
         Design design = siteInst.getDesign();
         EDIFNetlist netlist = design.getNetlist();
-        EDIFHierNet hierNet = netlist.getHierNetFromName(net.getName());
-        if (hierNet == null) return null;
-        List<EDIFPortInst> portInsts = hierNet.getNet().getSourcePortInsts(false);
-        for (EDIFPortInst portInst : portInsts) {
-            Cell c = design.getCell(hierNet.getHierarchicalInstName(portInst));
-            if (c != null) {
-                return c.getBELPin(portInst);
+        if (netlist != null) {
+            EDIFHierNet hierNet = netlist.getHierNetFromName(net.getName());
+            if (hierNet == null) return null;
+            List<EDIFPortInst> portInsts = hierNet.getNet().getSourcePortInsts(false);
+            for (EDIFPortInst portInst : portInsts) {
+                Cell c = design.getCell(hierNet.getHierarchicalInstName(portInst));
+                if (c != null) {
+                    return c.getBELPin(portInst);
+                }
             }
         }
         return null;

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1576,7 +1576,13 @@ public class DesignTools {
                                     // Make sure we are coming in on the routed-thru pin
                                     String otherPinName = otherCell.getPinMappingsP2L().keySet().iterator().next();
                                     if (pin.getName().equals(otherPinName)) {
-                                        otherPin = LUTTools.getLUTOutputPin(pin.getBEL());
+                                        if (otherCell.isFFRoutethruCell()) {
+                                            otherPin = pin.getBEL().getPin("Q");
+                                        } else if (LUTTools.isCellALUT(otherCell)) {
+                                            otherPin = LUTTools.getLUTOutputPin(pin.getBEL());
+                                        } else {
+                                            throw new RuntimeException("ERROR: Unrecognized routethru cell: " + cell.getName());
+                                        }
                                     }
                                 }
                                 if (otherPin != null) {

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1556,8 +1556,8 @@ public class DesignTools {
                     case PORT: {
                         // We found a site pin, add it to solution set
                         sitePinNames.add(pin.getName());
-                        if (belPin.isInput() && pin.isInput()) {
-                            // This is an input BEL pin that feeds an output site pin, mark it as an internal sink
+                        if (belPin.isInput() && pin.isInput() && siteInst.getSitePinInst(pin.getName()) != null) {
+                            // This is an input BEL pin that feeds a used output site pin, mark it as an internal sink
                             internalSinks.add(pin);
                         }
                         break;


### PR DESCRIPTION
Currently, `makeBlackbox()` leverages the `EDIFNetlist` to find all leaf cells inside a particular point of the hierarchy. In the case of encrypted or detached netlists, this is not possible. Instead, this PR proposes that only the physical netlist is used by assuming that any `Cell` that starts with the hierarchical name must be within the hierarchy to be blackboxed.

Am I missing a reason why this shouldn't be done? The only reason I can think of is that simply relying on the `Cell` name prefix may be imprecise, but is that enough of a (rare) reason to not proceed?

This PR also:
- Fixes a situation where the intra-site routing of FF routethru-s were not being unrouted correctly
- Depends on a new feature (in a future release) to defer the unrouting of sink pins such that they can be batched together and performed more efficiently later