### PR TITLE
[RouterHelper] findPathBetweenNodes() to ignore clocking tiles

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -584,6 +584,7 @@ public class RouterHelper {
 
     /**
      * Find a path from a source node to a sink node.
+     * Intermediate nodes with tile type returning true for {@link Utils#isClocking(TileTypeEnum)} will be ignored.
      * @param source The source node.
      * @param sink The sink node.
      * @return A list of nodes making up the path.
@@ -616,6 +617,9 @@ public class RouterHelper {
                 break;
             }
             for (Node n : curr.getAllDownhillNodes()) {
+                if (Utils.isClocking(n.getTile().getTileTypeEnum())) {
+                    continue;
+                }
                 NodeWithPrev child = new NodeWithPrev(n);
                 child.setPrev(curr);
                 queue.add(child);

--- a/src/com/xilinx/rapidwright/util/Utils.java
+++ b/src/com/xilinx/rapidwright/util/Utils.java
@@ -55,6 +55,8 @@ public class Utils{
 
     private static Set<TileTypeEnum> lagunas;
 
+    private static Set<TileTypeEnum> clocking;
+
     private static Set<SiteTypeEnum> lockedSiteTypes;
 
     private static Set<SiteTypeEnum> moduleSiteTypes;
@@ -168,6 +170,10 @@ public class Utils{
         return lagunas.contains(type);
     }
 
+    public static boolean isClocking(TileTypeEnum type) {
+        return clocking.contains(type);
+    }
+
     public static boolean isLockedSiteType(SiteTypeEnum type) {
         return lockedSiteTypes.contains(type);
     }
@@ -202,6 +208,10 @@ public class Utils{
 
     public static Set<TileTypeEnum> getLagunaTileTypes() {
         return lagunas;
+    }
+
+    public static Set<TileTypeEnum> getClockingTileTypes() {
+        return clocking;
     }
 
     public static Set<SiteTypeEnum> getLockedSiteTypes() {
@@ -336,6 +346,12 @@ public class Utils{
         lagunas = EnumSet.of(
                 TileTypeEnum.LAG_LAG,       // UltraScale+
                 TileTypeEnum.LAGUNA_TILE    // UltraScale
+        );
+
+        clocking = EnumSet.of(
+                // Versal
+                TileTypeEnum.CLK_REBUF_BUFGS_HSR_CORE,
+                TileTypeEnum.CLK_PLL_AND_PHY
         );
 
         lockedSiteTypes = EnumSet.of(


### PR DESCRIPTION
Without which this method (which uses breadth-first search) could take a while.

Also added `Utils.isClocking()` method to detect clocking tiles.

Only two entries so far, from Versal, affecting a failing testcase. Will add more as and when needed.