### PR TITLE
 EDIF cleanup preventing singleton cells/libraries from attaching to user designs

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.2-rc1.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.1.2-rc2.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.2-rc1-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.1.2-rc2-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2024.1.2-rc1-beta
+  RAPIDWRIGHT_VERSION: v2024.1.2-rc2-beta
 
 jobs:
   build:

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2095,7 +2095,7 @@ public class DesignTools {
             // Don't move cell if already placed
             return true;
         }
-        Map<SiteTypeEnum, Set<String>> compatTypes = c.getCompatiblePlacements();
+        Map<SiteTypeEnum, Set<String>> compatTypes = c.getCompatiblePlacements(design.getDevice());
 
         for (Entry<SiteTypeEnum, Set<String>> e : compatTypes.entrySet()) {
             for (Site s : design.getDevice().getAllSitesOfType(e.getKey())) {

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -487,8 +487,12 @@ public class EDIFCell extends EDIFPropertyObject {
      * @param library the library to set
      */
     public void setLibrary(EDIFLibrary library) {
-        assert(library != null);
-        assert(this.library == null || this.library == library);
+        if (library == null) {
+            throw new RuntimeException("ERROR: library argument cannot be null.");
+        }
+        if (this.library != null && this.library != library) {
+            throw new RuntimeException("ERROR: EDIFCell is already attached to a library. Call EDIFLibrary.removeCell() first.");
+        }
 
         this.library = library;
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -82,6 +82,16 @@ public class EDIFCell extends EDIFPropertyObject {
      * Shallow Copy constructor - Creates a new EDIFCell object, EDIFCell
      * contents point to orig.
      *
+     * @param orig The original cell
+     */
+    public EDIFCell(EDIFCell orig) {
+        this(null, orig);
+    }
+
+    /**
+     * Shallow Copy constructor - Creates a new EDIFCell object, EDIFCell
+     * contents point to orig.
+     *
      * @param lib  Destination library of the copied cell.
      * @param orig The original cell
      */
@@ -477,7 +487,14 @@ public class EDIFCell extends EDIFPropertyObject {
      * @param library the library to set
      */
     public void setLibrary(EDIFLibrary library) {
+        assert(library != null);
+        assert(this.library == null || this.library == library);
+
         this.library = library;
+    }
+
+    protected void clearLibrary() {
+        this.library = null;
     }
 
     public boolean hasContents() {

--- a/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
@@ -169,7 +169,6 @@ public class EDIFLibrary extends EDIFName {
         if (this.netlist != null && this.netlist != netlist) {
             throw new RuntimeException("ERROR: EDIFLibrary is already attached to a netlist. Call EDIFNetlist.removeLibrary() first.");
         }
-        assert(this.netlist == null || this.netlist == netlist);
 
         this.netlist = netlist;
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
@@ -59,6 +59,12 @@ public class EDIFLibrary extends EDIFName {
         super(name);
     }
 
+    /**
+     * Shallow copy constructor - Creates a new EDIFLibrary object containing
+     * shallow copies of its contained EDIFCell-s.
+     *
+     * @param copy The original library
+     */
     public EDIFLibrary(EDIFLibrary copy) {
         super(copy.getName());
 

--- a/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibrary.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -163,10 +163,19 @@ public class EDIFLibrary extends EDIFName {
      * @param netlist the netlist to set
      */
     public void setNetlist(EDIFNetlist netlist) {
-        assert(netlist != null);
+        if (netlist == null) {
+            throw new RuntimeException("ERROR: netlist argument cannot be null.");
+        }
+        if (this.netlist != null && this.netlist != netlist) {
+            throw new RuntimeException("ERROR: EDIFLibrary is already attached to a netlist. Call EDIFNetlist.removeLibrary() first.");
+        }
         assert(this.netlist == null || this.netlist == netlist);
 
         this.netlist = netlist;
+    }
+
+    protected void clearNetlist() {
+        this.netlist = null;
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFLibraryBuiltin.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibraryBuiltin.java
@@ -23,15 +23,20 @@
 package com.xilinx.rapidwright.edif;
 
 /**
- * Extension of {@link EDIFLibrary} with setNetlist() method disabled.
+ * Extension of {@link EDIFLibrary} with setNetlist() and removeCell() methods disabled.
  */
-public class EDIFLibraryNoNetlist extends EDIFLibrary {
-    public EDIFLibraryNoNetlist(String name) {
+public class EDIFLibraryBuiltin extends EDIFLibrary {
+    public EDIFLibraryBuiltin(String name) {
         super(name);
     }
 
     @Override
     public void setNetlist(EDIFNetlist netlist) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public EDIFCell removeCell(EDIFCell cell) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/com/xilinx/rapidwright/edif/EDIFLibraryNoNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibraryNoNetlist.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Eddie Hung, Advanced Micro Devices, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+public class EDIFLibraryNoNetlist extends EDIFLibrary {
+    public EDIFLibraryNoNetlist(String name) {
+        super(name);
+    }
+
+    @Override
+    public void setNetlist(EDIFNetlist netlist) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/EDIFLibraryNoNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFLibraryNoNetlist.java
@@ -22,6 +22,9 @@
 
 package com.xilinx.rapidwright.edif;
 
+/**
+ * Extension of {@link EDIFLibrary} with setNetlist() method disabled.
+ */
 public class EDIFLibraryNoNetlist extends EDIFLibrary {
     public EDIFLibraryNoNetlist(String name) {
         super(name);

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -486,8 +486,9 @@ public class EDIFNetlist extends EDIFName {
         EDIFLibrary oldWork = getLibrary(library);
         List<EDIFCell> toRemove = new ArrayList<>(oldWork.getCells());
         for (EDIFCell c : toRemove) {
-            work.addCell(c);
             oldWork.removeCell(c);
+            work.addCell(c);
+
         }
         removeLibrary(library);
     }
@@ -509,17 +510,19 @@ public class EDIFNetlist extends EDIFName {
     }
 
     private EDIFCell migrateCellAndSubCellsWorker(EDIFCell cell) {
-        EDIFLibrary destLib = getLibrary(cell.getLibrary().getName());
+        EDIFLibrary srcLib = cell.getLibrary();
+        EDIFLibrary destLib = getLibrary(srcLib.getName());
         if (destLib == null) {
-            if (cell.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)) {
+            if (srcLib.isHDIPrimitivesLibrary()) {
                 destLib = getHDIPrimitivesLibrary();
             } else {
-                destLib = addLibrary(new EDIFLibrary(cell.getLibrary().getName()));
+                destLib = addLibrary(new EDIFLibrary(srcLib.getName()));
             }
         }
 
         EDIFCell existingCell = destLib.getCell(cell.getName());
         if (existingCell == null) {
+            srcLib.removeCell(cell);
             destLib.addCell(cell);
             for (EDIFCellInst inst : cell.getCellInsts()) {
                 inst.setCellType(migrateCellAndSubCellsWorker(inst.getCellType()));
@@ -552,16 +555,18 @@ public class EDIFNetlist extends EDIFName {
         //Step 1: add the top cell to the library.
         //If the top cell belongs to HDIPrimitivesLibrary && the top cell exists in HDIPrimitivesLibrary, return and do nothing.
         //Otherwise, the code would add the top cell to the library; if repeat happens, using "parameterized" suffix to distinguish
-        EDIFLibrary destLibTop = getLibrary(cell.getLibrary().getName());
+        EDIFLibrary srcLib = cell.getLibrary();
+        EDIFLibrary destLibTop = getLibrary(srcLib.getName());
         if (destLibTop == null) {
-            if (cell.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)) {
+            if (srcLib.isHDIPrimitivesLibrary()) {
                 destLibTop = getHDIPrimitivesLibrary();
             } else {
-                destLibTop = addLibrary(new EDIFLibrary(cell.getLibrary().getName()));
+                destLibTop = addLibrary(new EDIFLibrary(srcLib.getName()));
             }
         }
-        if (destLibTop.containsCell(cell) && destLibTop.getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME))
+        if (destLibTop.containsCell(cell) && destLibTop.isHDIPrimitivesLibrary())
             return;
+        srcLib.removeCell(cell);
         int i=0;
         String currentCellName = cell.getName();
         while (destLibTop.containsCell(cell)) {
@@ -577,32 +582,34 @@ public class EDIFNetlist extends EDIFName {
         while (!cells.isEmpty()) {
             EDIFCell pollFromCells = cells.poll();
             for (EDIFCellInst inst : pollFromCells.getCellInsts()) {
-                EDIFCell instCellType = inst.getCellType();
-                EDIFLibrary destLibSub = getLibrary(instCellType.getLibrary().getName());
+                EDIFCell cellSub = inst.getCellType();
+                EDIFLibrary srcLibSub = cellSub.getLibrary();
+                EDIFLibrary destLibSub = getLibrary(srcLibSub.getName());
                 if (destLibSub == null) {
-                    if (instCellType.getLibrary().getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)) {
+                    if (srcLibSub.isHDIPrimitivesLibrary()) {
                         destLibSub = getHDIPrimitivesLibrary();
                     } else {
-                        destLibSub = addLibrary(new EDIFLibrary(instCellType.getLibrary().getName()));
+                        destLibSub = addLibrary(new EDIFLibrary(srcLibSub.getName()));
                     }
                 }
-                if (destLibSub.containsCell(instCellType) && destLibSub.getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME))
+                if (destLibSub.containsCell(cellSub) && destLibSub.isHDIPrimitivesLibrary())
                     continue;
-                i=0;
-                currentCellName = instCellType.getName();
-                if (checkIfAlreadyInLib(instCellType, destLibSub)) {
-                    inst.setViewref(instCellType.getEDIFView());
+                currentCellName = cellSub.getName();
+                if (checkIfAlreadyInLib(cellSub, destLibSub)) {
+                    inst.setViewref(cellSub.getEDIFView());
                     continue;
                 }
-                while (destLibSub.containsCell(instCellType) && !checkIfAlreadyInLib(instCellType, destLibSub)) {
+                srcLibSub.removeCell(cellSub);
+                i=0;
+                while (destLibSub.containsCell(cellSub) && !checkIfAlreadyInLib(cellSub, destLibSub)) {
                     String newName = currentCellName + "_parameterized" + i;
-                    instCellType.setName(newName);
-                    instCellType.setView(newName);
+                    cellSub.setName(newName);
+                    cellSub.setView(newName);
                     i++;
                 }
-                inst.setCellType(instCellType); // updating the celltype, which could be changed due to adding suffix
-                destLibSub.addCell(instCellType);
-                cells.add(instCellType);
+                inst.setCellType(cellSub); // updating the celltype, which could be changed due to adding suffix
+                destLibSub.addCell(cellSub);
+                cells.add(cellSub);
             }
         }
     }
@@ -637,7 +644,7 @@ public class EDIFNetlist extends EDIFName {
             }
             return newCell;
         } else {
-            if (destLib.isHDIPrimitivesLibrary() || copiedCells.contains(existingCell)  || cell==existingCell) {
+            if (destLib.isHDIPrimitivesLibrary() || copiedCells.contains(existingCell) || cell == existingCell) {
                 return existingCell;
             }
             throw new RuntimeException("ERROR: Destination netlist already contains EDIFCell named " +
@@ -783,7 +790,9 @@ public class EDIFNetlist extends EDIFName {
             List<EDIFLibrary> librariesToWrite = new ArrayList<>();
             librariesToWrite.add(getHDIPrimitivesLibrary());
             for (EDIFLibrary lib : EDIFTools.sortIfStable(getLibrariesMap().values(), stable)) {
-                if (lib.getName().equals(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME)) continue;
+                if (lib.isHDIPrimitivesLibrary()) {
+                    continue;
+                }
                 librariesToWrite.add(lib);
             }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -623,6 +623,18 @@ public class EDIFNetlist extends EDIFName {
         copyCellAndSubCellsWorker(cell, copiedCells);
     }
 
+    /**
+     * This copies the library and all of its cells into this netlist.
+     * @param library The library (and all its cells) to copy into this netlist's libraries
+     */
+    public EDIFLibrary copyLibraryAndSubCells(EDIFLibrary library) {
+        Set<EDIFCell> copiedCells = new HashSet<>();
+        for (EDIFCell cell : library.getCells()) {
+            copyCellAndSubCellsWorker(cell, copiedCells);
+        }
+        return getLibrary(library.getName());
+    }
+
     private EDIFCell copyCellAndSubCellsWorker(EDIFCell cell, Set<EDIFCell> copiedCells) {
         EDIFLibrary destLib = getLibrary(cell.getLibrary().getName());
         if (destLib == null) {

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -492,7 +492,6 @@ public class EDIFNetlist extends EDIFName {
         for (EDIFCell c : toRemove) {
             oldWork.removeCell(c);
             work.addCell(c);
-
         }
         removeLibrary(library);
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -322,7 +322,11 @@ public class EDIFNetlist extends EDIFName {
     }
 
     public EDIFLibrary removeLibrary(String name) {
-        return libraries.remove(name);
+        EDIFLibrary library = libraries.remove(name);
+        if (library != null) {
+            library.clearNetlist();
+        }
+        return library;
     }
 
     public void renameNetlistAndTopCell(String newName) {

--- a/src/com/xilinx/rapidwright/examples/PolynomialGenerator.java
+++ b/src/com/xilinx/rapidwright/examples/PolynomialGenerator.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2018-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -204,16 +204,6 @@ public class PolynomialGenerator {
         sub.setNetlist(subDesign2.getNetlist());
         operators.put("-o", sub2);
 
-        // EDIFLibrary work = d.getNetlist().getWorkLibrary();
-        // EDIFLibrary hdi = d.getNetlist().getHDIPrimitivesLibrary();
-        // for (Design design : new Design[]{multDesign,multDesign2,adderDesign,adderDesign2,subDesign,subDesign2}) {
-        //     for (EDIFCell cell : design.getNetlist().getWorkLibrary().getCells()) {
-        //         work.addCell(cell);
-        //     }
-        //     for (EDIFCell cell : design.getNetlist().getHDIPrimitivesLibrary().getCells()) {
-        //         if (!hdi.containsCell(cell)) hdi.addCell(cell);
-        //     }
-        // }
         return operators;
     }
 

--- a/src/com/xilinx/rapidwright/examples/PolynomialGenerator.java
+++ b/src/com/xilinx/rapidwright/examples/PolynomialGenerator.java
@@ -172,7 +172,7 @@ public class PolynomialGenerator {
         MultGenerator.createMult(multDesign2, origin, width, MULT_NAME, CLK_NAME);
         Module mult2 = new Module(multDesign2);
         ensureCellTypesSet(mult2);
-        mult2.setNetlist(multDesign.getNetlist());
+        mult2.setNetlist(multDesign2.getNetlist());
 
         operators.put("*o", mult2);
 
@@ -204,15 +204,16 @@ public class PolynomialGenerator {
         sub.setNetlist(subDesign2.getNetlist());
         operators.put("-o", sub2);
 
-        for (Design design : new Design[]{multDesign,multDesign2,adderDesign,adderDesign2,subDesign,subDesign2}) {
-            for (EDIFCell cell : design.getNetlist().getWorkLibrary().getCells()) {
-                d.getNetlist().getWorkLibrary().addCell(cell);
-            }
-            EDIFLibrary hdi = d.getNetlist().getHDIPrimitivesLibrary();
-            for (EDIFCell cell : design.getNetlist().getHDIPrimitivesLibrary().getCells()) {
-                if (!hdi.containsCell(cell)) hdi.addCell(cell);
-            }
-        }
+        // EDIFLibrary work = d.getNetlist().getWorkLibrary();
+        // EDIFLibrary hdi = d.getNetlist().getHDIPrimitivesLibrary();
+        // for (Design design : new Design[]{multDesign,multDesign2,adderDesign,adderDesign2,subDesign,subDesign2}) {
+        //     for (EDIFCell cell : design.getNetlist().getWorkLibrary().getCells()) {
+        //         work.addCell(cell);
+        //     }
+        //     for (EDIFCell cell : design.getNetlist().getHDIPrimitivesLibrary().getCells()) {
+        //         if (!hdi.containsCell(cell)) hdi.addCell(cell);
+        //     }
+        // }
         return operators;
     }
 

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -742,7 +742,7 @@ public class DeviceResourcesVerifier {
 
         List<Map.Entry<SiteTypeEnum, String>> entries = new ArrayList<>();
 
-        Map<SiteTypeEnum,Set<String>> sites = physCell.getCompatiblePlacements();
+        Map<SiteTypeEnum,Set<String>> sites = physCell.getCompatiblePlacements(design.getDevice());
         Set<SiteTypeEnum> siteTypes = new HashSet<SiteTypeEnum>();
         siteTypes.addAll(sites.keySet());
         siteTypes.retainAll(siteMap.keySet());

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesVerifier.java
@@ -504,7 +504,7 @@ public class DeviceResourcesVerifier {
         Set<Unisim> unisimsExpected = new HashSet<Unisim>();
         for (EDIFLibrary lib : primsAndMacros.getLibraries()) {
             EDIFLibrary reference = lib.isHDIPrimitivesLibrary() ? Design.getPrimitivesLibrary(design.getDevice().getName()) :
-                                                    Design.getMacroPrimitives(series);
+                                                    new EDIFLibrary(Design.getMacroPrimitives(series));
 
             if (!lib.isHDIPrimitivesLibrary()) {
                 // Remove unused macros from reference

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
+++ b/src/com/xilinx/rapidwright/interchange/DeviceResourcesWriter.java
@@ -321,6 +321,8 @@ public class DeviceResourcesWriter {
 
         removeUnusedMacros(macros, prims);
 
+        // Perform a deep copy because macro cells (which were shallow copied before)
+        // must now instantiate primitives from our primitives library
         macros = netlist.copyLibraryAndSubCells(macros);
 
         Map<String, Pair<String, EnumSet<IOStandard>>> macroCollapseExceptionMap =

--- a/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
+++ b/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
@@ -718,7 +718,7 @@ public class EnumerateCellBelMapping {
 
         List<Map.Entry<SiteTypeEnum, String>> entries = new ArrayList<>();
 
-        Map<SiteTypeEnum,Set<String>> sites = physCell.getCompatiblePlacements();
+        Map<SiteTypeEnum,Set<String>> sites = physCell.getCompatiblePlacements(design.getDevice());
         for (Map.Entry<SiteTypeEnum,Set<String>> site : sites.entrySet()) {
             for (String bel : site.getValue()) {
                 entries.add(new AbstractMap.SimpleEntry<SiteTypeEnum, String>(site.getKey(), bel));

--- a/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
+++ b/src/com/xilinx/rapidwright/interchange/EnumerateCellBelMapping.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Keith Rothman, Google, Inc.

--- a/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
+++ b/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Advanced Micro Devices, Inc.

--- a/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
+++ b/test/src/com/xilinx/rapidwright/device/TestUnisimPlacements.java
@@ -41,7 +41,7 @@ public class TestUnisimPlacements {
             Design des = new Design("top", part.getName());
             EDIFCell cell = Design.getPrimitivesLibrary(des.getDevice().getName()).getCell("FDRE");
             Cell c = des.createCell("inst", cell);
-            Assertions.assertTrue(c.getCompatiblePlacements().size() > 1);
+            Assertions.assertTrue(c.getCompatiblePlacements(des.getDevice()).size() > 1);
             break;
         }
     }


### PR DESCRIPTION
* `EDIFCell.setLibrary()` can no longer be used to move an `EDIFCell` to another library. This prevents the builtin "singleton" cell maintained by RapidWright from being moved out of the singleton library into a user library. Purposely moving `EDIFCell`-s now requires a `EDIFLibrary.removeCell()` first.  
This prevention is necessary to ensure that such cells can't be attached to a user design, which then prevents the user netlist from being GC-ed.
* `EDIFLibrary.setNetlist()` is modified in the same way as for `EDIFCell.setLibrary()`.
* `EDIFLibrary.addCell()` will now make a shallow copy of an `EDIFCell` if it already belongs to a library.
* Updates required to support the above changes
* Migrate to new API `Cell.getCompatiblePlacements(Device)`