### PR TITLE
[TestDesign] Add test for net ordering of >= 2022.1 DCPs

### DIFF
--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Jakob Wenzel, Xilinx Research Labs.
@@ -474,7 +474,7 @@ public class TestDesign {
             assert (d.getDevice().getName().equals("xcvu3p"));
             int tileDX = 0;
             int tileDY = slr * targetDevice.getMasterSLR().getNumOfClockRegionRows()
-                             * targetPart.getSeries().getCLEHeight();
+                    * targetPart.getSeries().getCLEHeight();
             Assertions.assertTrue(d.retargetPart(targetPart, tileDX, tileDY));
             Path output = tempDir.resolve("retarget_" + slr + ".dcp");
 
@@ -498,6 +498,21 @@ public class TestDesign {
                 VivadoToolsHelper.assertFullyRouted(output);
             }
         }
+    }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "picoblaze_ooc_X10Y235.dcp",            // Pre 2022.1 DCP
+            "picoblaze_ooc_X10Y235_2022_1.dcp",     // 2022.1 DCP
+    })
+    public void testNetOrder(String dcpFileName) {
+        Design design1 = RapidWrightDCP.loadDCP(dcpFileName);
+        Object[] nets1 = design1.getNets().toArray();
+
+        for (int i = 0; i < 10; i++) {
+            Design design2 = RapidWrightDCP.loadDCP(dcpFileName);
+            Object[] nets2 = design2.getNets().toArray();
+            Assertions.assertTrue(Arrays.equals(nets1, nets2));
+        }
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestNet.java
+++ b/test/src/com/xilinx/rapidwright/design/TestNet.java
@@ -354,4 +354,13 @@ public class TestNet {
 
         Assertions.assertEquals("I1", net0.getLogicalNet().getPortInst(f7mux0.getEDIFCellInst(), "I1").getName());
     }
+
+    @Test
+    public void testSingleClockNetSource() {
+        Design design = RapidWrightDCP.loadDCP("bug349.dcp");
+        Net net = design.getNet("CLK_BUFG_BOT_R_X60Y48_BUFGCTRL_X0Y0_O");
+        SitePinInst bufg_o = design.getSiteInstFromSiteName("BUFGCTRL_X0Y0").getSitePinInst("O");
+        Assertions.assertSame(bufg_o, net.getSource());
+        Assertions.assertNull(net.getAlternateSource());
+    }
 }


### PR DESCRIPTION
Looks like the net order of DCPs generated by Vivado >=2022.1 could be read non-deterministically. DCPs generated by RapidWright are unaffected. This test aims to demonstrate this issue (but perhaps unable to do so with GitHub Actions' free runners).