### PR TITLE
Make LogicalNetlistToEdif not expand macros by default

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -73,6 +73,7 @@ import com.xilinx.rapidwright.interchange.EnumerateCellBelMapping;
 import com.xilinx.rapidwright.interchange.GenerateInterchangeDevices;
 import com.xilinx.rapidwright.interchange.Interchange;
 import com.xilinx.rapidwright.interchange.LogicalNetlistExample;
+import com.xilinx.rapidwright.interchange.LogicalNetlistToEdif;
 import com.xilinx.rapidwright.interchange.PhysicalNetlistExample;
 import com.xilinx.rapidwright.interchange.PhysicalNetlistToDcp;
 import com.xilinx.rapidwright.ipi.BlockCreator;
@@ -152,6 +153,7 @@ public class MainEntrypoint {
         addFunction("JobQueue", JobQueue::main);
         addFunction("Lesson1", Lesson1::main);
         addFunction("LogicalNetlistExample", LogicalNetlistExample::main);
+        addFunction("LogicalNetlistToEdif", LogicalNetlistToEdif::main);
         addFunction("LUTTools", LUTTools::main);
         addFunction("MakeBlackBox", MakeBlackBox::main);
         addFunction("MergeDesigns", MergeDesigns::main);

--- a/src/com/xilinx/rapidwright/interchange/LogicalNetlistToEdif.java
+++ b/src/com/xilinx/rapidwright/interchange/LogicalNetlistToEdif.java
@@ -45,7 +45,7 @@ public class LogicalNetlistToEdif {
 
         // Read LogicalNetlist
         t.start("Read LogicalNetlist");
-        EDIFNetlist netlist = LogNetlistReader.readLogNetlist(args[0]);
+        EDIFNetlist netlist = LogNetlistReader.readLogNetlist(args[0], false);
 
         // Write EDIF
         t.stop().start("Write EDIF");


### PR DESCRIPTION
As Vivado must work with macros for the logical netlist, the default behavior of `LogicalNetlistToEdif`, which expands all macros, leads to an `opt_design` error in implementation of the post-synthesis project built on the output EDIF file. This error is evident in the following output:

> Command: opt_design
> Attempting to get a license for feature 'Implementation' and/or device 'xcvp1002'
> INFO: [Common 17-349] Got license for feature 'Implementation' and/or device 'xcvp1002'
> Running DRC as a precondition to command opt_design
> 
> Starting DRC Task
> INFO: [DRC 23-27] Running DRC with 8 threads
> ERROR: [DRC INBB-3] Black Box Instances: Cell 'ibufds/DIFFINBUF_INST' of type 'DIFFINBUF' has undefined contents and is considered a black box.  The contents of this cell must be defined for opt_design to complete successfully.
> ERROR: [DRC INBB-3] Black Box Instances: Cell 'ibufds/IBUFCTRL_INST' of type 'IBUFCTRL' has undefined contents and is considered a black box.  The contents of this cell must be defined for opt_design to complete successfully.
> INFO: [Project 1-461] DRC finished with 2 Errors
> INFO: [Project 1-462] Please refer to the DRC report (report_drc) for more information.
> ERROR: [Vivado_Tcl 4-78] Error(s) found during DRC. Opt_design not run.

It appears that not expanding macros would be the more suitable default behavior.