### PR TITLE
[EDIF] Fixes rare bus renaming collision

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -291,12 +291,23 @@ public class EDIFPort extends EDIFPropertyObject {
      * @throws IOException
      */
     public void exportEDIFBusName(OutputStream os, EDIFWriteLegalNameCache<?> cache) throws IOException {
-        String busName = getBusName(false);
-        EDIFPort collision = parentCell.getPort(busName);
-        byte[] rename = collision == null ? cache.getEDIFRename(busName) : cache.getBusCollisionEDIFRename(busName);
-        exportSomeEDIFName(os, getName(), rename == null ? busName.getBytes(StandardCharsets.UTF_8) : rename);
+        exportSomeEDIFName(os, getName(), getBusEDIFRename(cache));
     }
 
+    /**
+     * Handles bus name collisions with single bit ports (same root name) to avoid
+     * EDIF export name legalization collisions.
+     * 
+     * @param cache The current EDIF name legalization cache
+     * @return The legalize EDIF bus name for this port
+     */
+    protected byte[] getBusEDIFRename(EDIFWriteLegalNameCache<?> cache) {
+        String busName = getBusName(false);
+        boolean collision = parentCell.getPortMap().containsKey(busName);
+        byte[] rename = collision ? cache.getBusCollisionEDIFRename(busName) : cache.getEDIFRename(busName);
+        return rename == null ? busName.getBytes(StandardCharsets.UTF_8) : rename;
+    }
+    
     /**
      * @return the parentCell
      */

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -292,8 +292,9 @@ public class EDIFPort extends EDIFPropertyObject {
      */
     public void exportEDIFBusName(OutputStream os, EDIFWriteLegalNameCache<?> cache) throws IOException {
         String busName = getBusName(false);
-        byte[] rename = cache.getEDIFRename(busName);
-        exportSomeEDIFName(os, getName(), rename == null ? busName.getBytes() : rename);
+        EDIFPort collision = parentCell.getPort(busName);
+        byte[] rename = collision == null ? cache.getEDIFRename(busName) : cache.getBusCollisionEDIFRename(busName);
+        exportSomeEDIFName(os, getName(), rename == null ? busName.getBytes(StandardCharsets.UTF_8) : rename);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -291,7 +291,9 @@ public class EDIFPort extends EDIFPropertyObject {
      * @throws IOException
      */
     public void exportEDIFBusName(OutputStream os, EDIFWriteLegalNameCache<?> cache) throws IOException {
-        exportSomeEDIFName(os, getName(), cache.getEDIFRename(busName));
+        String busName = getBusName(false);
+        byte[] rename = cache.getEDIFRename(busName);
+        exportSomeEDIFName(os, getName(), rename == null ? busName.getBytes() : rename);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -314,7 +314,9 @@ public class EDIFPortInst implements Comparable<EDIFPortInst> {
         }
         else {
             os.write(EXPORT_CONST_MEMBER);
-            os.write(cache.getLegalEDIFName(getPort().getBusName(false)));
+            String busName = getPort().getBusName(false);
+            EDIFPort collision = getPort().getParentCell().getPort(busName);
+            os.write(collision == null ? cache.getLegalEDIFName(busName) : cache.getBusCollisionEDIFRename(busName));
             os.write(' ');
             os.write(Integer.toString(index).getBytes(StandardCharsets.UTF_8));
             os.write(')');

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -314,9 +314,7 @@ public class EDIFPortInst implements Comparable<EDIFPortInst> {
         }
         else {
             os.write(EXPORT_CONST_MEMBER);
-            String busName = getPort().getBusName(false);
-            EDIFPort collision = getPort().getParentCell().getPort(busName);
-            os.write(collision == null ? cache.getLegalEDIFName(busName) : cache.getBusCollisionEDIFRename(busName));
+            os.write(getPort().getBusEDIFRename(cache));
             os.write(' ');
             os.write(Integer.toString(index).getBytes(StandardCharsets.UTF_8));
             os.write(')');

--- a/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPortInst.java
@@ -314,7 +314,7 @@ public class EDIFPortInst implements Comparable<EDIFPortInst> {
         }
         else {
             os.write(EXPORT_CONST_MEMBER);
-            os.write(cache.getLegalEDIFName(getPort().getBusName(true)));
+            os.write(cache.getLegalEDIFName(getPort().getBusName(false)));
             os.write(' ');
             os.write(Integer.toString(index).getBytes(StandardCharsets.UTF_8));
             os.write(')');

--- a/src/com/xilinx/rapidwright/edif/EDIFWriteLegalNameCache.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFWriteLegalNameCache.java
@@ -52,12 +52,15 @@ public abstract class EDIFWriteLegalNameCache<T> {
      */
     private final Map<String, byte[]>[] renames;
 
+    private final Map<String, byte[]> busCollisionRenames;
+
     private EDIFWriteLegalNameCache(Map<String, T> usedRenames, Supplier<Map<String, byte[]>> renameSupplier) {
         this.usedRenames = usedRenames;
         this.renames = new Map[256];
         for (int i = 0; i < renames.length; i++) {
             renames[i] = renameSupplier.get();
         }
+        this.busCollisionRenames = new HashMap<>();
     }
 
     protected abstract int getAndIncrement(String rename);
@@ -84,6 +87,11 @@ public abstract class EDIFWriteLegalNameCache<T> {
             return null;
         }
         return rename;
+    }
+
+    public byte[] getBusCollisionEDIFRename(String name) {
+        return busCollisionRenames.computeIfAbsent(name,
+                n -> (EDIFTools.makeNameEDIFCompatible(n) + "_BUS_").getBytes(StandardCharsets.UTF_8));
     }
 
     public static EDIFWriteLegalNameCache<?> singleThreaded() {

--- a/src/com/xilinx/rapidwright/examples/MultGenerator.java
+++ b/src/com/xilinx/rapidwright/examples/MultGenerator.java
@@ -263,7 +263,12 @@ public class MultGenerator extends ArithmeticGenerator {
             for (int i=0; i < port.getWidth(); i++) {
                 EDIFNet net = top.createNet(port.getBusName() + (port.getWidth() > 1 ? "[" + i + "]" : ""));
                 int ii = port.getWidth() - 1 - i;
-                net.createPortInst(port.getBusName(), ii, inst);
+                if (port.isBus()) {
+                    net.createPortInst(port.getBusName(), ii, inst);
+                } else {
+                    net.createPortInst(port, inst);
+                }
+
                 Net physNet = d.createNet(inst + "/" + net.getName());
 
                 // Correct differences in physical pin names

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -461,7 +461,7 @@ class TestEDIFNetlist {
 
         String portName = "unfortunate_name";
 
-        // Create two ports, one single-bit and another bussed with the same root name
+        // Create two bussed ports with a common root name, one having a trailing '_' underscore
         EDIFPort port0 = top.createPort(portName + "[2:0]", EDIFDirection.INOUT, 3);
         EDIFPort port1 = top.createPort(portName + "_[1:0]", EDIFDirection.INOUT, 2);
 

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -464,6 +464,8 @@ class TestEDIFNetlist {
         // Create two bussed ports with a common root name, one having a trailing '_' underscore
         EDIFPort port0 = top.createPort(portName + "[2:0]", EDIFDirection.INOUT, 3);
         EDIFPort port1 = top.createPort(portName + "_[1:0]", EDIFDirection.INOUT, 2);
+        // And for good measure, throw in a single-bit port too with the same root
+        EDIFPort port2 = top.createPort(portName, EDIFDirection.INOUT, 1);
 
         EDIFNet net0 = top.createNet("net0");
         net0.createPortInst(port0, 0);
@@ -472,6 +474,10 @@ class TestEDIFNetlist {
         EDIFNet net1 = top.createNet("net1");
         net1.createPortInst(port1, 1);
         net1.createPortInst("R", ff);
+        
+        DIFNet net2 = top.createNet("net2");
+        net2.createPortInst(port2);
+        net2.createPortInst("Q", ff);
 
         Path tempFile = path.resolve("test.edf");
         origNetlist.exportEDIF(tempFile);

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -475,7 +475,7 @@ class TestEDIFNetlist {
         net1.createPortInst(port1, 1);
         net1.createPortInst("R", ff);
         
-        DIFNet net2 = top.createNet("net2");
+        EDIFNet net2 = top.createNet("net2");
         net2.createPortInst(port2);
         net2.createPortInst("Q", ff);
 


### PR DESCRIPTION
There are two competing issues relevant to this fix.

1. There are unfortunately situations where an `EDIFCell` can have two `EDIFPort` objects, a single bit port and a bussed port with the same name, for example `my_signal` and `my_signal[1:0]`.  We resolve this naming collision by storing the bussed version with a `[` suffix, `my_signal[`.  
2. In some designs, it is possible to have two `EDIFPort` objects belonging to the same `EDIFCell` such that when one bussed name is EDIF legalized, it collides with another valid `EDIFPort` name.  For example, `phy_ctrl[1:0]` and `phy_ctrl_[13:0]`.  Due to the possible naming collision issues from issue 1, all bussed ports are given a `[` suffix to the name and thus the legal names of busses are all extended by one character, `phy_ctrl`  (original) -> `phy_ctrl[` (stored) -> `phy_ctrl_` (legalized EDIF name).  This leads to ambiguity for the other bused port on the cell and leads to reading problems of the netlist (see test added in the PR to illustrate).

This PR attempts to resolve both of these issue by removing the trailing `[` before legalization and also checking to see if there is indeed a colliding single-bit port name that collides with the bussed port name, if there is, it is given an additional suffix during EDIF naming legalization and stored in a separate map, otherwise, the renaming proceeds as normal.  This has a small impact to runtime (~5% EDIF write time).  This does not impact EDIF read.

This also fixes a connectivity issue when generating multipliers (`MultGenerator`) where it was blindly connecting all signals as busses.  This now detects if it is a bus or single bit port and connects accordingly.