### PR TITLE
[GitHub Actions] Migrate to upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew -PlimitToSingleProc=${{ matrix.single_threaded }} test 
 
       - name: Archive Java Test Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always() && matrix.os == 'ubuntu-latest'
         with:
           name: Java Test Report
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload Test Results
         if: always() && matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,14 +53,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always() && matrix.os == 'ubuntu-latest'
         with:
-          name: Java Test Report ${{ matrix.single_threaded && '(Single Threaded)' || ''}}
+          name: Java Test Report ${{ matrix.single_threaded }}
           path: build/reports/tests/testJava
 
       - name: Upload Test Results
         if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: Unit Test Results ${{ matrix.single_threaded && '(Single Threaded)' || ''}}
+          name: Unit Test Results ${{ matrix.single_threaded }}
           path: |
             build/test-results/**/*.xml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,14 +53,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always() && matrix.os == 'ubuntu-latest'
         with:
-          name: Java Test Report
+          name: Java Test Report ${{ matrix.single_threaded && '(Single Threaded)' || ''}}
           path: build/reports/tests/testJava
 
       - name: Upload Test Results
         if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: Unit Test Results
+          name: Unit Test Results ${{ matrix.single_threaded && '(Single Threaded)' || ''}}
           path: |
             build/test-results/**/*.xml
 


### PR DESCRIPTION
Since @v2 is now deprecated and causes a failure.

Builds on commit from #1057.