### PR TITLE
[DesignTools] Conform to Vivado *RST* pin inversion site routing configuration 

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3302,15 +3302,15 @@ public class DesignTools {
     }
     
     private static void maybeCreateVccPinAndPossibleInversion(SiteInst si, String sitePinName, Net vcc, Net gndInvertibleToVcc) {
-        if (si.getSitePinInst(sitePinName) == null) {
-            SitePinInst sitePin = vcc.createPin(sitePinName, si);
-            if (gndInvertibleToVcc != null && sitePinName.contains("RST")) {
-                assert sitePin.getSiteWireBELPins().size() == 1;
-                BELPin pin = sitePin.getSiteWireBELPins().get(0);
-                assert pin.getBEL().getPins().length == 2;
-                si.routeIntraSiteNet(gndInvertibleToVcc, pin, pin);
-            }            
+        SitePinInst sitePin = si.getSitePinInst(sitePinName);
+        if (sitePin == null) {
+            sitePin = vcc.createPin(sitePinName, si);
         }
+        // For the RST inversion to be interpreted properly by Vivado, there must be no
+        // site routing
+        // on the path.
+        BELPin belPin = sitePin.getBELPin();
+        si.unrouteIntraSiteNet(belPin, belPin);
     }
 
     public static void createMissingStaticSitePins(BELPin belPin, SiteInst si, Cell cell) {

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3306,11 +3306,12 @@ public class DesignTools {
         if (sitePin == null) {
             sitePin = vcc.createPin(sitePinName, si);
         }
-        // For the RST inversion to be interpreted properly by Vivado, there must be no
-        // site routing
-        // on the path.
-        BELPin belPin = sitePin.getBELPin();
-        si.unrouteIntraSiteNet(belPin, belPin);
+        if (gndInvertibleToVcc != null) {
+            // For the RST inversion to be interpreted properly by Vivado, there must be no
+            // site routing on the path around the inverter BEL
+            BELPin belPin = sitePin.getBELPin();
+            si.unrouteIntraSiteNet(belPin, belPin);
+        }
     }
 
     public static void createMissingStaticSitePins(BELPin belPin, SiteInst si, Cell cell) {

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3263,9 +3263,7 @@ public class DesignTools {
                         } else { //SRST
                             sitePinName = sitePinNames.getSecond();
                         }
-                        if (si.getSitePinInst(sitePinName) == null) {
-                            vcc.createPin(sitePinName, si);
-                        }
+                        maybeCreateVccPinAndPossibleInversion(si, sitePinName, vcc, gndInvertibleToVcc);
                     }
                 }
             } else if (cell.getType().equals("RAMB36E2") && cell.getAllPhysicalPinMappings("RSTREGB") == null) {
@@ -3275,9 +3273,7 @@ public class DesignTools {
                 Net net = si.getNetFromSiteWire(siteWire);
                 if (net == null) {
                     for (String pinName : Arrays.asList("RSTREGBU", "RSTREGBL")) {
-                        if (si.getSitePinInst(pinName) == null) {
-                            vcc.createPin(pinName, si);
-                        }
+                        maybeCreateVccPinAndPossibleInversion(si, pinName, vcc, gndInvertibleToVcc);
                     }
                 }
             } else if (cell.getType().equals("RAMB18E2") && cell.getAllPhysicalPinMappings("RSTREGB") == null) {
@@ -3299,11 +3295,23 @@ public class DesignTools {
                     } else {
                         pinName = "RSTREGBU";
                     }
-                    if (si.getSitePinInst(pinName) == null) {
-                        vcc.createPin(pinName, si);
-                    }
+                    maybeCreateVccPinAndPossibleInversion(si, pinName, vcc, gndInvertibleToVcc);
                 }
             }
+        }
+    }
+    
+    private static void maybeCreateVccPinAndPossibleInversion(SiteInst si, String sitePinName, Net vcc, Net gndInvertibleToVcc) {
+        if (si.getSitePinInst(sitePinName) == null) {
+            SitePinInst sitePin = vcc.createPin(sitePinName, si);
+            if (gndInvertibleToVcc != null && sitePinName.contains("RST")) {
+                assert sitePin.getSiteWireBELPins().size() == 2;
+                for (BELPin pin : sitePin.getSiteWireBELPins()) {
+                    if (pin.isSitePort()) continue;
+                    assert pin.getBEL().getPins().length == 2;
+                    si.routeIntraSiteNet(gndInvertibleToVcc, pin, pin);
+                }
+            }            
         }
     }
 

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3305,12 +3305,10 @@ public class DesignTools {
         if (si.getSitePinInst(sitePinName) == null) {
             SitePinInst sitePin = vcc.createPin(sitePinName, si);
             if (gndInvertibleToVcc != null && sitePinName.contains("RST")) {
-                assert sitePin.getSiteWireBELPins().size() == 2;
-                for (BELPin pin : sitePin.getSiteWireBELPins()) {
-                    if (pin.isSitePort()) continue;
-                    assert pin.getBEL().getPins().length == 2;
-                    si.routeIntraSiteNet(gndInvertibleToVcc, pin, pin);
-                }
+                assert sitePin.getSiteWireBELPins().size() == 1;
+                BELPin pin = sitePin.getSiteWireBELPins().get(0);
+                assert pin.getBEL().getPins().length == 2;
+                si.routeIntraSiteNet(gndInvertibleToVcc, pin, pin);
             }            
         }
     }


### PR DESCRIPTION
as part of the `DesignTools.createCeSrRstPinsToVCC()` method which gets called by `RWRoute.preprocess()`