### PR TITLE
[PartialRouter] Disable ripup in global/static routing

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -516,28 +516,6 @@ public class RWRoute {
             GlobalSignalRouting.routeStaticNet(staticNet, gns, design, routethruHelper);
 
             preserveNet(staticNet, false);
-
-            // When a [A-H]MUX pin is used as a static source, also preserve the [A-H]_O pin
-            // so that it can't be used by other static nets, nor as a LUT routethru
-            for (SitePinInst spi : staticNet.getPins()) {
-                if (!spi.isOutPin()) {
-                    continue;
-                }
-
-                SiteInst si = spi.getSiteInst();
-                if (!Utils.isSLICE(si)) {
-                    continue;
-                }
-
-                String pinName = spi.getName();
-                if (pinName.endsWith("MUX")) {
-                    char lutLetter = pinName.charAt(0);
-                    Node oNode = si.getSite().getConnectedNode(lutLetter + "_O");
-                    routingGraph.preserve(oNode, staticNet);
-                } else {
-                    assert(pinName.endsWith("_O"));
-                }
-            }
         }
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -329,7 +329,7 @@ public class RouteNodeGraph {
                 } else if (pinName.endsWith("_O")) {
                     otherPinName = lutLetter + "MUX";
                 } else {
-                    throw new RuntimeException(pinName);
+                    throw new RuntimeException("ERROR: Unsupported site pin " + pin);
                 }
 
                 Node otherNode = si.getSite().getConnectedNode(otherPinName);


### PR DESCRIPTION
Mostly reverting https://github.com/Xilinx/RapidWright/pull/759.

Also fix an issue with same LUT source being used illegally to serve VCC and GND.