### PR TITLE
[RouterHelper] projectOutputPinToINTNode() to breadth-first-search

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -146,7 +146,7 @@ public class RouterHelper {
      */
     public static Node projectOutputPinToINTNode(SitePinInst output) {
         Node source = output.getConnectedNode();
-        int watchdog = 1000;
+        int watchdog = 20;
 
         // Starting from the SPI's connected node, perform a downhill breadth-first search
         Queue<Node> queue = new ArrayDeque<>();
@@ -177,7 +177,7 @@ public class RouterHelper {
      */
     public static Node projectInputPinToINTNode(SitePinInst input) {
         Node sink = input.getConnectedNode();
-        int watchdog = 1000;
+        int watchdog = 20;
 
         // Starting from the SPI's connected node, perform an uphill breadth-first search
         Queue<Node> queue = new ArrayDeque<>();

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -180,17 +180,14 @@ public class RouterHelper {
         queue.add(sink);
         while (!queue.isEmpty() && watchdog >= 0) {
             Node node = queue.poll();
-            watchdog--;
-            for (Node uphill : node.getAllUphillNodes()) {
-                TileTypeEnum uphillTileType = uphill.getTile().getTileTypeEnum();
-                if (uphillTileType == TileTypeEnum.INT ||
-                        // Versal only: Terminate at non INT (e.g. CLE_BC_CORE) tile type for CTRL pin inputs
-                        EnumSet.of(IntentCode.NODE_CLE_CTRL, IntentCode.NODE_INTF_CTRL).contains(uphill.getIntentCode())) {
-                    // Return node that has at least one uphill in the INT tile
-                    return node;
-                }
-                queue.add(uphill);
+            TileTypeEnum tileType = node.getTile().getTileTypeEnum();
+            if (tileType == TileTypeEnum.INT ||
+                    // Versal only: Terminate at non INT (e.g. CLE_BC_CORE) tile type for CTRL pin inputs
+                    EnumSet.of(IntentCode.NODE_CLE_CTRL, IntentCode.NODE_INTF_CTRL).contains(node.getIntentCode())) {
+                return node;
             }
+            watchdog--;
+            node.getAllUphillNodes(queue);
         }
 
         return null;

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -156,7 +156,7 @@ public class RouterHelper {
             watchdog--;
             for (Node downhill : node.getAllDownhillNodes()) {
                 if (Utils.isInterConnect(downhill.getTile().getTileTypeEnum())) {
-                    // Return node that has downhill in the INT tile
+                    // Return node that has at laest one downhill in the INT tile
                     return node;
                 }
                 queue.add(downhill);
@@ -186,8 +186,8 @@ public class RouterHelper {
                 if (uphillTileType == TileTypeEnum.INT ||
                         // Versal only: Terminate at non INT (e.g. CLE_BC_CORE) tile type for CTRL pin inputs
                         EnumSet.of(IntentCode.NODE_CLE_CTRL, IntentCode.NODE_INTF_CTRL).contains(uphill.getIntentCode())) {
-                    // Return the uphill in the INT tile
-                    return uphill;
+                    // Return node that has at least one uphill in the INT tile
+                    return node;
                 }
                 queue.add(uphill);
             }

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -156,7 +156,7 @@ public class RouterHelper {
             watchdog--;
             for (Node downhill : node.getAllDownhillNodes()) {
                 if (Utils.isInterConnect(downhill.getTile().getTileTypeEnum())) {
-                    // Return node that has at laest one downhill in the INT tile
+                    // Return node that has at least one downhill in the INT tile
                     return node;
                 }
                 queue.add(downhill);

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -155,9 +155,13 @@ public class RouterHelper {
             Node node = queue.poll();
             watchdog--;
             for (Node downhill : node.getAllDownhillNodes()) {
-                if (Utils.isInterConnect(downhill.getTile().getTileTypeEnum())) {
+                TileTypeEnum downhillTileType = downhill.getTile().getTileTypeEnum();
+                if (Utils.isInterConnect(downhillTileType)) {
                     // Return node that has at least one downhill in the INT tile
                     return node;
+                }
+                if (Utils.isClocking(downhillTileType)) {
+                    continue;
                 }
                 queue.add(downhill);
             }

--- a/src/com/xilinx/rapidwright/util/Utils.java
+++ b/src/com/xilinx/rapidwright/util/Utils.java
@@ -349,6 +349,7 @@ public class Utils{
         );
 
         clocking = EnumSet.of(
+                TileTypeEnum.RCLK_CLEM_CLKBUF_L,
                 // Versal
                 TileTypeEnum.CLK_REBUF_BUFGS_HSR_CORE,
                 TileTypeEnum.CLK_PLL_AND_PHY

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
@@ -209,8 +209,7 @@ public class TestRouterHelper {
         SitePinInst p = new SitePinInst("TX_T_OUT", si);
         Node intNode = RouterHelper.projectOutputPinToINTNode(p);
 
-        // FIXME: Known broken --  https://github.com/Xilinx/RapidWright/issues/558
-        Assertions.assertNotEquals(Objects.toString(intNode), "INT_INTF_L_CMT_X182Y90/LOGIC_OUTS_R19");
+        Assertions.assertEquals(intNode.toString(), "INT_INTF_L_CMT_X182Y90/LOGIC_OUTS_R19");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Much like `projectInputPinToINTNode()` as this seems necessary for Versal I/Os (and even fixed #558!)

Without this, in an upcoming `PartialRouter` test with `picoblaze_2022.2.dcp`, the projected result is not the same as Vivado's solution thereby leading to an unroutable situation.