### PR TITLE
Update actions and do not limit to 5G RAM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,17 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-
       - name: Setup JDK 1.11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'
           cache: 'gradle'
 
       - name: Setup Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Cache Jars & Data
         id: cache-rapidwright
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
               data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         single_threaded: [multi-threaded, single-threaded]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
 

--- a/common.gradle
+++ b/common.gradle
@@ -65,11 +65,7 @@ configurations.testFixturesImplementation.canBeResolved = true
 configurations.api.canBeResolved = true
 
 tasks.withType(Test) {
-  if (System.getenv("GITHUB_ACTION")) {
-    maxHeapSize = "5G"
-  } else {
-    maxHeapSize = "10G"
-  }
+  maxHeapSize = "10G"
   //Propagate JVM settings to test JVM
   jvmArgs applicationDefaultJvmArgs
 


### PR DESCRIPTION
- Updating a number of actions to eliminates warnings.
- Remove `gradle/wrapper-validation-action` which just checks Gradle Jar integrity
- GitHub-hosted runners now have 16G RAM.