### PR TITLE
[LUTTools] Add zero padding to LUT INIT strings

### DIFF
--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -353,7 +353,8 @@ public class LUTTools {
             boolean result = b.eval(i);
             if (result) init = setBit(init,i);
         }
-        return length + "'h" + String.format("%0" + ((length) >>> 2) + "x", init).toUpperCase();
+        int initLength = Integer.max(1, length >>> 2);
+        return length + "'h" + String.format("%0" + initLength + "x", init).toUpperCase();
     }
 
     /**

--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -353,7 +353,7 @@ public class LUTTools {
             boolean result = b.eval(i);
             if (result) init = setBit(init,i);
         }
-        return length + "'h" + Long.toUnsignedString(init, 16).toUpperCase();
+        return length + "'h" + String.format("%0" + ((length) >>> 2) + "x", init).toUpperCase();
     }
 
     /**

--- a/test/src/com/xilinx/rapidwright/design/tools/TestLUTTools.java
+++ b/test/src/com/xilinx/rapidwright/design/tools/TestLUTTools.java
@@ -171,4 +171,16 @@ public class TestLUTTools {
             System.setProperty("rapidwright.rwroute.lutPinSwapping.deferIntraSiteRoutingUpdates", "false");
         }
     }
+    
+    @ParameterizedTest
+    @CsvSource({
+            "O=I0 & !I1 & I2 & !I3 + !I0 & I1 & I2 & !I3 + I0 & !I1 & !I2 & I3 + !I0 & I1 & !I2 & I3,16'h0660,4",
+            "O=I0 & !I1 + !I0 & I1,4'h6,2",
+            "O=!I0 & !I1 & !I2 & !I3 + I0 & I1 & !I2 & !I3 + !I0 & !I1 & I2 & I3 + I0 & I1 & I2 & I3,16'h9009,4",
+            "O=I0 & I1 & I2 & I3 & I4 & I5,64'h8000000000000000,6",
+            "O=!I0 & !I1 & !I2 & !I3 & !I4 & !I5,64'h0000000000000001,6",
+    })
+    public void testGetLUTInitFromEquation(String equation, String init, int lutSize) {
+        Assertions.assertEquals(init, LUTTools.getLUTInitFromEquation(equation, lutSize));
+    }
 }


### PR DESCRIPTION
Vivado expects a zero-padded INIT string associated with LUTs, this PR ensures the INIT strings derived from equations are properly zero-padded.