### PR TITLE
Creating a standalone entry point to relocate DCPs

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -38,6 +38,7 @@ import com.xilinx.rapidwright.design.blocks.PBlock;
 import com.xilinx.rapidwright.design.blocks.PBlockGenerator;
 import com.xilinx.rapidwright.design.merge.MergeDesigns;
 import com.xilinx.rapidwright.design.tools.LUTTools;
+import com.xilinx.rapidwright.design.tools.RelocationTools;
 import com.xilinx.rapidwright.device.IntentCode;
 import com.xilinx.rapidwright.device.PseudoPIPHelper;
 import com.xilinx.rapidwright.device.browser.DeviceBrowser;
@@ -176,6 +177,7 @@ public class MainEntrypoint {
         addFunction("PrintEDIFInstances", PrintEDIFInstances::main);
         addFunction("ProbeRouter", ProbeRouter::main);
         addFunction("PseudoPIPHelper", PseudoPIPHelper::main);
+        addFunction("RelocationTools", RelocationTools::main);
         addFunction("ReplaceEDIFInDCP", ReplaceEDIFInDCP::main);
         addFunction("ReportDevicePerformance", ReportDevicePerformance::main);
         addFunction("ReportTimingExample", ReportTimingExample::main);

--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -386,8 +386,13 @@ public class RelocationTools {
         String inputDCPName = args[0];
         Design d = Design.readCheckpoint(inputDCPName);
         if (args.length == 1) {
-            
-            printValidRelocationOptions(getValidRelocationOptions(d), Integer.MAX_VALUE);
+            Pair<Site, Map<Integer, Site>> options = getValidRelocationOptions(d);
+            if (options == null || options.getSecond().size() < 2) {
+                System.out.println("No valid relocation options for the provided DCP '" + inputDCPName + "'");
+            } else {
+                System.out.println("Valid Relocation Options:");
+                printValidRelocationOptions(options, Integer.MAX_VALUE);
+            }
             return;
         }
         String outputDCPName = args[1];

--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -386,7 +386,8 @@ public class RelocationTools {
         String inputDCPName = args[0];
         Design d = Design.readCheckpoint(inputDCPName);
         if (args.length == 1) {
-            printValidRelocationOptions(null, Integer.MAX_VALUE);
+            
+            printValidRelocationOptions(getValidRelocationOptions(d), Integer.MAX_VALUE);
             return;
         }
         String outputDCPName = args[1];

--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -378,10 +378,24 @@ public class RelocationTools {
         }
     }
 
+    /**
+     * Offers a command line accessible way to relocate a design implementation. It
+     * can provide a list of valid relocation options for which full relocation is
+     * possible by providing just a single DCP as an option. Or, it will perform a
+     * best effort relocation (relocating as much as possible and
+     * unplacing/unrouting incompatible cells/routes) when provided a DCP, output
+     * location and set of offsets.
+     * 
+     * @param args Two modes, for listing relocation options args[0]==<input.dcp>;
+     *             for relocation (full or best effort partial)
+     *             args[0]==<input.dcp>, args[1]==<output.dcp>,
+     *             args[2]==<tile_x_offset>, args[3]==<tile_y_offset>.
+     */
     public static void main(String[] args) {
         if (args.length != 4 && args.length != 1) {
             System.out.println("USAGE (query valid relocation options): <input.dcp>");
-            System.out.println("USAGE (to relocate a design): <input.dcp> <output.dcp> <tile_x_offset> <tile_y_offset>");
+            System.out.println("USAGE (design relocation (full or partial): "
+                    + "<input.dcp> <output.dcp> <tile_x_offset> <tile_y_offset>");
             return;
         }
         String inputDCPName = args[0];

--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -370,8 +370,8 @@ public class RelocationTools {
         for (Entry<Integer, Site> e : map.entrySet()) {
             int validXOffset = anchor.getTile().getTileXCoordinate() - e.getValue().getTile().getTileXCoordinate();
             int validYOffset = anchor.getTile().getTileYCoordinate() - e.getValue().getTile().getTileYCoordinate();
-            ps.printf("  tileXOffset=%4d, tileYOffset=%4d anchorSite=%s, newAnchorSite=%s\n", validXOffset,
-                    validYOffset, anchor, e.getValue());
+            ps.printf("  tileXOffset=%4d, tileYOffset=%4d anchorSite=%s/%s, newAnchorSite=%s/%s\n", validXOffset,
+                    validYOffset, anchor.getTile(), anchor, e.getValue().getTile(), e.getValue());
             if (limit-- == 0) {
                 break;
             }

--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -368,8 +368,8 @@ public class RelocationTools {
         Site anchor = options.getFirst();
         Map<Integer, Site> map = options.getSecond();
         for (Entry<Integer, Site> e : map.entrySet()) {
-            int validXOffset = anchor.getTile().getTileXCoordinate() - e.getValue().getTile().getTileXCoordinate();
-            int validYOffset = anchor.getTile().getTileYCoordinate() - e.getValue().getTile().getTileYCoordinate();
+            int validXOffset = e.getValue().getTile().getTileXCoordinate() - anchor.getTile().getTileXCoordinate();
+            int validYOffset = e.getValue().getTile().getTileYCoordinate() - anchor.getTile().getTileYCoordinate();
             ps.printf("  tileXOffset=%4d, tileYOffset=%4d anchorSite=%s/%s, newAnchorSite=%s/%s\n", validXOffset,
                     validYOffset, anchor.getTile(), anchor, e.getValue().getTile(), e.getValue());
             if (limit-- == 0) {

--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -23,6 +23,7 @@
 
 package com.xilinx.rapidwright.design.tools;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -363,13 +364,13 @@ public class RelocationTools {
      * @param options The relocation options.
      * @param limit   Limit the number of printed options to this value.
      */
-    public static void printValidRelocationOptions(Pair<Site, Map<Integer, Site>> options, int limit) {
+    public static void printValidRelocationOptions(Pair<Site, Map<Integer, Site>> options, int limit, PrintStream ps) {
         Site anchor = options.getFirst();
         Map<Integer, Site> map = options.getSecond();
         for (Entry<Integer, Site> e : map.entrySet()) {
             int validXOffset = anchor.getTile().getTileXCoordinate() - e.getValue().getTile().getTileXCoordinate();
             int validYOffset = anchor.getTile().getTileYCoordinate() - e.getValue().getTile().getTileYCoordinate();
-            System.err.printf("  tileXOffset=%4d, tileYOffset=%4d anchorSite=%s, newAnchorSite=%s\n", validXOffset,
+            ps.printf("  tileXOffset=%4d, tileYOffset=%4d anchorSite=%s, newAnchorSite=%s\n", validXOffset,
                     validYOffset, anchor, e.getValue());
             if (limit-- == 0) {
                 break;
@@ -390,8 +391,8 @@ public class RelocationTools {
             if (options == null || options.getSecond().size() < 2) {
                 System.out.println("No valid relocation options for the provided DCP '" + inputDCPName + "'");
             } else {
-                System.out.println("Valid Relocation Options:");
-                printValidRelocationOptions(options, Integer.MAX_VALUE);
+                System.out.println("Possible Valid Relocation Options:");
+                printValidRelocationOptions(options, Integer.MAX_VALUE, System.out);
             }
             return;
         }
@@ -413,7 +414,7 @@ public class RelocationTools {
                 System.err.println("Could not relocate to tileXOffset=" + tileXOffset + ", tileYOffset="
                         + tileYOffset + ", here are some other valid options:");
                 int numOfValidSuggestions = 6;
-                printValidRelocationOptions(options, numOfValidSuggestions);
+                printValidRelocationOptions(options, numOfValidSuggestions, System.err);
                 System.exit(1);
             } else {
                 throw new RuntimeException("ERROR: Relocation of DCP '" + inputDCPName

--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -23,6 +23,16 @@
 
 package com.xilinx.rapidwright.design.tools;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.DesignTools;
@@ -38,16 +48,6 @@ import com.xilinx.rapidwright.edif.EDIFHierCellInst;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.Utils;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 /**
  * A collection of tools to help relocate designs.
@@ -385,7 +385,7 @@ public class RelocationTools {
         }
         String inputDCPName = args[0];
         Design d = Design.readCheckpoint(inputDCPName);
-        if (args.length > 1 && args.length < 4) {
+        if (args.length == 1) {
             printValidRelocationOptions(null, Integer.MAX_VALUE);
             return;
         }

--- a/test/src/com/xilinx/rapidwright/design/TestRelocationTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestRelocationTools.java
@@ -267,6 +267,10 @@ public class TestRelocationTools {
         int yOffset = 5;
         
         Path outputDCP = dir.resolve("output.dcp");
+
+        // Smoke test for valid location report mode
+        RelocationTools.main(new String[] { dcpName.toString() });
+
         RelocationTools.main(new String[] {dcpName.toString(), outputDCP.toString(), 
                         Integer.toString(xOffset), Integer.toString(yOffset)});
         

--- a/test/src/com/xilinx/rapidwright/design/TestRelocationTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestRelocationTools.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Eddie Hung, Xilinx Research Labs.
@@ -23,11 +23,13 @@
 
 package com.xilinx.rapidwright.design;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,6 +48,8 @@ import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.ReportRouteStatusResult;
 import com.xilinx.rapidwright.util.VivadoTools;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -252,4 +256,40 @@ public class TestRelocationTools {
         );
     }
 
+    @Test
+    public void testRelocationTools(@TempDir Path dir) {
+        Design d = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235_2022_1.dcp");
+        d.getNet("clk").unroute();
+        Path dcpName = dir.resolve("picoblaze_unrouted_clk.dcp");
+        d.writeCheckpoint(dcpName);
+        
+        int xOffset = 0;
+        int yOffset = 5;
+        
+        Path outputDCP = dir.resolve("output.dcp");
+        RelocationTools.main(new String[] {dcpName.toString(), outputDCP.toString(), 
+                        Integer.toString(xOffset), Integer.toString(yOffset)});
+        
+        Design testOutput = Design.readCheckpoint(outputDCP);
+        
+        for (SiteInst s : d.getSiteInsts()) {
+            Tile origin = s.getTile();
+            Tile relocated = origin.getTileXYNeighbor(xOffset, yOffset);
+            Site relocatedSite = relocated.getSites()[s.getSite().getSiteIndexInTile()];
+            SiteInst relocatedSiteInst = testOutput.getSiteInstFromSite(relocatedSite);
+            Assertions.assertNotNull(relocatedSiteInst);
+            Assertions.assertEquals(relocatedSiteInst.getCells().size(), s.getCells().size());
+        }
+    }
+
+    @Test
+    public void testGetValidRelocationOptions() {
+        Design d = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235_2022_1.dcp");
+        d.getNet("clk").unroute();
+        
+        Pair<Site, Map<Integer, Site>> relocOptions = RelocationTools.getValidRelocationOptions(d);
+
+        Assertions.assertNotNull(relocOptions);
+        Assertions.assertEquals(215, relocOptions.getSecond().size());
+    }
 }


### PR DESCRIPTION
Creating a command line accessible way to perform a raw relocation of the implementation inside a DCP.  This adds two usage modes to `RelocationTools`: 
```
USAGE (query valid relocation options): <input.dcp>
USAGE (to relocate a design): <input.dcp> <output.dcp> <tile_x_offset> <tile_y_offset>
```
