### PR TITLE
TileGroup and DeviceBrowser Improvements

### DIFF
--- a/src/com/xilinx/rapidwright/design/blocks/PBlock.java
+++ b/src/com/xilinx/rapidwright/design/blocks/PBlock.java
@@ -67,6 +67,9 @@ public class PBlock extends ArrayList<PBlockRange> {
         pblockTypes.add(SiteTypeEnum.SLICEM);
         pblockTypes.add(SiteTypeEnum.DSP48E1);
         pblockTypes.add(SiteTypeEnum.DSP48E2);
+        pblockTypes.add(SiteTypeEnum.DSP58_PRIMARY);
+        pblockTypes.add(SiteTypeEnum.DSP58);
+        pblockTypes.add(SiteTypeEnum.DSPFP);
         pblockTypes.add(SiteTypeEnum.RAMB180);
         pblockTypes.add(SiteTypeEnum.RAMB181);
         pblockTypes.add(SiteTypeEnum.RAMB18E1);

--- a/src/com/xilinx/rapidwright/design/tools/Edge.java
+++ b/src/com/xilinx/rapidwright/design/tools/Edge.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.design.tools;
+
+/**
+ * Describes the edge types of rectangles when composed of tiles.
+ */
+public enum Edge {
+    NORTH,
+    EAST,
+    SOUTH,
+    WEST,
+    NORTH_EAST,
+    SOUTH_EAST,
+    SOUTH_WEST,
+    NORTH_WEST,
+    INTERNAL,
+    EXTERNAL;
+
+    public boolean isEdgeCrossing() {
+        return this != INTERNAL && this != EXTERNAL;
+    }
+}

--- a/src/com/xilinx/rapidwright/design/tools/TileGroup.java
+++ b/src/com/xilinx/rapidwright/design/tools/TileGroup.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.design.tools;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.xilinx.rapidwright.device.ClockRegion;
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Tile;
+
+/**
+ * Simple class to capture a rectangular group of tiles defined by the upper
+ * left and lower right corner tiles.
+ */
+public class TileGroup {
+
+    private Tile upperLeft;
+
+    private Tile lowerRight;
+
+    private int northRow;
+
+    private int southRow;
+
+    private int westColumn;
+
+    private int eastColumn;
+
+    public TileGroup(Tile upperLeft, Tile lowerRight) {
+        this.upperLeft = upperLeft;
+        this.lowerRight = lowerRight;
+        northRow = upperLeft.getRow();
+        southRow = lowerRight.getRow();
+        westColumn = upperLeft.getColumn();
+        eastColumn = lowerRight.getColumn();
+    }
+
+    public TileGroup(ClockRegion cr) {
+        this(cr.getUpperLeft(), cr.getLowerRight());
+    }
+
+    public Map<Tile, Edge> getRegionTiles() {
+        Map<Tile, Edge> tiles = new HashMap<>();
+        Device device = upperLeft.getDevice();
+        for (int row = northRow; row <= southRow; row++) {
+            for (int col = westColumn; col <= eastColumn; col++) {
+                Tile tile = device.getTile(row, col);
+                tiles.put(tile, getEdgeOfTile(tile));
+            }
+        }
+        return tiles;
+    }
+
+    public Edge getEdgeOfTile(Tile tile) {
+        if (!tileInRegion(tile)) {
+            return Edge.EXTERNAL;
+        }
+        int row = tile.getRow();
+        int col = tile.getColumn();
+
+        if (row == northRow) {
+            return col == eastColumn ? Edge.NORTH_EAST : Edge.NORTH;
+        } else if (row == southRow) {
+            return col == westColumn ? Edge.SOUTH_WEST : Edge.SOUTH;
+        } else if (col == westColumn) {
+            return row == northRow ? Edge.NORTH_WEST : Edge.WEST;
+        } else if (col == eastColumn) {
+            return row == southRow ? Edge.SOUTH_EAST : Edge.EAST;
+        }
+
+        return Edge.INTERNAL;
+    }
+
+    public boolean tileInRegion(Tile tile) {
+        int row = tile.getRow();
+        int col = tile.getColumn();
+        return northRow <= row && row <= southRow && westColumn <= col && col <= eastColumn;
+
+    }
+
+    public String toString() {
+        return "[" + upperLeft + " (" + upperLeft.getColumn() + ", " + upperLeft.getRow() + ")" + ":"
+                + lowerRight + " (" + lowerRight.getColumn() + ", " + lowerRight.getRow() + ")" + "]";
+    }
+}

--- a/src/com/xilinx/rapidwright/device/browser/DeviceBrowser.java
+++ b/src/com/xilinx/rapidwright/device/browser/DeviceBrowser.java
@@ -24,23 +24,28 @@
 package com.xilinx.rapidwright.device.browser;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import com.trolltech.qt.core.QEvent;
 import com.trolltech.qt.core.QModelIndex;
 import com.trolltech.qt.core.Qt.DockWidgetArea;
 import com.trolltech.qt.core.Qt.ItemDataRole;
 import com.trolltech.qt.core.Qt.SortOrder;
 import com.trolltech.qt.gui.QApplication;
 import com.trolltech.qt.gui.QDockWidget;
+import com.trolltech.qt.gui.QDockWidget.DockWidgetFeature;
 import com.trolltech.qt.gui.QLabel;
 import com.trolltech.qt.gui.QMainWindow;
 import com.trolltech.qt.gui.QStatusBar;
 import com.trolltech.qt.gui.QTreeWidget;
 import com.trolltech.qt.gui.QTreeWidgetItem;
 import com.trolltech.qt.gui.QWidget;
-import com.trolltech.qt.gui.QDockWidget.DockWidgetFeature;
+import com.xilinx.rapidwright.design.tools.TileGroup;
 import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.Wire;
@@ -71,16 +76,24 @@ public class DeviceBrowser extends QMainWindow{
     private String currPart;
     /** This is the tree of parts to select */
     private QTreeWidget treeWidget;
+    /** This is the tree of nodes to select */
+    private QTreeWidget nodeTreeWidget;
     /** This is the list of primitive sites in the current tile selected */
     private QTreeWidget primitiveList;
     /** This is the list of wires in the current tile selected */
     private QTreeWidget wireList;
+
+    private Map<String, QTreeWidgetItem> nodeMap;
+
     /** This is the current tile that has been selected */
     private Tile currTile = null;
 
     protected boolean hideTiles = false;
 
     protected boolean drawPrimitives = true;
+
+    protected static final String UPHILL_NODES = "Uphill Nodes";
+    protected static final String DOWNHILL_NODES = "Downhill Nodes";
     /**
      * Main method setting up the Qt environment for the program to run.
      * @param args
@@ -147,7 +160,7 @@ public class DeviceBrowser extends QMainWindow{
         setStatusBar(statusBar);
 
         // Set the opening default window size to 1024x768 pixels
-        resize(1024, 768);
+        resize(1280, 1024);
     }
 
     public DeviceBrowser(QWidget parent) {
@@ -182,6 +195,19 @@ public class DeviceBrowser extends QMainWindow{
         dockWidget2.setFeatures(DockWidgetFeature.DockWidgetMovable);
         addDockWidget(DockWidgetArea.LeftDockWidgetArea, dockWidget2);
 
+        // Create the node list window
+        nodeMap = new HashMap<>();
+        nodeTreeWidget = new QTreeWidget();
+        nodeTreeWidget.setColumnCount(1);
+        nodeTreeWidget.setHeaderLabel("Nodes");
+        QDockWidget nodeWidget = new QDockWidget(tr("Node List"), this);
+        nodeWidget.setWidget(nodeTreeWidget);
+        nodeWidget.setFeatures(DockWidgetFeature.DockWidgetMovable);
+        addDockWidget(DockWidgetArea.LeftDockWidgetArea, nodeWidget);
+
+        // Draw wire connections when the wire name is double clicked
+        nodeTreeWidget.doubleClicked.connect(this, "nodeDoubleClicked(QModelIndex)");
+
         // Create the wire list window
         wireList = new QTreeWidget();
         wireList.setColumnCount(2);
@@ -215,12 +241,27 @@ public class DeviceBrowser extends QMainWindow{
     }
 
     /**
+     * Expands items in the node tree to add children nodes under uphill and
+     * downhill.
+     * 
+     * @param index
+     */
+    public void nodeDoubleClicked(QModelIndex index) {
+        String currNodeName = index.data().toString();
+        if (!currNodeName.equals(DOWNHILL_NODES) && !currNodeName.equals(UPHILL_NODES)) {
+            QTreeWidgetItem parent = nodeMap.get(index.data().toString());
+            updateNodeItem(currTile.getDevice().getNode(currNodeName), parent);
+        }
+    }
+
+    /**
      * This method gets called each time a user double clicks on a tile.
      */
     protected void updateTile(Tile tile) {
         currTile = tile;
         updatePrimitiveList();
         updateWireList();
+        updateNodeTreeWidget();
     }
 
     /**
@@ -255,6 +296,40 @@ public class DeviceBrowser extends QMainWindow{
         wireList.sortByColumn(0, SortOrder.AscendingOrder);
     }
 
+    protected void updateNodeTreeWidget() {
+        nodeTreeWidget.clear();
+
+        if (currTile == null || currTile.getWireNames() == null)
+            return;
+        Device d = currTile.getDevice();
+        for (int i = 0; i < currTile.getWireCount(); i++) {
+            Node n = d.getNode(currTile.toString() + "/" + currTile.getWireName(i));
+            if (n == null || n.isInvalidNode())
+                continue;
+
+            QTreeWidgetItem treeItem = new QTreeWidgetItem(nodeTreeWidget);
+            treeItem.setText(0, n.toString());
+            updateNodeItem(n, treeItem);
+        }
+    }
+
+    private void updateNodeItem(Node n, QTreeWidgetItem parent) {
+        QTreeWidgetItem uphillItem = new QTreeWidgetItem(parent);
+        uphillItem.setText(0, "Uphill Nodes");
+        for (Node up : n.getAllUphillNodes()) {
+            QTreeWidgetItem upNodeItem = new QTreeWidgetItem(uphillItem);
+            upNodeItem.setText(0, up.toString());
+            nodeMap.put(upNodeItem.text(0), upNodeItem);
+        }
+        QTreeWidgetItem downhillItem = new QTreeWidgetItem(parent);
+        downhillItem.setText(0, "Downhill Nodes");
+        for (Node down : n.getAllDownhillNodes()) {
+            QTreeWidgetItem downNodeItem = new QTreeWidgetItem(downhillItem);
+            downNodeItem.setText(0, down.toString());
+            nodeMap.put(downNodeItem.text(0), downNodeItem);
+        }
+    }
+
     /**
      * This method loads a new device based on the part name selected in the
      * treeWidget.
@@ -265,12 +340,16 @@ public class DeviceBrowser extends QMainWindow{
         if ( data != null) {
             if (currPart.equals(data))
                 return;
-            currPart = (String) data;
-            device = Device.getDevice(currPart);
-            scene.setDevice(device);
-            scene.initializeScene(hideTiles, drawPrimitives);
-            statusLabel.setText("Loaded: "+currPart.toUpperCase());
+            setPart((String) data);
         }
+    }
+
+    private void setPart(String partName) {
+        currPart = partName;
+        device = Device.getDevice(currPart);
+        scene.setDevice(device);
+        scene.initializeScene(hideTiles, drawPrimitives);
+        statusLabel.setText("Loaded: " + currPart.toUpperCase());
     }
 
     /**
@@ -281,5 +360,75 @@ public class DeviceBrowser extends QMainWindow{
         statusLabel.setText(text);
         //currTile = tile;
         //System.out.println("currTile=" + tile);
+    }
+
+    public Device getDevice() {
+        return device;
+    }
+
+    public DeviceBrowserScene getScene() {
+        return scene;
+    }
+
+    /**
+     * Triggers an event on the scene to clear any highlighted tiles
+     */
+    public void clearHighlightedTiles() {
+        QEvent event = new QEvent(QEvent.Type.resolve(DeviceBrowserScene.CLEAR_HIGHLIGHTED_TILES));
+        QApplication.postEvent(scene, event);
+    }
+
+    /**
+     * Populates the scene with the tile group and triggers a highlight event on the
+     * scene object to highlight the perimeter tiles of the tile groups
+     * 
+     * @param tileGroup The tile group to highlight
+     */
+    public void highlightTileGroup(TileGroup tileGroup) {
+        List<TileGroup> tgs = new ArrayList<>();
+        tgs.add(tileGroup);
+        highlightTileGroups(tgs);
+    }
+
+    /**
+     * Populates the scene with the tile groups and triggers a highlight event on
+     * the scene object to highlight the perimeter tiles of the tile groups.
+     * 
+     * @param tileGroups The tile groups to highlight
+     */
+    public void highlightTileGroups(List<TileGroup> tileGroups) {
+        scene.tileGroups = tileGroups;
+        QEvent event = new QEvent(QEvent.Type.resolve(DeviceBrowserScene.HIGHLIGHT_TILE_GROUPS));
+        QApplication.postEvent(scene, event);
+    }
+
+    /** Static reference to a threaded instance */
+    private static ThreadedDeviceBrowser threadedBrowser;
+
+    /**
+     * Creates a new DeviceBrowser window in a separate thread so that it can be
+     * called interactively from an interpreter.
+     * 
+     * @param partName The device or part name to load
+     * @return The DeviceBrowser window object
+     * @throws InterruptedException
+     */
+    public static DeviceBrowser createWindow(String partName) throws InterruptedException {
+        if (threadedBrowser != null) {
+            System.err.println("ERROR: Only a single instance of the DeviceBrowser is currently supported");
+            return null;
+        }
+        threadedBrowser = new ThreadedDeviceBrowser(new String[] { partName });
+        threadedBrowser.start();
+        // Since start() returns immediately, we need to wait until the constructor has
+        // finished populating class member variables before continuting
+        while (threadedBrowser.getDeviceBrowser() == null) {
+            Thread.sleep(10);
+        }
+        return threadedBrowser.getDeviceBrowser();
+    }
+
+    public static void removeThreadedInstance() {
+        threadedBrowser = null;
     }
 }

--- a/src/com/xilinx/rapidwright/device/browser/DeviceBrowser.java
+++ b/src/com/xilinx/rapidwright/device/browser/DeviceBrowser.java
@@ -159,7 +159,7 @@ public class DeviceBrowser extends QMainWindow{
         statusBar.addWidget(statusLabel);
         setStatusBar(statusBar);
 
-        // Set the opening default window size to 1024x768 pixels
+        // Set the opening default window size to 1280x1024 pixels
         resize(1280, 1024);
     }
 
@@ -315,14 +315,14 @@ public class DeviceBrowser extends QMainWindow{
 
     private void updateNodeItem(Node n, QTreeWidgetItem parent) {
         QTreeWidgetItem uphillItem = new QTreeWidgetItem(parent);
-        uphillItem.setText(0, "Uphill Nodes");
+        uphillItem.setText(0, UPHILL_NODES);
         for (Node up : n.getAllUphillNodes()) {
             QTreeWidgetItem upNodeItem = new QTreeWidgetItem(uphillItem);
             upNodeItem.setText(0, up.toString());
             nodeMap.put(upNodeItem.text(0), upNodeItem);
         }
         QTreeWidgetItem downhillItem = new QTreeWidgetItem(parent);
-        downhillItem.setText(0, "Downhill Nodes");
+        downhillItem.setText(0, DOWNHILL_NODES);
         for (Node down : n.getAllDownhillNodes()) {
             QTreeWidgetItem downNodeItem = new QTreeWidgetItem(downhillItem);
             downNodeItem.setText(0, down.toString());

--- a/src/com/xilinx/rapidwright/device/browser/DeviceBrowserScene.java
+++ b/src/com/xilinx/rapidwright/device/browser/DeviceBrowserScene.java
@@ -271,8 +271,6 @@ public class DeviceBrowserScene extends TileScene{
         }
     }
 
-
-    
     @Override
     public boolean event(QEvent event) {
         boolean result = true;

--- a/src/com/xilinx/rapidwright/device/browser/DeviceBrowserScene.java
+++ b/src/com/xilinx/rapidwright/device/browser/DeviceBrowserScene.java
@@ -28,8 +28,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Queue;
 
+import com.trolltech.qt.core.QEvent;
 import com.trolltech.qt.core.Qt.MouseButton;
 import com.trolltech.qt.core.Qt.PenStyle;
 import com.trolltech.qt.gui.QAction;
@@ -39,12 +42,14 @@ import com.trolltech.qt.gui.QGraphicsLineItem;
 import com.trolltech.qt.gui.QGraphicsSceneMouseEvent;
 import com.trolltech.qt.gui.QMenu;
 import com.trolltech.qt.gui.QPen;
-import com.xilinx.rapidwright.router.RouteNode;
+import com.xilinx.rapidwright.design.tools.Edge;
+import com.xilinx.rapidwright.design.tools.TileGroup;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.Wire;
 import com.xilinx.rapidwright.gui.NumberedHighlightedTile;
 import com.xilinx.rapidwright.gui.TileScene;
+import com.xilinx.rapidwright.router.RouteNode;
 
 /**
  * This class was written specifically for the DeviceBrowser class.  It
@@ -64,12 +69,18 @@ public class DeviceBrowserScene extends TileScene{
     /**     */
     private ArrayList<NumberedHighlightedTile> currentTiles = new ArrayList<NumberedHighlightedTile>();
 
+    // User Defined Qt Events
+    public static final int CLEAR_HIGHLIGHTED_TILES = 1001;
+    public static final int HIGHLIGHT_TILE_GROUPS = 1002;
+    // End Events
 
     public DeviceBrowserScene(Device device, boolean hideTiles, boolean drawPrimitives, DeviceBrowser browser) {
         super(device, hideTiles, drawPrimitives);
         currLines = new ArrayList<QGraphicsLineItem>();
         wirePen = new QPen(QColor.yellow, 0.25, PenStyle.SolidLine);
         this.browser = browser;
+        QEvent.registerEventType(CLEAR_HIGHLIGHTED_TILES);
+        QEvent.registerEventType(HIGHLIGHT_TILE_GROUPS);
     }
 
     public void drawWire(Tile src, Tile dst) {
@@ -181,6 +192,15 @@ public class DeviceBrowserScene extends TileScene{
     }
 
     private void menuReachabilityClear() {
+        clearHighlightedTiles();
+    }
+
+
+    public void addHighlightedTile(NumberedHighlightedTile tile) {
+        currentTiles.add(tile);
+    }
+
+    public void clearHighlightedTiles() {
         for (NumberedHighlightedTile rect : currentTiles) {
             rect.remove();
         }
@@ -229,5 +249,44 @@ public class DeviceBrowserScene extends TileScene{
 
 
         super.mouseReleaseEvent(event);
+    }
+
+    public List<TileGroup> tileGroups;
+
+    public void highlightTileGroups() {
+        for (TileGroup tg : tileGroups) {
+            highlightTileGroup(tg);
+        }
+    }
+
+    public void highlightTileGroup(TileGroup tg) {
+        QBrush brush = new QBrush(QColor.red);
+        Map<Tile, Edge> tileMap = tg.getRegionTiles();
+        for (Entry<Tile, Edge> e : tileMap.entrySet()) {
+            if (e.getValue() == Edge.INTERNAL)
+                continue;
+            NumberedHighlightedTile highTile = new NumberedHighlightedTile(e.getKey(), this, null);
+            highTile.setBrush(brush);
+            addHighlightedTile(highTile);
+        }
+    }
+
+
+    
+    @Override
+    public boolean event(QEvent event) {
+        boolean result = true;
+
+        switch(event.type().value()) {
+            case CLEAR_HIGHLIGHTED_TILES:
+                clearHighlightedTiles();
+                break;
+            case HIGHLIGHT_TILE_GROUPS:
+                highlightTileGroups();
+                break;
+            default:
+                result = super.event(event);
+            }
+        return result;
     }
 }

--- a/src/com/xilinx/rapidwright/device/browser/ThreadedDeviceBrowser.java
+++ b/src/com/xilinx/rapidwright/device/browser/ThreadedDeviceBrowser.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.device.browser;
+
+import com.trolltech.qt.gui.QApplication;
+
+/**
+ * Helper class to enable {@link DeviceBrowser} to be threaded and non-blocking
+ * when using an interpreter.
+ */
+public class ThreadedDeviceBrowser extends Thread {
+
+    private DeviceBrowser deviceBrowser;
+
+    private String[] args;
+
+    public ThreadedDeviceBrowser(String[] args) {
+        this.args = args;
+    }
+
+    @Override
+    public void run() {
+        QApplication.setGraphicsSystem("raster");
+        QApplication.initialize(args);
+
+        String defaultPart = null;
+        if (args.length > 0) {
+            defaultPart = args[0];
+        }
+
+        deviceBrowser = new DeviceBrowser(null, defaultPart);
+
+        deviceBrowser.show();
+        QApplication.exec();
+        DeviceBrowser.removeThreadedInstance();
+    }
+
+    public DeviceBrowser getDeviceBrowser() {
+        return deviceBrowser;
+    }
+}

--- a/src/com/xilinx/rapidwright/gui/NumberedHighlightedTile.java
+++ b/src/com/xilinx/rapidwright/gui/NumberedHighlightedTile.java
@@ -41,30 +41,34 @@ public class NumberedHighlightedTile  extends QGraphicsRectItem{
     protected static QFont font8 = new QFont("Arial", 8);
 
 
-    public NumberedHighlightedTile(Tile t, TileScene scene, int number) {
+    public NumberedHighlightedTile(Tile t, TileScene scene, Integer number) {
         super(0, 0, scene.tileSize - 2, scene.tileSize - 2);
         this.scene = scene;
-        this.text = new QGraphicsTextItem(Integer.toString(number));
         int x = scene.getDrawnTileX(t) * scene.tileSize;
         int y = scene.getDrawnTileY(t) * scene.tileSize;
-        text.setPos(x-4, y);
-        if (number < 100) {
-            text.setFont(font8);
-        } else if (number < 1000) {
-            text.setFont(font6);
-        } else {
-            text.setFont(font4);
-        }
 
         this.moveBy(x, y);
         this.scene.addItem(this);
-        this.scene.addItem(text);
 
-        this.text.setZValue(this.zValue() + 1);
+        if (number != null) {
+            this.text = new QGraphicsTextItem(Integer.toString(number));
+            text.setPos(x - 4, y);
+            if (number < 100) {
+                text.setFont(font8);
+            } else if (number < 1000) {
+                text.setFont(font6);
+            } else {
+                text.setFont(font4);
+            }
+            this.scene.addItem(text);
+            this.text.setZValue(this.zValue() + 1);
+        }
     }
 
     public void remove() {
-        scene.removeItem(text);
+        if (text != null) {
+            scene.removeItem(text);
+        }
         scene.removeItem(this);
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/tools/TestTileGroup.java
+++ b/test/src/com/xilinx/rapidwright/design/tools/TestTileGroup.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.design.tools;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.xilinx.rapidwright.device.ClockRegion;
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Tile;
+
+public class TestTileGroup {
+
+    @Test
+    public void testTileGroup() {
+        Device d = Device.getDevice("xcvc1902");
+
+        for (ClockRegion[] crs : d.getClockRegions()) {
+            for (ClockRegion cr : crs) {
+                if (cr.getUpperLeft() == null || cr.getUpperRight() == null) {
+                    continue;
+                }
+                TileGroup tg = new TileGroup(cr.getUpperLeft(), cr.getLowerRight());
+                Map<Tile, Edge> tileMap = tg.getRegionTiles();
+                for (Entry<Tile, Edge> e : tileMap.entrySet()) {
+                    Assertions.assertEquals(cr, e.getKey().getClockRegion());
+                    Assertions.assertTrue(e.getValue() != Edge.EXTERNAL);
+                }
+
+                for (Tile tile : d.getAllTiles()) {
+                    Edge edge = tg.getEdgeOfTile(tile);
+                    if (tile.getClockRegion() == cr) {
+                        Assertions.assertNotEquals(Edge.EXTERNAL, edge);
+                    } else {
+                        Assertions.assertEquals(Edge.EXTERNAL, edge);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a `TileGroup` object that is a contiguous rectangular range of tiles that can be highlighted in the `DeviceBrowser` or used for various tasks.

Updates the DeviceBrowser with a few new features:

1. Adds a Nodes sidebar that lists the `Node` objects present in a `Tile` and also allows infinite tree expansion based on uphill and downhill connectivity:
![image](https://github.com/user-attachments/assets/9144a40c-303d-41ac-863f-bef343a9bc3e)
2. Enables a threaded `DeviceBrowser` instance (see `DeviceBrowser.getWindow()`) that can live in an interpreter environment making interaction possible.  This is useful for Python/Jython/Jshell instances.
3. Adds functionality to highlight/unhighlight `TileGroup` edge tiles:
![image](https://github.com/user-attachments/assets/c8831e9c-5219-4022-a323-8c8dcf267d29)
