### PR TITLE
[PhysNetlistReader] Call SiteInst.setDesign() even for STATIC_SOURCEs

### DIFF
--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -738,8 +738,8 @@ public class PhysNetlistReader {
             // Create a dummy TIEOFF SiteInst
             String name = SiteInst.STATIC_SOURCE + "_" + site.getName();
             SiteInst si = new SiteInst(name, site.getSiteTypeEnum());
-            si.setDesign(design);
             si.place(site);
+            si.setDesign(design);
             // Ensure it is not attached to the design
             assert(design.getSiteInstFromSite(site) == null);
             return si;

--- a/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
+++ b/src/com/xilinx/rapidwright/interchange/PhysNetlistReader.java
@@ -738,9 +738,10 @@ public class PhysNetlistReader {
             // Create a dummy TIEOFF SiteInst
             String name = SiteInst.STATIC_SOURCE + "_" + site.getName();
             SiteInst si = new SiteInst(name, site.getSiteTypeEnum());
+            si.setDesign(design);
             si.place(site);
             // Ensure it is not attached to the design
-            assert(si.getDesign() == null);
+            assert(design.getSiteInstFromSite(site) == null);
             return si;
         });
         assert(siteInst != null && siteInst.isPlaced());


### PR DESCRIPTION
Necessary since https://github.com/Xilinx/RapidWright/pull/1040 requires `SiteInst.getDesign()`