### PR TITLE
[RWRoute] Always clear prev pointer of unpreserved RouteNode-s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew -PlimitToSingleProc=${{ matrix.single_threaded }} test 
 
       - name: Archive Java Test Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always() && matrix.os == 'ubuntu-latest'
         with:
           name: Java Test Report
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload Test Results
         if: always() && matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,14 +53,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always() && matrix.os == 'ubuntu-latest'
         with:
-          name: Java Test Report ${{ matrix.single_threaded && '(Single Threaded)' || ''}}
+          name: Java Test Report ${{ matrix.single_threaded }}
           path: build/reports/tests/testJava
 
       - name: Upload Test Results
         if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: Unit Test Results ${{ matrix.single_threaded && '(Single Threaded)' || ''}}
+          name: Unit Test Results ${{ matrix.single_threaded }}
           path: |
             build/test-results/**/*.xml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,14 +53,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always() && matrix.os == 'ubuntu-latest'
         with:
-          name: Java Test Report
+          name: Java Test Report ${{ matrix.single_threaded && '(Single Threaded)' || ''}}
           path: build/reports/tests/testJava
 
       - name: Upload Test Results
         if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: Unit Test Results
+          name: Unit Test Results ${{ matrix.single_threaded && '(Single Threaded)' || ''}}
           path: |
             build/test-results/**/*.xml
 

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -354,7 +354,7 @@ public class PartialRouter extends RWRoute {
                             continue;
                         }
 
-                        assert (rnode.getPrev() != null);
+                        assert(rnode.getPrev() != null);
                     }
 
                     // RouteNode must only exist if its net has been unpreserved
@@ -366,12 +366,13 @@ public class PartialRouter extends RWRoute {
                     // from the beginning. However, since other objects (e.g. Connection-s) may hold a reference
                     // to this, that would not be wise.
                     // Instead, increment the use of this RouteNode with a null net (since global nets have
-                    // no corresponding NetWrapper) in order to flag it as being irreversibly used thus forcing
-                    // the non-global to find another path
+                    // no corresponding NetWrapper) in order to indicate to Connection.isCongested() that it needs
+                    // to be rerouted.
                     rnode.incrementUser(null);
                 }
             }
         }
