### PR TITLE
[EDIFNetlist] getPhysicalPins() to call getPhysical{Gnd,Vcc}Pins()

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1597,9 +1597,9 @@ public class EDIFNetlist extends EDIFName {
     public List<EDIFHierPortInst> getPhysicalPins(Net net) {
         switch (net.getType()) {
             case GND:
-                return physicalGndPins;
+                return getPhysicalGndPins();
             case VCC:
-                return physicalVccPins;
+                return getPhysicalVccPins();
             default:
                 final EDIFHierNet hierNet = getHierNetFromName(net.getName());
                 return getPhysicalNetPinMap().get(hierNet);


### PR DESCRIPTION
To ensure pins are generated if not done already