### PR TITLE
Tile.getWireConnections() not consistent with Vivado

### DIFF
--- a/test/src/com/xilinx/rapidwright/device/TestTile.java
+++ b/test/src/com/xilinx/rapidwright/device/TestTile.java
@@ -49,7 +49,11 @@ public class TestTile {
 
     @ParameterizedTest
     @CsvSource({
+            // get_nodes -downhill -of [get_nodes -of [get_wires CLK_REBUF_VERT_VNOC_BAO_TILE_X30Y471/IF_WRAP_CLK_V_BOT_CLK_VDISTR21]]
             "xcvp1002,CLK_REBUF_VERT_VNOC_BAO_TILE_X30Y471,IF_WRAP_CLK_V_BOT_CLK_VDISTR21,[]",
+            // get_nodes -downhill -of [get_nodes -of [get_wires CLK_REBUF_VERT_VNOC_ACO_TILE_X30Y279/IF_WRAP_CLK_V_BOT_CLK_VDISTR21]]
+            "xcvp1002,CLK_REBUF_VERT_VNOC_ACO_TILE_X30Y279,IF_WRAP_CLK_V_BOT_CLK_VDISTR21," +
+                    "'[RCLK_BRAM_CLKBUF_CORE_X24Y239/IF_HCLK_R_CLK_HDISTR21, CLK_VNOC_AAO_TILE_X30Y239/CLKE2_PD_OPT_DELAY_SSIT_142_I]'",
     })
     public void testGetWireConnections(String partName, String tileName, String wireName, String wireConnections) {
         Device dev = Device.getDevice(partName);

--- a/test/src/com/xilinx/rapidwright/device/TestTile.java
+++ b/test/src/com/xilinx/rapidwright/device/TestTile.java
@@ -35,7 +35,7 @@ public class TestTile {
             "xcku025,true",
             "xcku035,false"
     })
-    public void testGetWireConnections(String partName, boolean expectThrow) {
+    public void testGetWireConnectionsThrows(String partName, boolean expectThrow) {
         Device dev = Device.getDevice(partName);
         Tile tile = dev.getTile("RCLK_CLE_M_L_X31Y149");
         Executable e = () -> tile.getWireConnections(8);
@@ -45,6 +45,16 @@ public class TestTile {
         } else {
             Assertions.assertDoesNotThrow(e);
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "xcvp1002,CLK_REBUF_VERT_VNOC_BAO_TILE_X30Y471,IF_WRAP_CLK_V_BOT_CLK_VDISTR21,[]",
+    })
+    public void testGetWireConnections(String partName, String tileName, String wireName, String wireConnections) {
+        Device dev = Device.getDevice(partName);
+        Tile tile = dev.getTile(tileName);
+        Assertions.assertEquals(wireConnections, tile.getWireConnections(wireName).toString());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Javadoc for `Tile.getWireConnections()` states that it should be equivalent to:
```
get_nodes -downhill -of_objects [get_nodes -of [get_wires -of $tile/$wireName]]]
```

Applying it in the following way on a `xcvp1002` in Vivado:
```
get_nodes -downhill -of [get_nodes -of [get_wires CLK_REBUF_VERT_VNOC_BAO_TILE_X30Y471/IF_WRAP_CLK_V_BOT_CLK_VDISTR21]]
WARNING: [Vivado 12-2683] No nodes matched 'get_nodes -downhill -of [get_nodes -of [get_wires CLK_REBUF_VERT_VNOC_BAO_TILE_X30Y471/IF_WRAP_CLK_V_BOT_CLK_VDISTR21]]'
```
returns nothing.

But this test demonstrates that RapidWright returns:
```
Expected :[]
Actual   :[CLK_REBUF_VERT_VNOC_CBO_TILE_X30Y375/IF_WRAP_CLK_V_TOP_CLK_VDISTR21, INVALID1_X30Y431/null]
```

1. `CLK_REBUF_VERT_VNOC_CBO_TILE_X30Y375/IF_WRAP_CLK_V_TOP_CLK_VDISTR21` seems to be a wire on the original input node:
  ```
  get_nodes -of [get_wires CLK_REBUF_VERT_VNOC_CBO_TILE_X30Y375/IF_WRAP_CLK_V_TOP_CLK_VDISTR21]
  CLK_REBUF_VERT_VNOC_BAO_TILE_X30Y471/IF_WRAP_CLK_V_BOT_CLK_VDISTR21
  ```
2. Obviously returning `INVALID1_X30Y431/null` is not desirable.