### PR TITLE
[RWRoute] Further cleanup

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -272,7 +272,6 @@ public class Connection implements Comparable<Connection>{
 
     public void resetRoute() {
         getRnodes().clear();
-        sink.setRouted(false);
     }
 
     public RouteNode getSourceRnode() {

--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -34,6 +34,7 @@ import com.xilinx.rapidwright.design.SitePinInst;
 import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.timing.TimingEdge;
 import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
+import com.xilinx.rapidwright.util.Pair;
 
 /**
  * A Connection instance represents a pair of source-sink {@link SitePinInst} instances of a {@link Net} instance.
@@ -488,5 +489,26 @@ public class Connection implements Comparable<Connection>{
                 }
             }
         }
+    }
+
+    protected Pair<SitePinInst,RouteNode> getOrCreateAlternateSource(RouteNodeGraph routingGraph) {
+        SitePinInst altSource = netWrapper.getOrCreateAlternateSource(routingGraph);
+        if (altSource == null) {
+            return null;
+        }
+
+        Net net = netWrapper.getNet();
+        RouteNode altSourceRnode;
+        if (source.equals(net.getSource())) {
+            altSourceRnode = netWrapper.getAltSourceRnode();
+        } else {
+            assert(source.equals(net.getAlternateSource()));
+            altSource = net.getSource();
+            assert(altSource != null);
+            altSourceRnode = netWrapper.getSourceRnode();
+        }
+
+        assert(altSourceRnode != null);
+        return new Pair<>(altSource, altSourceRnode);
     }
 }

--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2021 Ghent University.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Yun Zhou, Ghent University.

--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -49,7 +49,6 @@ public class Connection implements Comparable<Connection>{
      * They are created based on the INT tile nodes the source and sink SitePinInsts connect to, respectively.
      */
     private RouteNode sourceRnode;
-    private RouteNode altSourceRnode;
     private RouteNode sinkRnode;
     private List<RouteNode> altSinkRnodes;
     /**
@@ -282,14 +281,6 @@ public class Connection implements Comparable<Connection>{
 
     public void setSourceRnode(RouteNode sourceNode) {
         sourceRnode = sourceNode;
-    }
-
-    public RouteNode getAltSourceRnode() {
-        return altSourceRnode;
-    }
-
-    public void setAltSourceRnode(RouteNode altSourceNode) {
-        altSourceRnode = altSourceNode;
     }
 
     public RouteNode getSinkRnode() {

--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -413,7 +413,7 @@ public class Connection implements Comparable<Connection>{
     }
 
     public List<Node> getNodes() {
-        return nodes;
+        return nodes == null ? Collections.emptyList() : nodes;
     }
 
     public void setNodes(List<Node> nodes) {

--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -352,6 +352,7 @@ public class Connection implements Comparable<Connection>{
     }
 
     public void setSource(SitePinInst source) {
+        assert(source != null);
         this.source = source;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
+++ b/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
@@ -143,7 +143,7 @@ public class NetWrapper{
         this.sourceRnode = sourceRnode;
     }
 
-    public SitePinInst getAltSource(RouteNodeGraph routingGraph) {
+    public SitePinInst getOrCreateAlternateSource(RouteNodeGraph routingGraph) {
         if (noAltSourceFound) {
             return null;
         }

--- a/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
+++ b/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2021 Ghent University.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Yun Zhou, Ghent University.

--- a/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
+++ b/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
@@ -158,7 +158,8 @@ public class NetWrapper{
 
             net.addPin(altSource);
             DesignTools.routeAlternativeOutputSitePin(net, altSource);
-
+        }
+        if (altSourceRnode == null) {
             Node altSourceNode = RouterHelper.projectOutputPinToINTNode(altSource);
             if (altSourceNode == null) {
                 noAltSourceFound = true;
@@ -172,6 +173,7 @@ public class NetWrapper{
 
             altSourceRnode = routingGraph.getOrCreate(altSourceNode, RouteNodeType.PINFEED_O);
         }
+        assert(altSourceRnode != null);
         return altSource;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
+++ b/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
@@ -27,7 +27,10 @@ package com.xilinx.rapidwright.rwroute;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.xilinx.rapidwright.design.DesignTools;
 import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SitePinInst;
+import com.xilinx.rapidwright.device.Node;
 
 /**
  * A wrapper class of {@link Net} with additional information for the router.
@@ -44,11 +47,15 @@ public class NetWrapper{
     private float yCenter;
     /** The half-perimeter wirelength */
     private short doubleHpwl;
+    boolean noAltSourceFound;
+    private RouteNode sourceRnode;
+    private RouteNode altSourceRnode;
 
     public NetWrapper(int id, Net net) {
         this.id = id;
         this.net = net;
         connections = new ArrayList<>();
+        noAltSourceFound = false;
     }
 
     public void computeHPWLAndCenterCoordinates(int[] nextLagunaColumn, int[] prevLagunaColumn) {
@@ -128,4 +135,47 @@ public class NetWrapper{
         return id;
     }
 
+    public RouteNode getSourceRnode() {
+        return sourceRnode;
+    }
+
+    public void setSourceRnode(RouteNode sourceRnode) {
+        this.sourceRnode = sourceRnode;
+    }
+
+    public SitePinInst getAltSource(RouteNodeGraph routingGraph) {
+        if (noAltSourceFound) {
+            return null;
+        }
+
+        SitePinInst altSource = net.getAlternateSource();
+        if (altSource == null) {
+            altSource = DesignTools.getLegalAlternativeOutputPin(net);
+            if (altSource == null) {
+                noAltSourceFound = true;
+                return null;
+            }
+
+            net.addPin(altSource);
+            DesignTools.routeAlternativeOutputSitePin(net, altSource);
+
+            Node altSourceNode = RouterHelper.projectOutputPinToINTNode(altSource);
+            if (altSourceNode == null) {
+                noAltSourceFound = true;
+                return null;
+            }
+
+            if (routingGraph.isPreserved(altSourceNode)) {
+                noAltSourceFound = true;
+                return null;
+            }
+
+            altSourceRnode = routingGraph.getOrCreate(altSourceNode, RouteNodeType.PINFEED_O);
+        }
+        return altSource;
+    }
+
+    public RouteNode getAltSourceRnode() {
+        return altSourceRnode;
+    }
 }

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -87,12 +87,16 @@ public class PartialRouter extends RWRoute {
 
         @Override
         public boolean isAccessible(RouteNode childRnode, Connection connection) {
+            if (super.isAccessible(childRnode, connection)) {
+                return true;
+            }
             Net preservedNet = getPreservedNet(childRnode);
             if (preservedNet == connection.getNetWrapper().getNet()) {
                 // Always allow nodes preserved for this connection's net
+                super.isAccessible(childRnode, connection);
                 return true;
             }
-            return super.isAccessible(childRnode, connection);
+            return false;
         }
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -615,11 +615,19 @@ public class PartialRouter extends RWRoute {
         boolean hasAltOutput = super.handleUnroutableConnection(connection);
         if (hasAltOutput)
             return true;
-        if (softPreserve) {
-            if (routeIteration == 2) {
-                unpreserveNetsAndReleaseResources(connection);
-                return true;
+        if (routeIteration == 2) {
+            if (softPreserve) {
+                 int netsUnpreserved = unpreserveNetsAndReleaseResources(connection);
+                 if (netsUnpreserved > 0) {
+                     return true;
+                 }
             }
+        }
+        if (config.isUseBoundingBox() && !config.isEnlargeBoundingBox()) {
+            // Since bounding box is never enlarged, there is no hope of routing this connection
+            // so abandon it
+            indirectConnections.remove(connection);
+            return true;
         }
         return false;
     }

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -84,20 +84,6 @@ public class PartialRouter extends RWRoute {
             }
             return super.isExcluded(parent, child);
         }
-
-        @Override
-        public boolean isAccessible(RouteNode childRnode, Connection connection) {
-            if (super.isAccessible(childRnode, connection)) {
-                return true;
-            }
-            Net preservedNet = getPreservedNet(childRnode);
-            if (preservedNet == connection.getNetWrapper().getNet()) {
-                // Always allow nodes preserved for this connection's net
-                super.isAccessible(childRnode, connection);
-                return true;
-            }
-            return false;
-        }
     }
 
     protected static class RouteNodeGraphPartialTimingDriven extends RouteNodeGraphTimingDriven {
@@ -120,16 +106,6 @@ public class PartialRouter extends RWRoute {
                 return false;
             }
             return super.isExcluded(parent, child);
-        }
-
-        @Override
-        public boolean isAccessible(RouteNode childRnode, Connection connection) {
-            Net preservedNet = getPreservedNet(childRnode);
-            if (preservedNet == connection.getNetWrapper().getNet()) {
-                // Always allow nodes preserved for this connection's net
-                return true;
-            }
-            return super.isAccessible(childRnode, connection);
         }
     }
 
@@ -413,6 +389,8 @@ public class PartialRouter extends RWRoute {
         super.finishRouteConnection(connection, rnode);
 
         if (!connection.getSink().isRouted()) {
+            // TODO: Consider backtrack-ed result into alternate source
+
             connection.resetRoute();
             if (connection.getAltSinkRnodes().isEmpty()) {
                 // Undo what ripUp() would have done for this connection which has a single exclusive sink

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -505,6 +505,8 @@ public class PartialRouter extends RWRoute {
     }
 
     protected void unpreserveNet(Net net) {
+        assert(!net.getName().equals(Net.Z_NET));
+
         Set<RouteNode> rnodes = new HashSet<>();
         NetWrapper netWrapper = nets.get(net);
         if (netWrapper != null) {

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -262,19 +262,23 @@ public class PartialRouter extends RWRoute {
 
         // With all routingGraph.preserveAsync() calls having completed,
         // now check sink routability
-        Set<Net> netsToUnpreserve = new HashSet<>();
+        Set<Net> unpreserveNets = new HashSet<>();
         for (Connection connection : indirectConnections) {
             Net net = connection.getNetWrapper().getNet();
             RouteNode sinkRnode = connection.getSinkRnode();
             Net unpreserveNet = routingGraph.getPreservedNet(sinkRnode);
             if (unpreserveNet != null && unpreserveNet != net) {
-                netsToUnpreserve.add(unpreserveNet);
+                unpreserveNets.add(unpreserveNet);
                 sinkRnode.setType(RouteNodeType.PINFEED_I);
                 sinkRnode.clearPrev();
             }
         }
-        for (Net unpreserveNet : netsToUnpreserve) {
-            unpreserveNet(unpreserveNet);
+
+        if (unpreserveNets.isEmpty()) {
+            System.out.println("INFO: Unpreserving " + unpreserveNets.size() + " nets to improve sink routability");
+            for (Net unpreserveNet : unpreserveNets) {
+                unpreserveNet(unpreserveNet);
+            }
         }
 
         // Go through all nets to be routed

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -610,7 +610,7 @@ public class PartialRouter extends RWRoute {
         boolean hasAltOutput = super.handleUnroutableConnection(connection);
         if (hasAltOutput)
             return true;
-        if (routeIteration == 2) {
+        if ((routeIteration == 1 && !hasAltOutput) || routeIteration == 2) {
             if (softPreserve) {
                  int netsUnpreserved = unpreserveNetsAndReleaseResources(connection);
                  if (netsUnpreserved > 0) {
@@ -619,8 +619,8 @@ public class PartialRouter extends RWRoute {
             }
         }
         if (config.isUseBoundingBox() && !config.isEnlargeBoundingBox()) {
-            // Since bounding box is never enlarged, there is no hope of routing this connection
-            // so abandon it
+            // Since bounding box is never enlarged, and there is nothing to be unpreserved,
+            // then there is no hope of routing this connection so abandon it
             indirectConnections.remove(connection);
             return true;
         }

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -241,7 +241,10 @@ public class PartialRouter extends RWRoute {
         super.determineRoutingTargets();
 
         // With all routingGraph.preserveAsync() calls having completed,
-        // now check sink routability
+        // now check that no sinks are preserved by another net
+        // (e.g. a pin was moved from one net to the other, but
+        // its old routing was not ripped up and got preserved)
+        // if so, unpreserve that blocking net
         Set<Net> unpreserveNets = new HashSet<>();
         for (Connection connection : indirectConnections) {
             Net net = connection.getNetWrapper().getNet();

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2021 Ghent University.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Yun Zhou, Ghent University.

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -274,7 +274,7 @@ public class PartialRouter extends RWRoute {
             }
         }
 
-        if (unpreserveNets.isEmpty()) {
+        if (!unpreserveNets.isEmpty()) {
             System.out.println("INFO: Unpreserving " + unpreserveNets.size() + " nets to improve sink routability");
             for (Net unpreserveNet : unpreserveNets) {
                 unpreserveNet(unpreserveNet);

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -274,8 +274,10 @@ public class PartialRouter extends RWRoute {
 
         if (!unpreserveNets.isEmpty()) {
             System.out.println("INFO: Unpreserving " + unpreserveNets.size() + " nets to improve sink routability");
-            for (Net unpreserveNet : unpreserveNets) {
-                unpreserveNet(unpreserveNet);
+            for (Net net : unpreserveNets) {
+                System.out.println("\t" + net);
+                assert(!net.isStaticNet());
+                unpreserveNet(net);
             }
         }
     }

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -49,6 +49,7 @@ import com.xilinx.rapidwright.timing.ClkRouteTiming;
 import com.xilinx.rapidwright.timing.TimingManager;
 import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
 import com.xilinx.rapidwright.timing.delayestimator.InterconnectInfo;
+import com.xilinx.rapidwright.util.Pair;
 
 /**
  * A class extending {@link RWRoute} for partial routing.
@@ -389,7 +390,19 @@ public class PartialRouter extends RWRoute {
         super.finishRouteConnection(connection, rnode);
 
         if (!connection.getSink().isRouted()) {
-            // TODO: Consider backtrack-ed result into alternate source
+            List<RouteNode> rnodes = connection.getRnodes();
+            SitePinInst altSource = connection.getNetWrapper().getNet().getAlternateSource();
+            if (rnodes.size() > 1 && altSource != null) {
+                RouteNode sourceRnode = rnodes.get(rnodes.size() - 1);
+                assert(connection.getSourceRnode() != sourceRnode);
+                Pair<SitePinInst,RouteNode> altSourceAndRnode = connection.getOrCreateAlternateSource(routingGraph);
+                assert(altSourceAndRnode != null);
+                RouteNode altSourceRnode = altSourceAndRnode.getSecond();
+                if (sourceRnode == altSourceRnode) {
+                    // We must have backtracked to the alternate source
+                    throw new RuntimeException("TODO");
+                }
+            }
 
             connection.resetRoute();
             if (connection.getAltSinkRnodes().isEmpty()) {

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -370,8 +370,8 @@ public class PartialRouter extends RWRoute {
                 if (routingGraph.isExcludedTile(end))
                     continue;
 
-                RouteNode rstart = getOrCreateRouteNode(start, null);
-                RouteNode rend = getOrCreateRouteNode(end, null);
+                RouteNode rstart = routingGraph.getOrCreate(start);
+                RouteNode rend = routingGraph.getOrCreate(end);
                 assert(rend.getPrev() == null);
                 rend.setPrev(rstart);
             }
@@ -530,8 +530,8 @@ public class PartialRouter extends RWRoute {
                 boolean startPreserved = routingGraph.unpreserve(start);
                 boolean endPreserved = routingGraph.unpreserve(end);
 
-                RouteNode rstart = getOrCreateRouteNode(start, null);
-                RouteNode rend = getOrCreateRouteNode(end, null);
+                RouteNode rstart = routingGraph.getOrCreate(start);
+                RouteNode rend = routingGraph.getOrCreate(end);
                 boolean rstartAdded = rnodes.add(rstart);
                 boolean rendAdded = rnodes.add(rend);
                 assert(rstartAdded == startPreserved);

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -85,6 +85,16 @@ public class PartialRouter extends RWRoute {
             }
             return super.isExcluded(parent, child);
         }
+
+        @Override
+        public boolean isAccessible(RouteNode childRnode, Connection connection) {
+            Net preservedNet = getPreservedNet(childRnode);
+            if (preservedNet == connection.getNetWrapper().getNet()) {
+                // Always allow nodes preserved for this connection's net
+                return true;
+            }
+            return super.isAccessible(childRnode, connection);
+        }
     }
 
     protected static class RouteNodeGraphPartialTimingDriven extends RouteNodeGraphTimingDriven {
@@ -107,6 +117,16 @@ public class PartialRouter extends RWRoute {
                 return false;
             }
             return super.isExcluded(parent, child);
+        }
+
+        @Override
+        public boolean isAccessible(RouteNode childRnode, Connection connection) {
+            Net preservedNet = getPreservedNet(childRnode);
+            if (preservedNet == connection.getNetWrapper().getNet()) {
+                // Always allow nodes preserved for this connection's net
+                return true;
+            }
+            return super.isAccessible(childRnode, connection);
         }
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -311,7 +311,7 @@ public class RWRoute {
             connection.getAltSinkRnodes().removeIf((rnode) -> rnode.getOccupancy() > 0);
         }
 
-        // Wait for all outstanding RouteNodeGraph.asyncPreserve() calls to complete
+        // Wait for all outstanding RouteNodeGraph.preserveAsync() calls to complete
         routingGraph.awaitPreserve();
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -556,7 +556,7 @@ public class RWRoute {
             List<Node> nodes = RouterHelper.projectInputPinToINTNode(sink);
             if (sourceINTNode == null && !nodes.isEmpty()) {
                 // Sink can be projected to an INT tile, but source cannot be; try alternate source
-                Pair<SitePinInst,RouteNode> altSourceAndRnode = setupAlternateSource(connection.getSource());
+                Pair<SitePinInst,RouteNode> altSourceAndRnode = connection.getOrCreateAlternateSource(routingGraph);
                 if (altSourceAndRnode != null) {
                     SitePinInst altSource = altSourceAndRnode.getFirst();
                     RouteNode altSourceINTRnode = altSourceAndRnode.getSecond();
@@ -1633,32 +1633,6 @@ public class RWRoute {
         return false;
     }
 
-    protected Pair<SitePinInst,RouteNode> setupAlternateSource(SitePinInst source) {
-        Net net = source.getNet();
-        assert(net != null);
-
-        NetWrapper netWrapper = nets.get(net);
-        assert(netWrapper != null);
-
-        SitePinInst altSource = netWrapper.getAltSource(routingGraph);
-        if (altSource == null) {
-            return null;
-        }
-
-        RouteNode altSourceRnode;
-        if (source.equals(net.getSource())) {
-            altSourceRnode = netWrapper.getAltSourceRnode();
-        } else {
-            assert(source.equals(net.getAlternateSource()));
-            altSource = net.getSource();
-            assert(altSource != null);
-            altSourceRnode = netWrapper.getSourceRnode();
-        }
-
-        assert(altSourceRnode != null);
-        return new Pair<>(altSource, altSourceRnode);
-    }
-
     /**
      * Swaps the output pin of a connection, if its net has an alternative output pin.
      * @param connection The connection in question.
@@ -1666,7 +1640,7 @@ public class RWRoute {
      */
     protected boolean swapOutputPin(Connection connection) {
         SitePinInst source = connection.getSource();
-        Pair<SitePinInst,RouteNode> altSourceAndRnode = setupAlternateSource(connection.getSource());
+        Pair<SitePinInst,RouteNode> altSourceAndRnode = connection.getOrCreateAlternateSource(routingGraph);
         if (altSourceAndRnode == null) {
             return false;
         }

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1655,7 +1655,6 @@ public class RWRoute {
                 if (altSource == null) {
                     return null;
                 }
-                // Add this SitePinInst to the net, but not to the SiteInst since it's not yet clear we'll be using it
                 net.addPin(altSource);
                 DesignTools.routeAlternativeOutputSitePin(net, altSource);
             }

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1996,7 +1996,8 @@ public class RWRoute {
      * @param newTotalPathCost Total path cost of childRnode.
      */
     protected void push(ConnectionState state, RouteNode childRnode, float newPartialPathCost, float newTotalPathCost) {
-        assert(childRnode.getPrev() != null || childRnode.getType() == RouteNodeType.PINFEED_O);
+        // Pushed node must have a prev pointer, unless it is a source (with no upstream path cost)
+        assert(childRnode.getPrev() != null || newPartialPathCost == 0);
         childRnode.setLowerBoundTotalPathCost(newTotalPathCost);
         childRnode.setUpstreamPathCost(newPartialPathCost);
         // Use the number-of-connections-routed-so-far as the identifier for whether a rnode

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -572,7 +572,7 @@ public class RWRoute {
                 if (connection.getSourceRnode() == null) {
                     assert(sourceINTNode != null);
                     if (sourceINTRnode == null) {
-                        sourceINTRnode = getOrCreateRouteNode(sourceINTNode, RouteNodeType.PINFEED_O);
+                        sourceINTRnode = routingGraph.getOrCreate(sourceINTNode, RouteNodeType.PINFEED_O);
                         // Where only a single primary source exists, always preserve
                         // its projected-to-INT source node, since it could
                         // be a projection from LAGUNA/RXQ* -> RXD* (node for INT/LOGIC_OUTS_*)
@@ -585,7 +585,7 @@ public class RWRoute {
 
                 Node sinkINTNode = nodes.get(0);
                 indirectConnections.add(connection);
-                RouteNode sinkRnode = getOrCreateRouteNode(sinkINTNode, RouteNodeType.PINFEED_I);
+                RouteNode sinkRnode = routingGraph.getOrCreate(sinkINTNode, RouteNodeType.PINFEED_I);
                 assert(sinkRnode.getType() == RouteNodeType.PINFEED_I);
                 connection.setSinkRnode(sinkRnode);
 
@@ -635,7 +635,7 @@ public class RWRoute {
                     if (routingGraph.isPreserved(node)) {
                         continue;
                     }
-                    RouteNode altSinkRnode = getOrCreateRouteNode(node, RouteNodeType.PINFEED_I);
+                    RouteNode altSinkRnode = routingGraph.getOrCreate(node, RouteNodeType.PINFEED_I);
                     assert(altSinkRnode.getType() == RouteNodeType.PINFEED_I);
                     connection.addAltSinkRnode(altSinkRnode);
                 }
@@ -675,18 +675,6 @@ public class RWRoute {
      */
     private void addConnectionSpanInfo(Connection connection) {
         connectionSpan.merge(connection.getHpwl(), 1, Integer::sum);
-    }
-
-    /**
-     * Creates a {@link RouteNode} Object based on a {@link Node} instance and avoids duplicates,
-     * used for creating the source and sink rnodes of {@link Connection} instances.
-     * NOTE: This method does not consider whether returned node is preserved.
-     * @param node The node associated to the {@link SitePinInst} instance.
-     * @param type The {@link RouteNodeType} of the {@link RouteNode} Object.
-     * @return The created {@link RouteNode} instance.
-     */
-    protected RouteNode getOrCreateRouteNode(Node node, RouteNodeType type) {
-        return routingGraph.getOrCreate(node, type);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -555,7 +555,8 @@ public class RWRoute {
             Connection connection = new Connection(numConnectionsToRoute++, source, sink, netWrapper);
             List<Node> nodes = RouterHelper.projectInputPinToINTNode(sink);
             if (sourceINTNode == null && !nodes.isEmpty()) {
-                // Sink can be projected to an INT tile, but source cannot be; try alternate source
+                // Sink can be projected to an INT tile, but primary source (e.g. COUT)
+                // cannot be; try alternate source
                 Pair<SitePinInst,RouteNode> altSourceAndRnode = connection.getOrCreateAlternateSource(routingGraph);
                 if (altSourceAndRnode != null) {
                     SitePinInst altSource = altSourceAndRnode.getFirst();
@@ -577,10 +578,10 @@ public class RWRoute {
                         // Where only a single primary source exists, always preserve
                         // its projected-to-INT source node, since it could
                         // be a projection from LAGUNA/RXQ* -> RXD* (node for INT/LOGIC_OUTS_*)
+                        assert(sourceINTRnode != null);
                         routingGraph.preserve(sourceINTNode, net);
                         netWrapper.setSourceRnode(sourceINTRnode);
                     }
-                    assert(sourceINTRnode != null);
                     connection.setSourceRnode(sourceINTRnode);
                 }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1716,6 +1716,16 @@ public class RWRoute {
         }
     }
 
+    protected void saveRoutingSource(Connection connection) {
+        List<RouteNode> rnodes = connection.getRnodes();
+        RouteNode sourceRnode = rnodes.get(rnodes.size() - 1);
+        if (sourceRnode.equals(connection.getSourceRnode())) {
+            return;
+        }
+
+        throw new RuntimeException("ERROR: Backtracking terminated at unexpected rnode: " + sourceRnode);
+    }
+
     /**
      * Traces back for a connection from its sink rnode to its source, in order to build and store the routing path.
      * @param connection: The connection that is being routed.
@@ -1746,11 +1756,7 @@ public class RWRoute {
             return false;
         }
 
-        RouteNode sourceRnode = rnodes.get(rnodes.size()-1);
-        if (!sourceRnode.equals(connection.getSourceRnode())) {
-            throw new RuntimeException();
-        }
-
+        saveRoutingSource(connection);
         return true;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1693,11 +1693,9 @@ public class RWRoute {
         } while ((rnode = rnode.getPrev()) != null);
 
         List<RouteNode> rnodes = connection.getRnodes();
-        if (rnodes.size() == 1) {
-            // No prev pointer from sink rnode -> not routed
-            return false;
-        }
-        return true;
+        RouteNode sourceRnode = rnodes.get(rnodes.size() - 1);
+        // Only succesfully routed if backtracked to this connection's source node
+        return sourceRnode == connection.getSourceRnode();
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -586,7 +586,7 @@ public class RWRoute {
                 Node sinkINTNode = nodes.get(0);
                 indirectConnections.add(connection);
                 RouteNode sinkRnode = routingGraph.getOrCreate(sinkINTNode, RouteNodeType.PINFEED_I);
-                assert(sinkRnode.getType() == RouteNodeType.PINFEED_I);
+                sinkRnode.setType(RouteNodeType.PINFEED_I);
                 connection.setSinkRnode(sinkRnode);
 
                 // Where appropriate, allow all 6 LUT pins to be swapped to begin with

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1598,21 +1598,38 @@ public class RWRoute {
         targets.clear();
     }
 
+    protected void enlargeBoundingBox(Connection connection) {
+        if (!config.isEnlargeBoundingBox()) {
+            return;
+        }
+
+        connection.enlargeBoundingBox(config.getExtensionXIncrement(), config.getExtensionYIncrement());
+    }
+
+    protected void abandonConnectionIfUnroutable(Connection connection) {
+        if (!config.isUseBoundingBox() || config.isEnlargeBoundingBox()) {
+            return;
+        }
+
+        // Since bounding box is never enlarged there is no hope of routing this connection so abandon it
+        indirectConnections.remove(connection);
+    }
+
     /**
      * Deals with a failed connection by possible output pin swapping and unrouting preserved nets if the router is in the soft preserve mode.
      * @param connection The failed connection.
      */
     protected boolean handleUnroutableConnection(Connection connection) {
-        if (config.isEnlargeBoundingBox()) {
-            connection.enlargeBoundingBox(config.getExtensionXIncrement(), config.getExtensionYIncrement());
+        enlargeBoundingBox(connection);
+        if (routeIteration == 1 && swapOutputPin(connection)) {
+            return true;
         }
-        return routeIteration == 1 && swapOutputPin(connection);
+        abandonConnectionIfUnroutable(connection);
+        return false;
     }
 
     protected boolean handleCongestedConnection(Connection connection) {
-        if (config.isEnlargeBoundingBox()) {
-            connection.enlargeBoundingBox(config.getExtensionXIncrement(), config.getExtensionYIncrement());
-        }
+        enlargeBoundingBox(connection);
         return false;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -578,7 +578,6 @@ public class RWRoute {
             } else {
                 Node sinkINTNode = nodes.get(0);
                 indirectConnections.add(connection);
-                checkSinkRoutability(net, sinkINTNode);
                 RouteNode sinkRnode = getOrCreateRouteNode(sinkINTNode, RouteNodeType.PINFEED_I);
                 assert(sinkRnode.getType() == RouteNodeType.PINFEED_I);
                 connection.setSinkRnode(sinkRnode);
@@ -685,14 +684,6 @@ public class RWRoute {
             }
         }
         return netWrapper;
-    }
-
-    protected void checkSinkRoutability(Net net, Node sinkNode) {
-        Net oldNet = routingGraph.getPreservedNet(sinkNode);
-        if (oldNet != null && oldNet != net) {
-            throw new RuntimeException("ERROR: Sink node " + sinkNode + " of net '" + net.getName() + "' is "
-                    + " preserved by net '" + oldNet.getName() + "'");
-        }
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1609,10 +1609,13 @@ public class RWRoute {
     protected void abandonConnectionIfUnroutable(Connection connection) {
         if (!config.isUseBoundingBox() || config.isEnlargeBoundingBox()) {
             return;
-        }
+       }
+
+        System.out.println("                 " + "Abandoning");
 
         // Since bounding box is never enlarged there is no hope of routing this connection so abandon it
         indirectConnections.remove(connection);
+        sortedIndirectConnections.remove(connection);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -565,7 +565,8 @@ public class RWRoute {
                 }
             }
 
-            if (sourceINTNode == null && connection.getSourceRnode() == null) {
+            if ((sourceINTNode == null && connection.getSourceRnode() == null) || nodes.isEmpty()) {
+                // Direct connection if either source or sink pin cannot be projected to INT tile
                 directConnections.add(connection);
                 connection.setDirect(true);
             } else {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -563,13 +563,6 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
     }
 
     /**
-     * Clears the parent RouteNode instance.
-     */
-    public void clearPrev() {
-        this.prev = null;
-    }
-
-    /**
      * Gets the present congestion cost of a RouteNode Object.
      * @return The present congestion of a RouteNode Object.
      */

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -256,22 +256,6 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
         return s.toString();
     }
 
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        // This method requires that object is Node or a subclass of one, otherwise exception will be thrown.
-        // If so, explicitly call the Node.equals(Node) overload, rather than the general-purpose Node.equals(Object).
-        return super.equals((Node) obj);
-    }
-
     /**
      * Checks if coordinates of a RouteNode Object is within the connection's bounding box.
      * @param connection The connection that is being routed.

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -312,9 +312,12 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
      * @param type New RouteNodeType value.
      */
     public void setType(RouteNodeType type) {
-        // Only support demotion from PINFEED_I to WIRE or PINBOUNCE since they have the same base cost
-        assert(this.type == RouteNodeType.PINFEED_I
-                && (type == RouteNodeType.WIRE || type == RouteNodeType.PINBOUNCE));
+        assert(this.type == type ||
+                // Support demotion from PINFEED_I to PINBOUNCE since they have the same base cost
+                (this.type == RouteNodeType.PINFEED_I && type == RouteNodeType.PINBOUNCE) ||
+                // Or promotion from PINBOUNCE to PINFEED_I (by PartialRouter when PINBOUNCE on
+                // preserved net needs to become a PINFEED_I)
+                (this.type == RouteNodeType.PINBOUNCE && type == RouteNodeType.PINFEED_I));
         this.type = type;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -382,7 +382,7 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
                     continue;
                 }
 
-                RouteNode child = routingGraph.getOrCreate(downhill, null);
+                RouteNode child = routingGraph.getOrCreate(downhill);
                 childrenList.add(child);//the sink rnode of a target connection has been created up-front
             }
             if (!childrenList.isEmpty()) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2021 Ghent University.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Yun Zhou, Ghent University.

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -520,6 +520,10 @@ public class RouteNodeGraph {
         return new RouteNode(this, node, type);
     }
 
+    public RouteNode getOrCreate(Node node) {
+        return getOrCreate(node, null);
+    }
+
     public RouteNode getOrCreate(Node node, RouteNodeType type) {
         Tile tile = node.getTile();
         int wireIndex = node.getWireIndex();

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Eddie Hung, Xilinx Research Labs.

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -78,17 +78,6 @@ public class RouterHelper {
         NodeWithPrev getPrev() {
             return prev;
         }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            // This method requires that object is Node or a subclass of one, otherwise exception will be thrown.
-            // If so, explicitly call the Node.equals(Node) overload, rather than the general-purpose Node.equals(Object).
-            return super.equals((Node) obj);
-        }
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -579,7 +579,7 @@ public class RouterHelper {
      */
     public static boolean routeDirectConnection(Connection directConnection) {
         directConnection.setNodes(findPathBetweenNodes(directConnection.getSource().getConnectedNode(), directConnection.getSink().getConnectedNode()));
-        return directConnection.getNodes() != null;
+        return !directConnection.getNodes().isEmpty();
     }
 
     /**

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -131,6 +131,7 @@ public class VivadoTools {
         final Path dcp = writeCheckpoint(design);
         boolean encrypted = !design.getNetlist().getEncryptedCells().isEmpty();
         ReportRouteStatusResult rrs = reportRouteStatus(dcp, dcp.getParent(), encrypted);
+
         FileTools.deleteFolder(dcp.getParent().toString());
 
         return rrs;

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -131,7 +131,6 @@ public class VivadoTools {
         final Path dcp = writeCheckpoint(design);
         boolean encrypted = !design.getNetlist().getEncryptedCells().isEmpty();
         ReportRouteStatusResult rrs = reportRouteStatus(dcp, dcp.getParent(), encrypted);
-
         FileTools.deleteFolder(dcp.getParent().toString());
 
         return rrs;

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -271,7 +271,7 @@ public class TestRWRoute {
         design.setTrackNetChanges(true);
 
         // Pseudo-randomly unroute some pins from a multi-pin net
-        Random random = new Random();
+        Random random = new Random(0);
         for (Net net : design.getNets()) {
             if (!net.getName().endsWith("/processor/t_state_0")) {
                 continue;

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -26,9 +26,11 @@ package com.xilinx.rapidwright.rwroute;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import com.xilinx.rapidwright.util.VivadoToolsHelper;
 import org.junit.jupiter.api.Assertions;
@@ -267,6 +269,19 @@ public class TestRWRoute {
     public void testNonTimingDrivenPartialRouting() {
         Design design = RapidWrightDCP.loadDCP("picoblaze_partial.dcp");
         design.setTrackNetChanges(true);
+
+        // Pseudo-randomly unroute some pins from a multi-pin net
+        Random random = new Random();
+        for (Net net : design.getNets()) {
+            if (!net.getName().endsWith("/processor/t_state_0")) {
+                continue;
+            }
+
+            List<SitePinInst> sinkPins = net.getSinkPins();
+            Assertions.assertTrue(sinkPins.size() > 1);
+            SitePinInst spi = sinkPins.get(random.nextInt(sinkPins.size()));
+            DesignTools.unroutePins(net, Collections.singletonList(spi));
+        }
 
         boolean softPreserve = false;
         Design routed = PartialRouter.routeDesignPartialNonTimingDriven(design, null, softPreserve);


### PR DESCRIPTION
- `RWRoute` to not check for sink routability anymore
- `PartialRouter` to only check sink routability after all nodes have been preserved
- `RWRoute.handleUnroutableConnection()` to abandon connections that are guaranteed to be unroutable since the bounding box is never enlarged (nor any nets be unpreserved, in the case of `PartialRouter`)
- `RWRoute` to not pre-emptively set up the second source; do so only when needed in `RWRoute.swapOutputPin()` or when recovering partially routed nets in `PartialRouter`
- Various cleanups/optimizations