### PR TITLE
[RouterHelper] projectInputPinToINTNode() to return solitary node

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -268,11 +268,10 @@ public class GlobalSignalRouting {
         for (SitePinInst p : clkPins) {
             if (p.isOutPin()) continue;
             assert(lcbCandidates.isEmpty());
-            List<Node> intNodes = RouterHelper.projectInputPinToINTNode(p);
-            if (intNodes == null || intNodes.isEmpty()) {
+            Node intNode = RouterHelper.projectInputPinToINTNode(p);
+            if (intNode == null) {
                 throw new RuntimeException("Unable to get INT tile for pin " + p);
             }
-            Node intNode = intNodes.get(0);
 
             outer: for (Node prev : intNode.getAllUphillNodes()) {
                 NodeStatus prevNodeStatus = getNodeStatus.apply(prev);

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -553,8 +553,8 @@ public class RWRoute {
         int indirect = 0;
         for (SitePinInst sink : sinkPins) {
             Connection connection = new Connection(numConnectionsToRoute++, source, sink, netWrapper);
-            List<Node> nodes = RouterHelper.projectInputPinToINTNode(sink);
-            if (sourceINTNode == null && !nodes.isEmpty()) {
+            Node sinkINTNode = RouterHelper.projectInputPinToINTNode(sink);
+            if (sourceINTNode == null && sinkINTNode != null) {
                 // Sink can be projected to an INT tile, but primary source (e.g. COUT)
                 // cannot be; try alternate source
                 Pair<SitePinInst,RouteNode> altSourceAndRnode = connection.getOrCreateAlternateSource(routingGraph);
@@ -566,7 +566,7 @@ public class RWRoute {
                 }
             }
 
-            if ((sourceINTNode == null && connection.getSourceRnode() == null) || nodes.isEmpty()) {
+            if ((sourceINTNode == null && connection.getSourceRnode() == null) || sinkINTNode == null) {
                 // Direct connection if either source or sink pin cannot be projected to INT tile
                 directConnections.add(connection);
                 connection.setDirect(true);
@@ -585,7 +585,6 @@ public class RWRoute {
                     connection.setSourceRnode(sourceINTRnode);
                 }
 
-                Node sinkINTNode = nodes.get(0);
                 indirectConnections.add(connection);
                 RouteNode sinkRnode = routingGraph.getOrCreate(sinkINTNode, RouteNodeType.PINFEED_I);
                 sinkRnode.setType(RouteNodeType.PINFEED_I);

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -176,31 +176,24 @@ public class RouterHelper {
     /**
      * Gets a list of {@link Node} instances that connect an input {@link SitePinInst} instance to an INT {@link Tile} instance.
      * @param input The input pin.
-     * @return A list of nodes from the input SitePinInst to an INT tile.
+     * @return A node that connects to an INT tile from an input pin.
      */
-    public static List<Node> projectInputPinToINTNode(SitePinInst input) {
-        List<Node> sinkToSwitchBoxPath = new ArrayList<>();
-        NodeWithPrev sink = new NodeWithPrev(input.getConnectedNode());
-        sink.setPrev(null);
-        Queue<NodeWithPrev> q = new LinkedList<>();
+    public static Node projectInputPinToINTNode(SitePinInst input) {
+        Node sink = input.getConnectedNode();
+        Queue<Node> q = new LinkedList<>();
         q.add(sink);
         int watchdog = 1000;
         while (!q.isEmpty()) {
-            NodeWithPrev n = q.poll();
-            if (n.getTile().getTileTypeEnum() == TileTypeEnum.INT) {
-                while (n != null) {
-                    sinkToSwitchBoxPath.add(n);
-                    n = n.getPrev();
-                }
-                return sinkToSwitchBoxPath;
+            Node n = q.poll();
+            TileTypeEnum tileType = n.getTile().getTileTypeEnum();
+            if (tileType == TileTypeEnum.INT) {
+                return n;
             }
             for (Node uphill : n.getAllUphillNodes()) {
                 if (uphill.getAllUphillNodes().size() == 0) {
                     continue;
                 }
-                NodeWithPrev prev = new NodeWithPrev(uphill);
-                prev.setPrev(n);
-                q.add(prev);
+                q.add(uphill);
             }
             watchdog--;
             if (watchdog < 0) {
@@ -208,16 +201,16 @@ public class RouterHelper {
             }
         }
 
-        return sinkToSwitchBoxPath;
+        return null;
     }
 
     public static Tile getUpstreamINTTileOfClkIn(SitePinInst clkIn) {
-        List<Node> pathToINTTile = projectInputPinToINTNode(clkIn);
-        if (pathToINTTile.isEmpty()) {
+        Node intNode = projectInputPinToINTNode(clkIn);
+        if (intNode == null) {
             throw new RuntimeException("ERROR: CLK_IN does not connect to INT Tile directly");
         }
 
-        return pathToINTTile.get(0).getTile();
+        return intNode.getTile();
     }
 
     /**
@@ -544,9 +537,9 @@ public class RouterHelper {
         for (SitePinInst sink : net.getSinkPins()) {
             Node sinkNode = sink.getConnectedNode();
             if (sinkNode.getTile().getTileTypeEnum() != TileTypeEnum.INT) {
-                List<Node> nodes = projectInputPinToINTNode(sink);
-                if (!nodes.isEmpty()) {
-                    sinkNode = nodes.get(0);
+                Node sinkINTNode = projectInputPinToINTNode(sink);
+                if (sinkINTNode != null) {
+                    sinkNode = sinkINTNode;
                 } else {
                     // Must be a direct connection (e.g. COUT -> CIN)
                 }

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -124,11 +124,11 @@ public class TimingAndWirelengthReport{
                 }
             }
             Connection connection = new Connection(numConnectionsToRoute++, source, sink, netWrapper);
-            List<Node> nodes = RouterHelper.projectInputPinToINTNode(sink);
-            if (nodes.isEmpty()) {
+            Node sinkINTNode = RouterHelper.projectInputPinToINTNode(sink);
+            if (sinkINTNode == null) {
                 connection.setDirect(true);
             } else {
-                connection.setSinkRnode(routingGraph.getOrCreate(nodes.get(0), RouteNodeType.PINFEED_I));
+                connection.setSinkRnode(routingGraph.getOrCreate(sinkINTNode, RouteNodeType.PINFEED_I));
                 if (sourceINTNode == null) {
                     sourceINTNode = RouterHelper.projectOutputPinToINTNode(source);
                 }


### PR DESCRIPTION
... instead of list which was never used anyway.

This brings it in line with `projectOutputPinToINTNode()` which returns a single node too.