+
         return unpreserveNets;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -224,7 +224,7 @@ public class PartialRouter extends RWRoute {
             return NodeStatus.INUSE;
         }
         if (preservedNet != null) {
-            if (!softPreserve || net.isStaticNet()) {
+            if (!softPreserve) {
                 return NodeStatus.UNAVAILABLE;
             }
 
@@ -331,7 +331,7 @@ public class PartialRouter extends RWRoute {
 
                         // This could be a leftover node from a previously unpreserved net
                         // (with its prev pointer set to allow its routing to be recovered)
-                        // Fall through so that this can be cleared
+                        // Fall through so that this can be cleared and blocked
                     } else {
                         if (preservedNet == null) {
                             // Assume this node has already been unpreserved

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -372,7 +372,6 @@ public class PartialRouter extends RWRoute {
                 }
             }
         }
-
         return unpreserveNets;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -160,7 +160,7 @@ public class PartialRouter extends RWRoute {
 
         // Presence of a prev pointer means that:
         //   (a) end node has been visited before
-        //   (b) only this is arc allowed to enter this end node
+        //   (b) only that arc is allowed to enter this end node
         RouteNode prev = endRnode.getPrev();
         if (prev != null) {
             if (endRnode.isVisited(start.getVisited())) {
@@ -224,7 +224,7 @@ public class PartialRouter extends RWRoute {
             return NodeStatus.INUSE;
         }
         if (preservedNet != null) {
-            if (!softPreserve) {
+            if (!softPreserve || net.isStaticNet()) {
                 return NodeStatus.UNAVAILABLE;
             }
 
@@ -321,40 +321,54 @@ public class PartialRouter extends RWRoute {
         for (Net net : globalNets) {
             for (PIP pip : net.getPIPs()) {
                 for (Node node : Arrays.asList(pip.getStartNode(), pip.getEndNode())) {
+                    RouteNode rnode;
                     Net preservedNet = routingGraph.getPreservedNet(node);
                     if (preservedNet == net) {
-                        continue;
-                    }
-                    if (preservedNet == null) {
-                        // Assume this node has already been unpreserved
-                    } else if (RouterHelper.isRoutableNetWithSourceSinks(preservedNet)) {
-                        unpreserveNet(preservedNet);
-                        unpreserveNets.add(preservedNet);
-                    }
+                        rnode = routingGraph.getNode(node);
+                        if (rnode == null) {
+                            continue;
+                        }
 
-                    // Preserve node for global net
-                    Net oldNet = routingGraph.preserve(node, net);
-                    if (oldNet != null) {
-                        // oldNet/preservedNet is not a routable net (e.g. driven by hier port)
-                        assert(oldNet == preservedNet);
-                        assert(!RouterHelper.isRoutableNetWithSourceSinks(preservedNet));
-                    }
-
-                    // RouteNode must only exist if the net has been unpreserved
-                    RouteNode rnode = routingGraph.getNode(node);
-                    if (rnode != null) {
-                        // Clear its prev pointer so that it doesn't get misinterpreted
-                        // by RouteNodeGraph.mustInclude as being part of an existing route
-                        assert (rnode.getPrev() != null);
-                        rnode.clearPrev();
-
-                        // Increment this RouteNode with a null net (since global nets have
-                        // no corresponding NetWrapper) in order to flag it as being irreversibly
-                        // used by a global net thus forcing the non-global to find another path
-                        rnode.incrementUser(null);
+                        // This could be a leftover node from a previously unpreserved net
+                        // (with its prev pointer set to allow its routing to be recovered)
+                        // Fall through so that this can be cleared
                     } else {
-                        assert(oldNet != null);
+                        if (preservedNet == null) {
+                            // Assume this node has already been unpreserved
+                        } else if (RouterHelper.isRoutableNetWithSourceSinks(preservedNet)) {
+                            unpreserveNet(preservedNet);
+                            unpreserveNets.add(preservedNet);
+                        }
+
+                        // Preserve node for global net
+                        Net oldNet = routingGraph.preserve(node, net);
+                        if (oldNet != null) {
+                            // oldNet/preservedNet is not a routable net (e.g. driven by hier port)
+                            assert(oldNet == preservedNet);
+                            assert(!RouterHelper.isRoutableNetWithSourceSinks(preservedNet));
+                        }
+
+                        rnode = routingGraph.getNode(node);
+                        if (rnode == null) {
+                            assert(oldNet != null);
+                            continue;
+                        }
+
+                        assert (rnode.getPrev() != null);
                     }
+
+                    // RouteNode must only exist if its net has been unpreserved
+                    // Clear its prev pointer so that it doesn't get misinterpreted
+                    // by RouteNodeGraphPartial.isPartOfExistingRoute as being part of an existing route
+                    rnode.clearPrev();
+
+                    // Ideally, we would want to blow this RouteNode from existence as if it was preserved
+                    // from the beginning. However, since other objects (e.g. Connection-s) may hold a reference
+                    // to this, that would not be wise.
+                    // Instead, increment the use of this RouteNode with a null net (since global nets have
+                    // no corresponding NetWrapper) in order to flag it as being irreversibly used thus forcing
+                    // the non-global to find another path
+                    rnode.incrementUser(null);
                 }
             }
         }


### PR DESCRIPTION
Very rare behaviour described below.

Context: Net1 is a fully routed net utilizing a number of nodes (Node1, Node2, Node3, ...)

1. During clock routing, it's decided that Node1 is needed to complete the clock net, and so the entirety of Net1 is unpreserved, and the result of the clock route is then preserved.
2. During static net routing, Node2 is determined to be needed to complete a static net. Since Node2 is no longer being preserved, the static net gets to preserve it. 

Note that because Node2 was unpreserved previously, it already exists in the routing graph as a `RouteNode`. 

3. Later, during signal routing, this node breaks the assumption that preserved nodes can only be used by the same net pointed to by its `prev` pointer.

This PR allows clears this `prev` pointer so that this assumption is maintained.