### PR TITLE
[RWRoute] Divide nodes into LOCAL and NON_LOCAL

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -305,9 +305,9 @@ public class Connection implements Comparable<Connection>{
         } else {
             assert(!altSinkRnodes.contains(sinkRnode));
         }
-        assert(sinkRnode.getType() == RouteNodeType.PINFEED_I ||
+        assert(sinkRnode.getType() == RouteNodeType.EXCLUSIVE_SINK ||
                // Can be a WIRE if node is not exclusive a sink
-               sinkRnode.getType() == RouteNodeType.WIRE);
+               sinkRnode.getType() == RouteNodeType.NON_LOCAL);
         altSinkRnodes.add(sinkRnode);
     }
 
@@ -487,7 +487,7 @@ public class Connection implements Comparable<Connection>{
                 // where the same physical pin services more than one logical pin
                 if (rnode.countConnectionsOfUser(netWrapper) == 0 ||
                     // Except if it is not a PINFEED_I
-                    rnode.getType() != RouteNodeType.PINFEED_I) {
+                    rnode.getType() != RouteNodeType.EXCLUSIVE_SINK) {
                     assert(rnode.getIntentCode() != IntentCode.NODE_PINBOUNCE);
                     rnode.markTarget(state);
                 }

--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -486,7 +486,7 @@ public class Connection implements Comparable<Connection>{
                 // if it's not already in use by the current net to prevent the case
                 // where the same physical pin services more than one logical pin
                 if (rnode.countConnectionsOfUser(netWrapper) == 0 ||
-                    // Except if it is not a PINFEED_I
+                    // Except if it is not an EXCLUSIVE_SINK
                     rnode.getType() != RouteNodeType.EXCLUSIVE_SINK) {
                     assert(rnode.getIntentCode() != IntentCode.NODE_PINBOUNCE);
                     rnode.markTarget(state);

--- a/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
+++ b/src/com/xilinx/rapidwright/rwroute/NetWrapper.java
@@ -171,7 +171,7 @@ public class NetWrapper{
                 return null;
             }
 
-            altSourceRnode = routingGraph.getOrCreate(altSourceNode, RouteNodeType.PINFEED_O);
+            altSourceRnode = routingGraph.getOrCreate(altSourceNode, RouteNodeType.EXCLUSIVE_SOURCE);
         }
         assert(altSourceRnode != null);
         return altSource;

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -256,7 +256,7 @@ public class PartialRouter extends RWRoute {
             preservedNet = routingGraph.getPreservedNet(sinkRnode);
             if (preservedNet != null && preservedNet != net) {
                 unpreserveNets.add(preservedNet);
-                assert(sinkRnode.getType() == RouteNodeType.PINFEED_I);
+                assert(sinkRnode.getType() == RouteNodeType.EXCLUSIVE_SINK);
             }
         }
 
@@ -598,8 +598,8 @@ public class PartialRouter extends RWRoute {
                 assert(!connection.isDirect());
                 RouteNode sourceRnode = connection.getSourceRnode();
                 RouteNode sinkRnode = connection.getSinkRnode();
-                assert(sourceRnode.getType() == RouteNodeType.PINFEED_O);
-                assert(sinkRnode.getType() == RouteNodeType.PINFEED_I);
+                assert(sourceRnode.getType() == RouteNodeType.EXCLUSIVE_SOURCE);
+                assert(sinkRnode.getType() == RouteNodeType.EXCLUSIVE_SINK);
 
                 // Even though this connection is not expected to have any routing yet,
                 // perform a rip up anyway in order to release any exclusive sinks

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1803,8 +1803,11 @@ public class RWRoute {
                         }
                         break;
                     case NON_LOCAL:
+                        // LOCALs cannot connect to NON_LOCALs except via a LUT routethru
                         assert(rnode.getType() != RouteNodeType.LOCAL ||
-                                routingGraph.lutRoutethru && rnode.getIntentCode() == IntentCode.NODE_PINFEED);
+                               routingGraph.lutRoutethru && rnode.getIntentCode() == IntentCode.NODE_PINFEED ||
+                               // FIXME:
+                               design.getSeries() == Series.Versal);
 
                         if (!routingGraph.isAccessible(childRNode, connection)) {
                             continue;

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1803,6 +1803,9 @@ public class RWRoute {
                         }
                         break;
                     case NON_LOCAL:
+                        assert(rnode.getType() != RouteNodeType.LOCAL ||
+                                routingGraph.lutRoutethru && rnode.getIntentCode() == IntentCode.NODE_PINFEED);
+
                         if (!routingGraph.isAccessible(childRNode, connection)) {
                             continue;
                         }
@@ -1817,7 +1820,7 @@ public class RWRoute {
                             continue;
                         }
                         break;
-                    case LAGUNA_I:
+                    case LAGUNA_PINFEED:
                         if (!connection.isCrossSLR() ||
                             connection.getSinkRnode().getSLRIndex(routingGraph) == childRNode.getSLRIndex(routingGraph)) {
                             // Do not consider approaching a SLL if not needing to cross

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -56,7 +56,6 @@ import com.xilinx.rapidwright.util.MessageGenerator;
 import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.RuntimeTracker;
 import com.xilinx.rapidwright.util.RuntimeTrackerTree;
-import com.xilinx.rapidwright.util.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1798,6 +1797,11 @@ public class RWRoute {
                     continue;
                 }
                 switch (childRNode.getType()) {
+                    case LOCAL:
+                        if (!routingGraph.isAccessible(childRNode, connection)) {
+                            continue;
+                        }
+                        break;
                     case WIRE:
                         if (!routingGraph.isAccessible(childRNode, connection)) {
                             continue;

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -1819,7 +1819,7 @@ public class RWRoute {
                         }
                         break;
                     case EXCLUSIVE_SINK:
-                        if (!isAccessiblePinfeedI(childRNode, connection)) {
+                        if (!isAccessibleSink(childRNode, connection)) {
                             continue;
                         }
                         break;
@@ -1857,12 +1857,12 @@ public class RWRoute {
         return !config.isUseBoundingBox() || child.isInConnectionBoundingBox(connection);
     }
 
-    protected boolean isAccessiblePinfeedI(RouteNode child, Connection connection) {
-        // When LUT pin swapping is enabled, PINFEED_I are not exclusive anymore
-        return isAccessiblePinfeedI(child, connection, !lutPinSwapping);
+    protected boolean isAccessibleSink(RouteNode child, Connection connection) {
+        // When LUT pin swapping is enabled, EXCLUSIVE_SINK-s are not exclusive anymore
+        return isAccessibleSink(child, connection, !lutPinSwapping);
     }
 
-    protected boolean isAccessiblePinfeedI(RouteNode child, Connection connection, boolean assertOnOveruse) {
+    protected boolean isAccessibleSink(RouteNode child, Connection connection, boolean assertOnOveruse) {
         assert(child.getType() == RouteNodeType.EXCLUSIVE_SINK);
         assert(!assertOnOveruse || !child.isOverUsed());
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -124,12 +124,14 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
                         (length <= 3 && series == Series.Versal));
                 break;
             case EXCLUSIVE_SINK:
+                assert(length == 0);
+                break;
             case LOCAL:
                 assert(length == 0 ||
-                       (length == 1 && (series == Series.UltraScalePlus || series == Series.UltraScale) &&
-                               (getIntentCode() == IntentCode.NODE_PINBOUNCE ||
-                               (series == Series.UltraScalePlus && type == RouteNodeType.LOCAL && getWireName().matches("INODE_[EW]_\\d+_FT[01]")) ||
-                               (series == Series.UltraScale && type == RouteNodeType.LOCAL && getWireName().matches("INODE_[12]_[EW]_\\d+_FT[NS]"))
+                       (length == 1 && (
+                               ((series == Series.UltraScalePlus || series == Series.UltraScale) && getIntentCode() == IntentCode.NODE_PINBOUNCE) ||
+                               (series == Series.UltraScalePlus && getWireName().matches("INODE_[EW]_\\d+_FT[01]")) ||
+                               (series == Series.UltraScale && getWireName().matches("INODE_[12]_[EW]_\\d+_FT[NS]"))
                        ))
                    );
                 break;

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -124,7 +124,8 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
                         (length <= 3 && series == Series.Versal));
                 break;
             case EXCLUSIVE_SINK:
-                assert(length == 0);
+                assert(length == 0 ||
+                       (length == 1 && (series == Series.UltraScalePlus || series == Series.UltraScale) && getIntentCode() == IntentCode.NODE_PINBOUNCE));
                 break;
             case LOCAL:
                 assert(length == 0 ||

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -120,13 +120,18 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
         baseCost = 0.4f;
         switch (type) {
             case EXCLUSIVE_SOURCE:
-                assert(length == 0);
+                assert(length == 0 ||
+                        (length <= 3 && series == Series.Versal));
                 break;
             case EXCLUSIVE_SINK:
             case LOCAL:
                 assert(length == 0 ||
-                       length == 1 && (getIntentCode() == IntentCode.NODE_PINBOUNCE || (type == RouteNodeType.LOCAL && getWireName().matches("INODE_[EW]_\\d+_FT[01]")))
-                                   && (series == Series.UltraScale || series == Series.UltraScalePlus));
+                       (length == 1 && (series == Series.UltraScalePlus || series == Series.UltraScale) &&
+                               (getIntentCode() == IntentCode.NODE_PINBOUNCE ||
+                               (series == Series.UltraScalePlus && type == RouteNodeType.LOCAL && getWireName().matches("INODE_[EW]_\\d+_FT[01]")) ||
+                               (series == Series.UltraScale && type == RouteNodeType.LOCAL && getWireName().matches("INODE_[12]_[EW]_\\d+_FT[NS]"))
+                       ))
+                   );
                 break;
             case LAGUNA_PINFEED:
                 // Make all approaches to SLLs zero-cost to encourage exploration

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -363,7 +363,7 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
                 // Support demotion from EXCLUSIVE_SINK to LOCAL since they have the same base cost
                 (this.type == RouteNodeType.EXCLUSIVE_SINK && type == RouteNodeType.LOCAL) ||
                 // Or promotion from LOCAL to EXCLUSIVE_SINK (by PartialRouter when NODE_PINBOUNCE on
-                // preserved net needs to become a PINFEED_I)
+                // a newly unpreserved net becomes a sink)
                 (this.type == RouteNodeType.LOCAL && type == RouteNodeType.EXCLUSIVE_SINK));
         this.type = type;
     }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -92,7 +92,7 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
 
     protected RouteNode(RouteNodeGraph routingGraph, Node node, RouteNodeType type) {
         super(node);
-        RouteNodeInfo nodeInfo = RouteNodeInfo.get(this, routingGraph.lagunaI);
+        RouteNodeInfo nodeInfo = RouteNodeInfo.get(this, routingGraph);
         this.type = (type == null) ? nodeInfo.type : type;
         endTileXCoordinate = nodeInfo.endTileXCoordinate;
         endTileYCoordinate = nodeInfo.endTileYCoordinate;
@@ -118,6 +118,9 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
     private void setBaseCost() {
         baseCost = 0.4f;
         switch (type) {
+            case LOCAL:
+                assert(length <= 1);
+                break;
             case LAGUNA_I:
                 // Make all approaches to SLLs zero-cost to encourage exploration
                 // Assigning a base cost of zero would normally break congestion resolution
@@ -139,10 +142,10 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
                     case NODE_LAGUNA_OUTPUT: // LAG_LAG.{LAG_MUX_ATOM_*_TXOUT,RXD*} (US+)
                     case NODE_LAGUNA_DATA:   // LAG_LAG.UBUMP* super long lines for u-turns at the boundary of the device (US+)
                     case NODE_PINFEED:
+                    case INTENT_DEFAULT:     // INT.VCC_WIRE
                         assert(length == 0);
                         break;
-                    case NODE_LOCAL:    // US and US+
-                    case INTENT_DEFAULT:
+                    case NODE_LOCAL: // US and US+
                         assert(length <= 1);
                         break;
                     case NODE_VSINGLE: // Versal-only

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -128,7 +128,7 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
                        length == 1 && (getIntentCode() == IntentCode.NODE_PINBOUNCE || (type == RouteNodeType.LOCAL && getWireName().matches("INODE_[EW]_\\d+_FT[01]")))
                                    && (series == Series.UltraScale || series == Series.UltraScalePlus));
                 break;
-            case LAGUNA_I:
+            case LAGUNA_PINFEED:
                 // Make all approaches to SLLs zero-cost to encourage exploration
                 // Assigning a base cost of zero would normally break congestion resolution
                 // (since RWroute.getNodeCost() would return zero) but doing it here should be

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -417,8 +417,8 @@ public class RouteNodeGraph {
             RouteNode childRnode = getNode(child);
             if (childRnode != null) {
                 assert(childRnode.getType() == RouteNodeType.EXCLUSIVE_SINK ||
-                       childRnode.getType() == RouteNodeType.LAGUNA_I ||
-                        (lutRoutethru && childRnode.getType() == RouteNodeType.NON_LOCAL));
+                       childRnode.getType() == RouteNodeType.LAGUNA_PINFEED ||
+                       (lutRoutethru && childRnode.getType() == RouteNodeType.LOCAL));
             } else if (!lutRoutethru) {
                 // child does not already exist in our routing graph, meaning it's not a used site pin
                 // in our design, but it could be a LAGUNA_I

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -416,9 +416,9 @@ public class RouteNodeGraph {
             // PINFEEDs can lead to a site pin, or into a Laguna tile
             RouteNode childRnode = getNode(child);
             if (childRnode != null) {
-                assert(childRnode.getType() == RouteNodeType.PINFEED_I ||
+                assert(childRnode.getType() == RouteNodeType.EXCLUSIVE_SINK ||
                        childRnode.getType() == RouteNodeType.LAGUNA_I ||
-                        (lutRoutethru && childRnode.getType() == RouteNodeType.WIRE));
+                        (lutRoutethru && childRnode.getType() == RouteNodeType.NON_LOCAL));
             } else if (!lutRoutethru) {
                 // child does not already exist in our routing graph, meaning it's not a used site pin
                 // in our design, but it could be a LAGUNA_I
@@ -513,17 +513,7 @@ public class RouteNodeGraph {
     }
 
     protected RouteNode create(Node node, RouteNodeType type) {
-        RouteNode rnode = new RouteNode(this, node, type);
-        // PINFEED_I should have zero length, except for on US/US+ where the PINFEED_I can be a PINBOUNCE node.
-        assert(rnode.getType() != RouteNodeType.PINFEED_I ||
-                rnode.getLength() == 0 ||
-                (rnode.getLength() == 1 && (design.getSeries() == Series.UltraScale || design.getSeries() == Series.UltraScalePlus) &&
-                        rnode.getIntentCode() == IntentCode.NODE_PINBOUNCE));
-        // PINBOUNCE should have zero length, except for on US/US+
-        assert(rnode.getType() != RouteNodeType.PINBOUNCE ||
-                rnode.getLength() == 0 ||
-                (rnode.getLength() == 1 && design.getSeries() == Series.UltraScale || design.getSeries() == Series.UltraScalePlus));
-        return rnode;
+        return new RouteNode(this, node, type);
     }
 
     public RouteNode getOrCreate(Node node) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -99,7 +99,7 @@ public class RouteNodeGraph {
     protected final boolean lutRoutethru;
 
     /** Map indicating the wire indices that have a local intent code, but is what RWRoute considers to be non-local */
-    protected final Map<TileTypeEnum, BitSet> nonLocalWires;
+    protected final Map<TileTypeEnum, BitSet> ultraScaleNonLocalWires;
 
     public RouteNodeGraph(Design design, RWRouteConfig config) {
         this(design, config, new HashMap<>());
@@ -129,57 +129,60 @@ public class RouteNodeGraph {
             }
         }
 
-        nonLocalWires = new EnumMap<>(TileTypeEnum.class);
-        BitSet wires = new BitSet();
-        Tile intTile = device.getArbitraryTileOfType(TileTypeEnum.INT);
-        // Device.getArbitraryTileOfType() typically gives you the North-Western-most
-        // tile (with minimum X, maximum Y). Analyze the tile just below that.
-        intTile = intTile.getTileXYNeighbor(0, -1);
-        nonLocalWires.put(intTile.getTileTypeEnum(), wires);
         Series series = device.getSeries();
         boolean isUltraScale = series == Series.UltraScale;
         boolean isUltraScalePlus = series == Series.UltraScalePlus;
-        boolean isVersal = series == Series.Versal;
-        for (int wireIndex = 0; wireIndex < intTile.getWireCount(); wireIndex++) {
-            Node baseNode = Node.getNode(intTile, wireIndex);
-            if (baseNode == null) {
-                continue;
-            }
-            if (baseNode.getIntentCode() != IntentCode.NODE_LOCAL) {
-                continue;
-            }
-            Tile baseTile = baseNode.getTile();
-            String wireName = baseNode.getWireName();
-            if (isUltraScalePlus) {
-                if (!wireName.startsWith("INT_NODE_SDQ_") && !wireName.startsWith("SDQNODE_")) {
+        if (isUltraScale || isUltraScalePlus) {
+            ultraScaleNonLocalWires = new EnumMap<>(TileTypeEnum.class);
+            BitSet wires = new BitSet();
+            Tile intTile = device.getArbitraryTileOfType(TileTypeEnum.INT);
+            // Device.getArbitraryTileOfType() typically gives you the North-Western-most
+            // tile (with minimum X, maximum Y). Analyze the tile just below that.
+            intTile = intTile.getTileXYNeighbor(0, -1);
+            ultraScaleNonLocalWires.put(intTile.getTileTypeEnum(), wires);
+            for (int wireIndex = 0; wireIndex < intTile.getWireCount(); wireIndex++) {
+                Node baseNode = Node.getNode(intTile, wireIndex);
+                if (baseNode == null) {
                     continue;
                 }
-                if (baseTile != intTile) {
-                    if (wireName.endsWith("_FT0")) {
-                        assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() - 1);
-                    } else {
-                        assert(wireName.endsWith("_FT1"));
-                        assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() + 1);
-                    }
-                }
-            } else if (isUltraScale) {
-                if (!wireName.startsWith("INT_NODE_SINGLE_DOUBLE_") && !wireName.startsWith("SDND") &&
-                        !wireName.startsWith("INT_NODE_QUAD_LONG") && !wireName.startsWith("QLND")) {
+                if (baseNode.getIntentCode() != IntentCode.NODE_LOCAL) {
                     continue;
                 }
-                if (baseTile != intTile) {
-                    if (wireName.endsWith("_FTN")) {
-                        assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() - 1);
-                    } else {
-                        assert(wireName.endsWith("_FTS"));
-                        assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() + 1);
+
+                Tile baseTile = baseNode.getTile();
+                String wireName = baseNode.getWireName();
+                if (isUltraScalePlus) {
+                    if (!wireName.startsWith("INT_NODE_SDQ_") && !wireName.startsWith("SDQNODE_")) {
+                        continue;
+                    }
+                    if (baseTile != intTile) {
+                        if (wireName.endsWith("_FT0")) {
+                            assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() - 1);
+                        } else {
+                            assert(wireName.endsWith("_FT1"));
+                            assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() + 1);
+                        }
+                    }
+                } else {
+                    assert(isUltraScale);
+
+                    if (!wireName.startsWith("INT_NODE_SINGLE_DOUBLE_") && !wireName.startsWith("SDND") &&
+                            !wireName.startsWith("INT_NODE_QUAD_LONG") && !wireName.startsWith("QLND")) {
+                        continue;
+                    }
+                    if (baseTile != intTile) {
+                        if (wireName.endsWith("_FTN")) {
+                            assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() - 1);
+                        } else {
+                            assert(wireName.endsWith("_FTS"));
+                            assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() + 1);
+                        }
                     }
                 }
-            } else {
-                assert(isVersal);
-                continue;
+                wires.set(baseNode.getWireIndex());
             }
-            wires.set(baseNode.getWireIndex());
+        } else {
+            ultraScaleNonLocalWires = null;
         }
 
         if (lutRoutethru) {
@@ -191,7 +194,7 @@ public class RouteNodeGraph {
                 if (clbTile == null) {
                     continue;
                 }
-                wires = new BitSet();
+                BitSet wires = new BitSet();
                 for (int wireIndex = 0; wireIndex < clbTile.getWireCount(); wireIndex++) {
                     String wireName = clbTile.getWireName(wireIndex);
                     if (wireName.endsWith("MUX")) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -23,10 +23,8 @@
 
 package com.xilinx.rapidwright.rwroute;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Collection;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -79,11 +77,6 @@ public class RouteNodeGraph {
      */
     private final CountUpDownLatch asyncPreserveOutstanding;
 
-    /**
-     * Visited rnodes data during connection routing
-     */
-    private final Collection<RouteNode> targets;
-
     private long createRnodeTime;
 
     public static final short SUPER_LONG_LINE_LENGTH_IN_TILES = 60;
@@ -121,7 +114,6 @@ public class RouteNodeGraph {
         preservedMap = new ConcurrentHashMap<>();
         preservedMapSize = new AtomicInteger();
         asyncPreserveOutstanding = new CountUpDownLatch();
-        targets = new ArrayList<>();
         createRnodeTime = 0;
 
         Device device = design.getDevice();
@@ -287,7 +279,6 @@ public class RouteNodeGraph {
     }
 
     public void initialize() {
-        assert(targets.isEmpty());
     }
 
     protected Net preserve(Node node, Net net) {
@@ -581,9 +572,9 @@ public class RouteNodeGraph {
             return true;
         }
 
-        // (d) when in row above/below the sink tile
+        // (d) when in X as the sink tile, but Y +/- 1
         return childX == sinkTile.getTileXCoordinate() &&
-                Math.abs(childTile.getTileYCoordinate() - sinkTile.getTileYCoordinate()) <= 1;
+               Math.abs(childTile.getTileYCoordinate() - sinkTile.getTileYCoordinate()) <= 1;
     }
 
     protected boolean allowRoutethru(Node head, Node tail) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -129,7 +129,7 @@ public class RouteNodeInfo {
         // NOTE: IntentCode is device-dependent
         IntentCode ic = node.getIntentCode();
         switch (ic) {
-            case NODE_LOCAL: {
+            case NODE_LOCAL: { // US/US+
                 assert(node.getTile().getTileTypeEnum() == TileTypeEnum.INT);
                 if (routingGraph != null) {
                     BitSet bs = routingGraph.nonLocalWires.get(node.getTile().getTileTypeEnum());

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -92,7 +92,7 @@ public class RouteNodeInfo {
                 }
                 break;
             case INT:
-                if (type == RouteNodeType.LAGUNA_I) {
+                if (type == RouteNodeType.LAGUNA_PINFEED) {
                     assert(length == 0);
                 }
                 break;
@@ -111,7 +111,7 @@ public class RouteNodeInfo {
                 // fanout nodes of the SLL are marked as) unless it is a fanin (LAGUNA_I)
                 // (i.e. do not apply it to the fanout nodes).
                 // Nor apply it to VCC_WIREs since their end tiles are INT tiles.
-                if ((node.getIntentCode() != IntentCode.NODE_LAGUNA_OUTPUT || type == RouteNodeType.LAGUNA_I) &&
+                if ((node.getIntentCode() != IntentCode.NODE_LAGUNA_OUTPUT || type == RouteNodeType.LAGUNA_PINFEED) &&
                         !node.isTiedToVcc()) {
                     assert(baseTile.getTileXCoordinate() == endTileXCoordinate);
                     endTileXCoordinate++;
@@ -147,16 +147,16 @@ public class RouteNodeInfo {
                 if (routingGraph != null && routingGraph.lagunaI != null) {
                     BitSet bs = routingGraph.lagunaI.get(node.getTile());
                     if (bs != null && bs.get(node.getWireIndex())) {
-                        return RouteNodeType.LAGUNA_I;
+                        return RouteNodeType.LAGUNA_PINFEED;
                     }
                 }
-                break;
+                return RouteNodeType.LOCAL;
             }
 
             case NODE_LAGUNA_OUTPUT: // UltraScale+ only
                 assert(node.getTile().getTileTypeEnum() == TileTypeEnum.LAG_LAG);
                 if (node.getWireName().endsWith("_TXOUT")) {
-                    return RouteNodeType.LAGUNA_I;
+                    return RouteNodeType.LAGUNA_PINFEED;
                 }
                 break;
 
@@ -177,7 +177,7 @@ public class RouteNodeInfo {
                         return RouteNodeType.SUPER_LONG_LINE;
                     } else if (wireName.endsWith("_TXOUT")) {
                         // This is the inner LAGUNA_I, mark it so it gets a base cost discount
-                        return RouteNodeType.LAGUNA_I;
+                        return RouteNodeType.LAGUNA_PINFEED;
                     }
                 }
                 break;

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -129,9 +129,6 @@ public class RouteNodeInfo {
         // NOTE: IntentCode is device-dependent
         IntentCode ic = node.getIntentCode();
         switch (ic) {
-            case NODE_PINBOUNCE:
-                return RouteNodeType.PINBOUNCE;
-
             case NODE_LOCAL: {
                 assert(node.getTile().getTileTypeEnum() == TileTypeEnum.INT);
                 if (routingGraph != null) {
@@ -142,6 +139,9 @@ public class RouteNodeInfo {
                     break;
                 }
             }
+
+            case NODE_PINBOUNCE:
+                return RouteNodeType.LOCAL;
 
             case NODE_PINFEED: {
                 if (routingGraph != null && routingGraph.lagunaI != null) {
@@ -183,6 +183,6 @@ public class RouteNodeInfo {
                 break;
         }
 
-        return RouteNodeType.WIRE;
+        return RouteNodeType.NON_LOCAL;
     }
 }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -132,7 +132,7 @@ public class RouteNodeInfo {
             case NODE_LOCAL: { // US/US+
                 assert(node.getTile().getTileTypeEnum() == TileTypeEnum.INT);
                 if (routingGraph != null) {
-                    BitSet bs = routingGraph.nonLocalWires.get(node.getTile().getTileTypeEnum());
+                    BitSet bs = routingGraph.ultraScaleNonLocalWires.get(node.getTile().getTileTypeEnum());
                     if (!bs.get(node.getWireIndex())) {
                         return RouteNodeType.LOCAL;
                     }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
@@ -24,8 +24,6 @@
 
 package com.xilinx.rapidwright.rwroute;
 
-import com.xilinx.rapidwright.design.Net;
-import com.xilinx.rapidwright.device.IntentCode;
 import com.xilinx.rapidwright.device.Node;
 
 public enum RouteNodeType {
@@ -42,7 +40,7 @@ public enum RouteNodeType {
      * Denotes {@link RouteNode} objects that correspond to {@link Node} objects that enter
      * a Laguna tile from an INT tile, or those Laguna tile nodes leading to a SUPER_LONG_LINE.
      */
-    LAGUNA_I,
+    LAGUNA_PINFEED,
 
     NON_LOCAL,
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
@@ -29,21 +29,8 @@ import com.xilinx.rapidwright.device.IntentCode;
 import com.xilinx.rapidwright.device.Node;
 
 public enum RouteNodeType {
-    /**
-     * Denotes {@link RouteNode} objects that correspond to the output pins of {@link Net} Objects,
-     * typically the source {@link RouteNode} Objects of {@link Connection} Objects.
-     */
-    PINFEED_O,
-    /**
-     * Denotes {@link RouteNode} objects that correspond to input pins of {@link Net} Objects,
-     * typically the sink {@link RouteNode} Objects of {@link Connection} Objects.
-     */
-    PINFEED_I,
-    /**
-     * Denotes {@link RouteNode} objects that are created based on {@link Node} Objects
-     * that have an {@link IntentCode} of NODE_PINBOUNCE.
-     */
-    PINBOUNCE,
+    EXCLUSIVE_SOURCE,
+    EXCLUSIVE_SINK,
 
     /**
      * Denotes {@link RouteNode} objects that correspond to a super long line {@link Node},
@@ -57,11 +44,7 @@ public enum RouteNodeType {
      */
     LAGUNA_I,
 
-    /**
-     * Denotes other wiring {@link RouteNode} Objects
-     * that are created for routing {@link Connection} Objects.
-     */
-    WIRE,
+    NON_LOCAL,
 
     LOCAL
 }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
@@ -61,6 +61,7 @@ public enum RouteNodeType {
      * Denotes other wiring {@link RouteNode} Objects
      * that are created for routing {@link Connection} Objects.
      */
-    WIRE
+    WIRE,
 
+    LOCAL
 }

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -25,7 +25,6 @@
 package com.xilinx.rapidwright.rwroute;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.xilinx.rapidwright.design.Design;
@@ -35,7 +34,6 @@ import com.xilinx.rapidwright.design.NetType;
 import com.xilinx.rapidwright.design.SitePinInst;
 import com.xilinx.rapidwright.device.IntentCode;
 import com.xilinx.rapidwright.device.Node;
-import com.xilinx.rapidwright.device.TileTypeEnum;
 import com.xilinx.rapidwright.timing.TimingManager;
 import com.xilinx.rapidwright.timing.TimingVertex;
 import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
@@ -130,11 +128,11 @@ public class TimingAndWirelengthReport{
             if (sinkINTNode == null) {
                 connection.setDirect(true);
             } else {
-                connection.setSinkRnode(routingGraph.getOrCreate(sinkINTNode, RouteNodeType.PINFEED_I));
+                connection.setSinkRnode(routingGraph.getOrCreate(sinkINTNode, RouteNodeType.EXCLUSIVE_SINK));
                 if (sourceINTNode == null) {
                     sourceINTNode = RouterHelper.projectOutputPinToINTNode(source);
                 }
-                connection.setSourceRnode(routingGraph.getOrCreate(sourceINTNode, RouteNodeType.PINFEED_O));
+                connection.setSourceRnode(routingGraph.getOrCreate(sourceINTNode, RouteNodeType.EXCLUSIVE_SOURCE));
                 connection.setDirect(false);
             }
         }

--- a/test/src/com/xilinx/rapidwright/device/TestNode.java
+++ b/test/src/com/xilinx/rapidwright/device/TestNode.java
@@ -94,6 +94,10 @@ public class TestNode {
             "xcvu3p,INT_X37Y220,SDQNODE_.*",
             "xcvu3p,INT_X37Y220,IMUX_.*",
             "xcvu3p,INT_X37Y220,CTRL_.*",
+            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)1_.*",
+            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)2_.*",
+            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)4_.*",
+            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)12_.*",
             "xcvu3p,CLEM_X37Y220,CLE_CLE_M_SITE_0_[A-H](_O|Q|Q2|MUX)",
 
             // UltraScale part
@@ -107,6 +111,12 @@ public class TestNode {
             "xcvu065,INT_X38Y220,INT_NODE_QUAD_LONG_.*",
             "xcvu065,INT_X38Y220,IMUX_.*",
             "xcvu065,INT_X38Y220,CTRL_.*",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)1_.*",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)2_.*",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)4_.*",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)5_.*",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)12_.*",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)16_.*",
             "xcvu065,INT_X38Y220,QLND.*",
             "xcvu065,INT_X38Y220,SDND.*",
             "xcvu065,CLE_M_X38Y220,CLE_CLE_M_SITE_0_[A-H](_O|Q|Q2|MUX)",
@@ -138,7 +148,7 @@ public class TestNode {
                                        // UltraScale+
                         ultraScalePlus ? "((CLE_CLE_[LM]_SITE_0|CLK_LEAF_SITES|INT_INT_SDQ|(NN|EE|SS|WW)(1|2|4|12))_)[^\\(]+"
                                        // UltraScale
-                                       : "((CLE_CLE_[LM]_SITE_0|CLK_BUFCE_LEAF_X16_1_CLK|EE[124]|INT_INT_SINGLE|(NN|SS)(1|2|4|5|12|16)|(EE|WW)(1|2|4|12)|SDND[NS]W)_)[^\\(]+",
+                                       : "((CLE_CLE_[LM]_SITE_0|CLK_BUFCE_LEAF_X16_1_CLK|EE[124]|INT_INT_SINGLE|(NN|SS)(1|2|4|5|12|16)|(EE|WW)(1|2|4|12)|QLND(NW|SE|SW)|SDND[NS]W)_)[^\\(]+",
                         "$1"))
                 .distinct()
                 .sorted()
@@ -153,7 +163,7 @@ public class TestNode {
                                        // UltraScale+
                         ultraScalePlus ? "((CLE_CLE_[LM]_SITE_0|INT_INT_SDQ|(NN|EE|SS|WW)(1|2|4|12))_)[^\\(]+"
                                        // UltraScale
-                                       : "((INT_INT_SINGLE|(NN|SS)(1|2|4|5|12|16)|(EE|WW)(1|2|4|12)|QLND(NW|SE)|SDND[NS]W)_)[^\\(]+",
+                                       : "((CLE_CLE_[LM]_SITE_0|INT_INT_SINGLE|(NN|SS)(1|2|4|5|12|16)|(EE|WW)(1|2|4|12)|QLND(NW|S[EW])|SDND[NS]W)_)[^\\(]+",
                         "$1"))
                 .distinct()
                 .sorted()
@@ -163,10 +173,11 @@ public class TestNode {
         while (!queue.isEmpty()) {
             Node node = queue.poll();
             String wireName = node.getWireName();
-            if ((ultraScalePlus && wireName.matches("(INT_NODE_SDQ|SDQNODE)_.*")) ||                                      // UltraScale+
-                (!ultraScalePlus && wireName.matches("(INT_NODE_(SINGLE_DOUBLE|QUAD_LONG)|QLND(NW|SE|SW)|SDND[NS]W)_.*")) // UltraScale
+            if ((ultraScalePlus && wireName.matches("(INT_NODE_SDQ|SDQNODE)_.*")) ||                                        // UltraScale+
+                (!ultraScalePlus && wireName.matches("(INT_NODE_(SINGLE_DOUBLE|QUAD_LONG)|QLND(NW|SE|SW)|SDND[NS]W)_.*") || // UltraScale
+                wireName.matches("(NN|EE|SS|WW)\\d+(_[EW])?_BEG\\d+"))
             ) {
-                // Do not desccend into SDQNODEs
+                // Do not desccend into SDQNODEs or SDQLs
                 continue;
             }
             for (Node downhill : node.getAllDownhillNodes()) {

--- a/test/src/com/xilinx/rapidwright/device/TestNode.java
+++ b/test/src/com/xilinx/rapidwright/device/TestNode.java
@@ -175,7 +175,7 @@ public class TestNode {
             String wireName = node.getWireName();
             if ((ultraScalePlus && wireName.matches("(INT_NODE_SDQ|SDQNODE)_.*")) ||                                        // UltraScale+
                 (!ultraScalePlus && wireName.matches("(INT_NODE_(SINGLE_DOUBLE|QUAD_LONG)|QLND(NW|SE|SW)|SDND[NS]W)_.*") || // UltraScale
-                EnumSet.of(IntentCode.NODE_SINGLE, IntentCode.NODE_DOUBLE, IntentCode.NODE_HQUAD, IntentCode.VQUAD, IntentCode.HLONG, IntentCode. VLONG)
+                EnumSet.of(IntentCode.NODE_SINGLE, IntentCode.NODE_DOUBLE, IntentCode.NODE_HQUAD, IntentCode.NODE_VQUAD, IntentCode.NODE_HLONG, IntentCode.NODE_VLONG)
                         .contains(node.getIntentCode()))
             ) {
                 // Do not desccend into SDQNODEs or SDQLs

--- a/test/src/com/xilinx/rapidwright/device/TestNode.java
+++ b/test/src/com/xilinx/rapidwright/device/TestNode.java
@@ -84,44 +84,44 @@ public class TestNode {
     @ParameterizedTest
     @CsvSource({
             // UltraScale+ part
-            "xcvu3p,INT_X37Y220,BOUNCE_.*",
-            "xcvu3p,INT_X37Y220,BYPASS_.*",
-            "xcvu3p,INT_X37Y220,INT_NODE_GLOBAL_.*",
-            "xcvu3p,INT_X37Y220,INT_NODE_IMUX_.*",
-            "xcvu3p,INT_X37Y220,INODE_.*",
-            "xcvu3p,INT_X37Y220,INT_INT_SDQ_.*", // IntentCode.NODE_SINGLE
-            "xcvu3p,INT_X37Y220,INT_NODE_SDQ_.*",
-            "xcvu3p,INT_X37Y220,SDQNODE_.*",
-            "xcvu3p,INT_X37Y220,IMUX_.*",
-            "xcvu3p,INT_X37Y220,CTRL_.*",
-            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)1_.*",
-            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)2_.*",
-            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)4_.*",
-            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)12_.*",
-            "xcvu3p,CLEM_X37Y220,CLE_CLE_M_SITE_0_[A-H](_O|Q|Q2|MUX)",
+            "xcvu3p,INT_X37Y220,BOUNCE_.*,true",
+            "xcvu3p,INT_X37Y220,BYPASS_.*,true",
+            "xcvu3p,INT_X37Y220,INT_NODE_GLOBAL_.*,true",
+            "xcvu3p,INT_X37Y220,INT_NODE_IMUX_.*,true",
+            "xcvu3p,INT_X37Y220,INODE_.*,true",
+            "xcvu3p,INT_X37Y220,INT_INT_SDQ_.*,false", // IntentCode.NODE_SINGLE
+            "xcvu3p,INT_X37Y220,INT_NODE_SDQ_.*,false",
+            "xcvu3p,INT_X37Y220,SDQNODE_.*,false",
+            "xcvu3p,INT_X37Y220,IMUX_.*,true",
+            "xcvu3p,INT_X37Y220,CTRL_.*,true",
+            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)1_.*,false",
+            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)2_.*,false",
+            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)4_.*,false",
+            "xcvu3p,INT_X37Y220,(NN|EE|SS|WW)12_.*,false",
+            "xcvu3p,CLEM_X37Y220,CLE_CLE_M_SITE_0_[A-H](_O|Q|Q2|MUX),false",
 
             // UltraScale part
-            "xcvu065,INT_X38Y220,BOUNCE_.*",
-            "xcvu065,INT_X38Y220,BYPASS_.*",
-            "xcvu065,INT_X38Y220,INT_NODE_GLOBAL_.*",
-            "xcvu065,INT_X38Y220,INT_NODE_IMUX_.*",
-            "xcvu065,INT_X38Y220,INODE_.*",
-            "xcvu065,INT_X38Y220,INT_INT_SINGLE_.*", // IntentCode.NODE_SINGLE
-            "xcvu065,INT_X38Y220,INT_NODE_SINGLE_DOUBLE_.*",
-            "xcvu065,INT_X38Y220,INT_NODE_QUAD_LONG_.*",
-            "xcvu065,INT_X38Y220,IMUX_.*",
-            "xcvu065,INT_X38Y220,CTRL_.*",
-            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)1_.*",
-            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)2_.*",
-            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)4_.*",
-            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)5_.*",
-            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)12_.*",
-            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)16_.*",
-            "xcvu065,INT_X38Y220,QLND.*",
-            "xcvu065,INT_X38Y220,SDND.*",
-            "xcvu065,CLE_M_X38Y220,CLE_CLE_M_SITE_0_[A-H](_O|Q|Q2|MUX)",
+            "xcvu065,INT_X38Y220,BOUNCE_.*,true",
+            "xcvu065,INT_X38Y220,BYPASS_.*,true",
+            "xcvu065,INT_X38Y220,INT_NODE_GLOBAL_.*,true",
+            "xcvu065,INT_X38Y220,INT_NODE_IMUX_.*,true",
+            "xcvu065,INT_X38Y220,INODE_.*,true",
+            "xcvu065,INT_X38Y220,INT_INT_SINGLE_.*,false", // IntentCode.NODE_SINGLE
+            "xcvu065,INT_X38Y220,INT_NODE_SINGLE_DOUBLE_.*,false",
+            "xcvu065,INT_X38Y220,INT_NODE_QUAD_LONG_.*,false",
+            "xcvu065,INT_X38Y220,IMUX_.*,true",
+            "xcvu065,INT_X38Y220,CTRL_.*,true",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)1_.*,false",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)2_.*,false",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)4_.*,false",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)5_.*,false",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)12_.*,false",
+            "xcvu065,INT_X37Y220,(NN|EE|SS|WW)16_.*,false",
+            "xcvu065,INT_X38Y220,QLND.*,false",
+            "xcvu065,INT_X38Y220,SDND.*,false",
+            "xcvu065,CLE_M_X38Y220,CLE_CLE_M_SITE_0_[A-H](_O|Q|Q2|MUX),false",
     })
-    public void testNodeReachabilityUltraScale(String partName, String tileName, String wireRegex) {
+    public void testNodeReachabilityUltraScale(String partName, String tileName, String wireRegex, boolean local) {
         Device device = Device.getDevice(partName);
         Tile baseTile = device.getTile(tileName);
         Queue<Node> queue = new ArrayDeque<>();
@@ -170,6 +170,7 @@ public class TestNode {
                 .forEachOrdered(s -> System.out.println("\t" + s));
 
         Set<Node> visited = new HashSet<>();
+        boolean exitsBaseTile = false;
         while (!queue.isEmpty()) {
             Node node = queue.poll();
             String wireName = node.getWireName();
@@ -178,7 +179,8 @@ public class TestNode {
                 EnumSet.of(IntentCode.NODE_SINGLE, IntentCode.NODE_DOUBLE, IntentCode.NODE_HQUAD, IntentCode.NODE_VQUAD, IntentCode.NODE_HLONG, IntentCode.NODE_VLONG)
                         .contains(node.getIntentCode()))
             ) {
-                // Do not desccend into SDQNODEs or SDQLs
+                // Do not descend into SDQNODEs or SDQLs
+                exitsBaseTile = true;
                 continue;
             }
             for (Node downhill : node.getAllDownhillNodes()) {
@@ -195,38 +197,41 @@ public class TestNode {
             }
         }
         System.out.println("visited.size() = " + visited.size());
+
+        // Local nodes should never exit the tile
+        Assertions.assertNotEquals(local, exitsBaseTile);
     }
 
     @ParameterizedTest
     @CsvSource({
-            "xcvp1002,INT_X38Y220,NODE_PINBOUNCE",
-            "xcvp1002,INT_X38Y220,NODE_INODE",
-            "xcvp1002,INT_X38Y220,NODE_IMUX",
-            "xcvp1002,INT_X38Y220,NODE_SDQNODE",
-            "xcvp1002,INT_X38Y220,NODE_HSINGLE",
-            "xcvp1002,INT_X38Y220,NODE_VSINGLE",
-            "xcvp1002,INT_X38Y220,NODE_HDOUBLE",
-            "xcvp1002,INT_X38Y220,NODE_VDOUBLE",
-            "xcvp1002,INT_X38Y220,NODE_HQUAD",
-            "xcvp1002,INT_X38Y220,NODE_VQUAD",
-            "xcvp1002,INT_X38Y220,NODE_HLONG6",
-            "xcvp1002,INT_X38Y220,NODE_HLONG10",
-            "xcvp1002,INT_X38Y220,NODE_VLONG7",
-            "xcvp1002,INT_X38Y220,NODE_VLONG12",
-            "xcvp1002,CLE_BC_CORE_X37Y220,NODE_CLE_BNODE",
-            "xcvp1002,CLE_BC_CORE_X37Y220,NODE_CLE_CNODE",
-            "xcvp1002,CLE_BC_CORE_X37Y220,NODE_CLE_CTRL",
-            "xcvp1002,CLE_W_CORE_X38Y220,NODE_PINFEED",
-            "xcvp1002,CLE_E_CORE_X38Y220,NODE_CLE_OUTPUT",
-            "xcvp1002,CLE_W_CORE_X38Y220,NODE_CLE_OUTPUT",
+            "xcvp1002,INT_X38Y220,NODE_PINBOUNCE,true",
+            "xcvp1002,INT_X38Y220,NODE_INODE,true",
+            "xcvp1002,INT_X38Y220,NODE_IMUX,true",
+            "xcvp1002,INT_X38Y220,NODE_SDQNODE,false",
+            "xcvp1002,INT_X38Y220,NODE_HSINGLE,false",
+            "xcvp1002,INT_X38Y220,NODE_VSINGLE,false",
+            "xcvp1002,INT_X38Y220,NODE_HDOUBLE,false",
+            "xcvp1002,INT_X38Y220,NODE_VDOUBLE,false",
+            "xcvp1002,INT_X38Y220,NODE_HQUAD,false",
+            "xcvp1002,INT_X38Y220,NODE_VQUAD,false",
+            "xcvp1002,INT_X38Y220,NODE_HLONG6,false",
+            "xcvp1002,INT_X38Y220,NODE_HLONG10,false",
+            "xcvp1002,INT_X38Y220,NODE_VLONG7,false",
+            "xcvp1002,INT_X38Y220,NODE_VLONG12,false",
+            "xcvp1002,CLE_BC_CORE_X37Y220,NODE_CLE_BNODE,true",
+            "xcvp1002,CLE_BC_CORE_X37Y220,NODE_CLE_CNODE,true",
+            "xcvp1002,CLE_BC_CORE_X37Y220,NODE_CLE_CTRL,true",
+            "xcvp1002,CLE_W_CORE_X38Y220,NODE_PINFEED,true",
+            "xcvp1002,CLE_E_CORE_X38Y220,NODE_CLE_OUTPUT,false",
+            "xcvp1002,CLE_W_CORE_X38Y220,NODE_CLE_OUTPUT,false",
     })
-    public void testNodeReachabilityVersal(String partName, String tileName, String intentCodeName) {
+    public void testNodeReachabilityVersal(String partName, String tileName, String intentCodeName, boolean local) {
         Device device = Device.getDevice(partName);
         Tile baseTile = device.getTile(tileName);
+        IntentCode baseIntentCode = IntentCode.valueOf(intentCodeName);
         Queue<Node> queue = new ArrayDeque<>();
-        IntentCode ic = IntentCode.valueOf(intentCodeName);
         for (int wireIdx = 0; wireIdx < baseTile.getWireCount(); wireIdx++) {
-            if (baseTile.getWireIntentCode(wireIdx) != ic) {
+            if (baseTile.getWireIntentCode(wireIdx) != baseIntentCode) {
                 continue;
             }
             queue.add(Node.getNode(baseTile, wireIdx));
@@ -250,6 +255,7 @@ public class TestNode {
 
         TileTypeEnum baseTileTypeEnum = baseTile.getTileTypeEnum();
         Set<Node> visited = new HashSet<>();
+        boolean exitsBaseTile = false;
         while (!queue.isEmpty()) {
             Node node = queue.poll();
             if (EnumSet.of(IntentCode.NODE_SDQNODE, IntentCode.NODE_HSINGLE, IntentCode.NODE_VSINGLE,
@@ -257,7 +263,8 @@ public class TestNode {
                             IntentCode.NODE_HQUAD, IntentCode.NODE_VQUAD,
                             IntentCode.NODE_HLONG10, IntentCode.NODE_HLONG6,
                             IntentCode.NODE_VLONG12, IntentCode.NODE_VLONG7).contains(node.getIntentCode())) {
-                // Do not desccend into SDQNODEs or any SDQLs
+                // Do not descend into SDQNODEs or any SDQLs
+                exitsBaseTile = true;
                 continue;
             }
             for (Node downhill : node.getAllDownhillNodes()) {
@@ -280,11 +287,9 @@ public class TestNode {
                             Assertions.assertTrue(1 >= Math.abs(baseTile.getTileYCoordinate() - downhill.getTile().getTileYCoordinate()));
                         }
                     }
-                    // Do not descend further
-                    continue;
                 }
                 // All INT-to-INT connections should be to the same tile
-                if (baseTileTypeEnum == TileTypeEnum.CLE_BC_CORE) {
+                else if (baseTileTypeEnum == TileTypeEnum.CLE_BC_CORE) {
                     // Except CLE_BC_CORE tiles which spans two adjacent INT tiles
                     if (baseTile != downhill.getTile()) {
                         Assertions.assertTrue(1 >= Math.abs(baseTile.getTileXCoordinate() - downhill.getTile().getTileXCoordinate()));
@@ -297,6 +302,9 @@ public class TestNode {
             }
         }
         System.out.println("visited.size() = " + visited.size());
+
+        // Local nodes should never exit the tile
+        Assertions.assertNotEquals(local, exitsBaseTile);
     }
 
     @ParameterizedTest

--- a/test/src/com/xilinx/rapidwright/device/TestNode.java
+++ b/test/src/com/xilinx/rapidwright/device/TestNode.java
@@ -188,6 +188,7 @@ public class TestNode {
                 if (!Utils.isInterConnect(downhill.getTile().getTileTypeEnum())) {
                     continue;
                 }
+                // Check that they are all in the same column
                 Assertions.assertEquals(baseTile.getTileXCoordinate(),
                         downhill.getTile().getTileXCoordinate());
                 queue.add(downhill);


### PR DESCRIPTION
* `RouteNodeType.NON_LOCAL` are the single, double, quad, long wires that travel between INT tiles, along with the uphill muxes (e.g. `INT_NODE_SDQ_*`) that feed them.
* `RouteNodeType.LOCAL` is everything else (e.g. `INT_NODE_IMUX_*`) that is used to connect `NON_LOCAL` to sinks.

This PR optimizes the rather messy https://github.com/Xilinx/RapidWright/pull/893 that kept a set of wire indices that were allowed to be used. Now, `RouteNode.type` indicates whether a node is local or non-local, with the idea that you should only leave your non-local node onto a local one if you are in the vicinity of the sink, since once you are a local node you cannot use a non-local node again (unless LUT routethrus are considered).

Furthermore:
* `RouteNodeType.PINFEED_O` is now `EXCLUSIVE_SOURCE`
* `RouteNodeType.PINFEED_I` is now `EXCLUSIVE_SINK`
* `RouteNodeType.PINBOUNCE` has been merged into `LOCAL`
* `RouteNodeType.LAGUNA_I` is now `LAGUNA_PINFEED`
* `RouteNodeType.WIRE` is split into `LOCAL` and `NON_LOCAL`

Also expand the node reachability tests for US, US+, and Versal.