### PR TITLE
[RWRoute] Assign empty list when direct connections fails

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1030,7 +1030,7 @@ public class RWRoute {
             for (Connection connection : netWrapper.getConnections()) {
                 // Examine getNodes() because connection.getRnodes() is empty for direct connections
                 List<Node> nodes = connection.getNodes();
-                if (nodes.isEmpty()) {
+                if (nodes == null || nodes.isEmpty()) {
                     // Unroutable connection
                     continue;
                 }
@@ -1348,6 +1348,10 @@ public class RWRoute {
         for (Entry<Net,NetWrapper> e : nets.entrySet()) {
             NetWrapper netWrapper = e.getValue();
             for (Connection connection:netWrapper.getConnections()) {
+                if (connection.getNodes() == null) {
+                    continue;
+                }
+                    
                 netNodes.addAll(connection.getNodes());
             }
             for (Node node:netNodes) {


### PR DESCRIPTION
In `RouterHelper.routeDirectConnection(Connection directConnection)`, the field `nodes` of `directConnection` will be assigned a `null` value when `RouterHelper.findPathBetweenNodes` fails to find a path for it. This leads to `NullPointerException`s in `RWRoute.{postRouteProcess, computesNodeUsageAndTotalWirelength}`, and prevent the router from completing the output process. It would be more reasonable to allow the process to finish even if it fails to route some direct connections, as this would provide better debugging capabilities.