### PR TITLE
[RWRoute] Refactoring/cleanup/preparation for multi-threading

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -472,7 +472,7 @@ public class Connection implements Comparable<Connection>{
         return s.toString();
     }
 
-    public void setAllTargets(RouteNodeGraph routingGraph) {
+    public void setAllTargets(RWRoute.ConnectionState state) {
         if (sinkRnode.countConnectionsOfUser(netWrapper) == 0 ||
             sinkRnode.getIntentCode() == IntentCode.NODE_PINBOUNCE) {
             // Since this connection will have been ripped up, only mark a node
@@ -480,7 +480,7 @@ public class Connection implements Comparable<Connection>{
             // This prevents -- for the case where the same net needs to be routed
             // to the same LUT more than once -- the illegal case of the same
             // physical pin servicing more than one logical pin
-            routingGraph.addTarget(sinkRnode);
+            sinkRnode.markTarget(state);
         } else {
             assert(altSinkRnodes != null && !altSinkRnodes.isEmpty());
         }
@@ -493,7 +493,7 @@ public class Connection implements Comparable<Connection>{
                     // Except if it is not a PINFEED_I
                     rnode.getType() != RouteNodeType.PINFEED_I) {
                     assert(rnode.getIntentCode() != IntentCode.NODE_PINBOUNCE);
-                    routingGraph.addTarget(rnode);
+                    rnode.markTarget(state);
                 }
             }
         }

--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -435,23 +435,14 @@ public class Connection implements Comparable<Connection>{
     }
 
     @Override
-    public int compareTo(Connection arg0) {
-        if (this == arg0)
-            return 0;
-        if (netWrapper.getConnections().size() > arg0.getNetWrapper().getConnections().size()) {
-            return 1;
-        } else if (netWrapper.getConnections().size() == arg0.getNetWrapper().getConnections().size()) {
-            if (this.getHpwl() > arg0.getHpwl()) {
-                return 1;
-            } else if (getHpwl() == arg0.getHpwl()) {
-                if (hashCode() > arg0.hashCode()) {
-                    return -1;
-                }
-            }
-        } else {
-            return -1;
+    public int compareTo(Connection that) {
+        // 1st priority: descending net fanout
+        int comp = Integer.compare(that.getNetWrapper().getConnections().size(), this.getNetWrapper().getConnections().size());
+        if (comp != 0) {
+            return comp;
         }
-        return -1;
+        // 2nd priority: ascending HPWL
+        return Short.compare(this.getHpwl(), that.getHpwl());
     }
 
     public String bbRectangleString() {
@@ -481,7 +472,7 @@ public class Connection implements Comparable<Connection>{
         return s.toString();
     }
 
-    public void setAllTargets(boolean target) {
+    public void setAllTargets(RouteNodeGraph routingGraph) {
         if (sinkRnode.countConnectionsOfUser(netWrapper) == 0 ||
             sinkRnode.getIntentCode() == IntentCode.NODE_PINBOUNCE) {
             // Since this connection will have been ripped up, only mark a node
@@ -489,7 +480,7 @@ public class Connection implements Comparable<Connection>{
             // This prevents -- for the case where the same net needs to be routed
             // to the same LUT more than once -- the illegal case of the same
             // physical pin servicing more than one logical pin
-            sinkRnode.setTarget(target);
+            routingGraph.addTarget(sinkRnode);
         } else {
             assert(altSinkRnodes != null && !altSinkRnodes.isEmpty());
         }
@@ -502,7 +493,7 @@ public class Connection implements Comparable<Connection>{
                     // Except if it is not a PINFEED_I
                     rnode.getType() != RouteNodeType.PINFEED_I) {
                     assert(rnode.getIntentCode() != IntentCode.NODE_PINBOUNCE);
-                    rnode.setTarget(target);
+                    routingGraph.addTarget(rnode);
                 }
             }
         }

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -70,7 +70,7 @@ public class PartialRouter extends RWRoute {
 
     protected Map<Net, List<SitePinInst>> netToPins;
 
-    protected class RouteNodeGraphPartial extends RouteNodeGraph {
+    protected static class RouteNodeGraphPartial extends RouteNodeGraph {
 
         public RouteNodeGraphPartial(Design design, RWRouteConfig config, Map<Tile, RouteNode[]> nodesMap) {
             super(design, config, nodesMap);
@@ -83,14 +83,14 @@ public class PartialRouter extends RWRoute {
         @Override
         protected boolean isExcluded(RouteNode parent, Node child) {
             // Routing part of an existing (preserved) route are never excluded
-            if (isPartOfExistingRoute(parent, child)) {
+            if (isPartOfExistingRoute(this, parent, child)) {
                 return false;
             }
             return super.isExcluded(parent, child);
         }
     }
 
-    protected class RouteNodeGraphPartialTimingDriven extends RouteNodeGraphTimingDriven {
+    protected static class RouteNodeGraphPartialTimingDriven extends RouteNodeGraphTimingDriven {
         public RouteNodeGraphPartialTimingDriven(Design design,
                                                  RWRouteConfig config,
                                                  DelayEstimatorBase delayEstimator,
@@ -106,7 +106,7 @@ public class PartialRouter extends RWRoute {
 
         @Override
         protected boolean isExcluded(RouteNode parent, Node child) {
-            if (isPartOfExistingRoute(parent, child)) {
+            if (isPartOfExistingRoute(this, parent, child)) {
                 return false;
             }
             return super.isExcluded(parent, child);
@@ -151,7 +151,7 @@ public class PartialRouter extends RWRoute {
      * @param end End Node of arc.
      * @return True if arc is part of an existing route.
      */
-    protected boolean isPartOfExistingRoute(RouteNode start, Node end) {
+    protected static boolean isPartOfExistingRoute(RouteNodeGraph routingGraph, RouteNode start, Node end) {
         // End node can only be part of existing route if it is in the graph already
         RouteNode endRnode = routingGraph.getNode(end);
         if (endRnode == null) {

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -158,10 +158,11 @@ public class PartialRouter extends RWRoute {
             return false;
         }
 
-        // Presence of a prev pointer means that only that arc is allowed to enter this end node
+        // Presence of a prev pointer means that:
+        //   (a) end node has been visited before
+        //   (b) only this is arc allowed to enter this end node
         RouteNode prev = endRnode.getPrev();
         if (prev != null) {
-            // If end node has been visited already
             if (endRnode.isVisited(start.getVisited())) {
                 // Visited possibly from a different arc uphill of end, or possibly from
                 // the same start -> end arc during prepareRouteConnection()

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -443,8 +443,6 @@ public class PartialRouter extends RWRoute {
             }
             stashedPrev.clear();
         }
-
-        routingGraph.resetExpansion();
     }
 
     @Override
@@ -695,8 +693,6 @@ public class PartialRouter extends RWRoute {
                 }
             }
         }
-
-        routingGraph.resetExpansion();
 
         for (RouteNode rnode : rnodes) {
             // Check already unpreserved above

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -89,7 +89,7 @@ public class RWRoute {
     /** A list of direct connections that are easily routed through dedicated resources */
     private List<Connection> directConnections;
     /** Sorted indirect connections */
-    private List<Connection> sortedIndirectConnections;
+    protected List<Connection> sortedIndirectConnections;
     /** A list of global clock nets */
     protected List<Net> clkNets;
     /** Static nets */
@@ -119,9 +119,9 @@ public class RWRoute {
     /** 1 - timingWeight */
     private float oneMinusTimingWeight;
     /** Flag for whether LUT pin swaps are to be considered */
-    protected boolean lutPinSwapping;
+    private boolean lutPinSwapping;
     /** Flag for whether LUT routethrus are to be considered */
-    protected boolean lutRoutethru;
+    private boolean lutRoutethru;
 
     /** The current routing iteration */
     protected int routeIteration;
@@ -784,7 +784,9 @@ public class RWRoute {
         routeWireNets.addChild(rnodesTimer);
         // Do not time the cost evaluation method for routing connections, the timer itself takes time
         routerTimer.createRuntimeTracker("route connections", "route wire nets").setTime(routeWireNets.getTime() - rnodesTimer.getTime() - updateTimingTimer.getTime() - updateCongestionCosts.getTime());
-        routeWireNets.addChild(updateTimingTimer);
+        if (config.isTimingDriven()) {
+            routeWireNets.addChild(updateTimingTimer);
+        }
         routeWireNets.addChild(updateCongestionCosts);
 
         routerTimer.createRuntimeTracker("finalize routes", "Routing").start();
@@ -1187,7 +1189,7 @@ public class RWRoute {
     /**
      * Sorts indirect connections for routing.
      */
-    private void sortConnections() {
+    protected void sortConnections() {
         sortedIndirectConnections.clear();
         sortedIndirectConnections.addAll(indirectConnections);
         Collections.sort(sortedIndirectConnections);
@@ -2101,7 +2103,7 @@ public class RWRoute {
         System.out.print(MessageGenerator.formatString(s, value));
     }
 
-    private void printRoutingStatistics() {
+    protected void printRoutingStatistics() {
         MessageGenerator.printHeader("Statistics");
         computesNodeUsageAndTotalWirelength();
         printNodeTypeUsageAndWirelength(config.isVerbose(), nodeTypeUsage, nodeTypeLength);

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1502,6 +1502,7 @@ public class RWRoute {
         protected final float dlyWeight;
         protected final float estDlyWeight;
         protected final PriorityQueue<RouteNode> queue;
+        protected final List<RouteNode> targets;
 
         ConnectionState(Connection connection, int sequence, float rnodeCostWeight, float shareWeight,
                         float rnodeWLWeight, float estWlWeight, float dlyWeight, float estDlyWeight,
@@ -1515,6 +1516,7 @@ public class RWRoute {
             this.dlyWeight = dlyWeight;
             this.estDlyWeight = estDlyWeight;
             this.queue = queue;
+            targets = new ArrayList<>();
         }
     }
 
@@ -1576,7 +1578,10 @@ public class RWRoute {
             }
         }
 
-        routingGraph.resetExpansion();
+        for (RouteNode target : state.targets) {
+            assert(target.isTarget());
+            target.clearTarget();
+        }
     }
 
     /**
@@ -1984,7 +1989,7 @@ public class RWRoute {
         assert(state.queue.isEmpty());
 
         // Sets the sink rnode(s) of the connection as the target(s)
-        connection.setAllTargets(routingGraph);
+        connection.setAllTargets(state);
 
         // Adds the source rnode to the queue
         RouteNode sourceRnode = connection.getSourceRnode();

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1189,7 +1189,7 @@ public class RWRoute {
     /**
      * Sorts indirect connections for routing.
      */
-    protected void sortConnections() {
+    private void sortConnections() {
         sortedIndirectConnections.clear();
         sortedIndirectConnections.addAll(indirectConnections);
         Collections.sort(sortedIndirectConnections);

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1570,10 +1570,12 @@ public class RWRoute {
             }
         }
 
-        for (RouteNode target : state.targets) {
-            assert(target.isTarget());
+        // Reset the nodes marked as this connection's target(s)
+        List<RouteNode> targets = state.targets;
+        for (RouteNode target : targets) {
             target.clearTarget();
         }
+        targets.clear();
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -309,11 +309,17 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
     }
 
     /**
-     * Sets the boolean value of target.
-     * @param isTarget The value to be set.
+     * Marks this node as a target.
+     * @param state State from the connection that is being routed.
      */
-    public void setTarget(boolean isTarget) {
-        this.isTarget = isTarget;
+    public void markTarget(RWRoute.ConnectionState state) {
+        this.isTarget = true;
+        state.targets.add(this);
+    }
+
+
+    public void clearTarget() {
+        this.isTarget = false;
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -309,17 +309,21 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
     }
 
     /**
-     * Marks this node as a target.
+     * Marks this node as a target, and adds it to state's targets list.
      * @param state State from the connection that is being routed.
      */
     public void markTarget(RWRoute.ConnectionState state) {
-        this.isTarget = true;
+        isTarget = true;
         state.targets.add(this);
     }
 
 
+    /*
+     * Clears the target state on this node.
+     */
     public void clearTarget() {
-        this.isTarget = false;
+        assert(isTarget);
+        isTarget = false;
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -84,7 +84,7 @@ public class RouteNodeGraph {
      */
     private final Collection<RouteNode> targets;
 
-    private AtomicLong createRnodeTime;
+    private long createRnodeTime;
 
     public static final short SUPER_LONG_LINE_LENGTH_IN_TILES = 60;
 
@@ -126,7 +126,7 @@ public class RouteNodeGraph {
         preservedMapSize = new AtomicInteger();
         asyncPreserveOutstanding = new CountUpDownLatch();
         targets = new ArrayList<>();
-        createRnodeTime = new AtomicLong();
+        createRnodeTime = 0;
 
         Device device = design.getDevice();
         intYToSLRIndex = new int[device.getRows()];
@@ -417,11 +417,11 @@ public class RouteNodeGraph {
     }
 
     protected void addCreateRnodeTime(long time) {
-        createRnodeTime.addAndGet(time);
+        createRnodeTime += time;
     }
 
     protected long getCreateRnodeTime() {
-        return createRnodeTime.get();
+        return createRnodeTime;
     }
 
     public Net getPreservedNet(Node node) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
@@ -83,7 +84,7 @@ public class RouteNodeGraph {
      */
     private final Collection<RouteNode> targets;
 
-    private long createRnodeTime;
+    private AtomicLong createRnodeTime;
 
     public static final short SUPER_LONG_LINE_LENGTH_IN_TILES = 60;
 
@@ -125,7 +126,7 @@ public class RouteNodeGraph {
         preservedMapSize = new AtomicInteger();
         asyncPreserveOutstanding = new CountUpDownLatch();
         targets = new ArrayList<>();
-        createRnodeTime = 0;
+        createRnodeTime = new AtomicLong();
 
         Device device = design.getDevice();
         intYToSLRIndex = new int[device.getRows()];
@@ -416,11 +417,11 @@ public class RouteNodeGraph {
     }
 
     protected void addCreateRnodeTime(long time) {
-        createRnodeTime += time;
+        createRnodeTime.addAndGet(time);
     }
 
     protected long getCreateRnodeTime() {
-        return createRnodeTime;
+        return createRnodeTime.get();
     }
 
     public Net getPreservedNet(Node node) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -508,26 +508,6 @@ public class RouteNodeGraph {
         return rnode;
     }
 
-    protected Collection<RouteNode> getTargets() {
-        return targets;
-    }
-
-    public void addTarget(RouteNode rnode) {
-        getTargets().add(rnode);
-        rnode.setTarget(true);
-    }
-
-    /**
-     * Resets the expansion history.
-     */
-    public void resetExpansion() {
-        for (RouteNode node : getTargets()) {
-            assert(node.isTarget());
-            node.setTarget(false);
-        }
-        getTargets().clear();
-    }
-
     public int averageChildren() {
         int sum = 0;
         for (RouteNode rnode : getRnodes()) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -511,7 +511,6 @@ public class RouteNodeGraph {
         return targets;
     }
 
-
     public void addTarget(RouteNode rnode) {
         getTargets().add(rnode);
         rnode.setTarget(true);

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -63,7 +63,7 @@ public class TimingAndWirelengthReport{
         this.design = design;
         timingManager = new TimingManager(design, null, config, RWRoute.createClkTimingData(config), design.getNets(), isPartialRouting);
         estimator = new DelayEstimatorBase(design.getDevice(), new InterconnectInfo(), config.isUseUTurnNodes(), 0);
-        routingGraph = new RouteNodeGraphTimingDriven(null, design, config, estimator);
+        routingGraph = new RouteNodeGraphTimingDriven(design, config, estimator);
         wirelength = 0;
         usedNodes = 0;
         nodeTypeUsage = new HashMap<>();

--- a/src/com/xilinx/rapidwright/util/RuntimeTracker.java
+++ b/src/com/xilinx/rapidwright/util/RuntimeTracker.java
@@ -46,8 +46,7 @@ public class RuntimeTracker {
     }
 
     public RuntimeTracker(String name, short level) {
-        this.name = name + ":";
-        this.time = 0;
+        this(name);
         this.level = level;
         if (this.getLevel() * 3 + this.getName().length() > 36) {
             System.out.println("\nWARNING: RuntimeTracker name too long: " + name + ". Ideal max string length: " + (35 - this.getLevel() * 3));
@@ -92,15 +91,23 @@ public class RuntimeTracker {
         }
     }
 
+    public static long now() {
+        return System.nanoTime();
+    }
+
+    public static long elapsed(long start) {
+        return now() - start;
+    }
+
     public void start() {
-        this.start = System.nanoTime();
+        this.start = now();
     }
 
     /**
      * Stops the runtime tracker and stores the total time elapsed in nanoseconds.
      */
     public void stop() {
-        this.time += System.nanoTime() - this.start;
+        this.time += elapsed(this.start);
     }
 
     /**


### PR DESCRIPTION
- Fold `RouteNodeImpl` into `RouteNode` which is now a non-abstract *static* class -- static should remove one reference (to the outer `RouteNodeGraph`) from all `RouteNode` objects -- achieved by making necessary methods require a `RouteNodeGraph` reference instead of relying on that outer reference.
- Convert a number of counters (`RWRoute.{connectionsRouted{,Iteration}`, `RouteNodeGraph.nodesMapSize`, etc.) to `AtomicInteger` or `AtomicLong` to facilitate multi-threaded use
- Create `RWRoute.getQueue()` for getting the `PriorityQueue` to allow downstream (multi-threaded) classes to override
- Create a `ConnectionState` class to encapsulate all state necessary only when routing a particular connection
- General tidying up