### PR TITLE
[Utils] isClocking() to include TileTypeEnum.CMT_L

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -180,9 +180,13 @@ public class RouterHelper {
      */
     public static Node projectInputPinToINTNode(SitePinInst input) {
         Node sink = input.getConnectedNode();
-        if (sink.getTile().getTileTypeEnum() == TileTypeEnum.INT) {
+        TileTypeEnum sinkTileType = sink.getTile().getTileTypeEnum();
+        if (sinkTileType == TileTypeEnum.INT) {
             return sink;
         }
+        // Only block clocking tiles if source is not in a clock tile
+        final boolean blockClocking = !Utils.isClocking(sinkTileType);
+
         int watchdog = 40;
 
         // Starting from the SPI's connected node, perform an uphill breadth-first search
@@ -198,7 +202,7 @@ public class RouterHelper {
                         EnumSet.of(IntentCode.NODE_CLE_CTRL, IntentCode.NODE_INTF_CTRL).contains(uphill.getIntentCode())) {
                     return uphill;
                 }
-                if (Utils.isClocking(uphillTileType)) {
+                if (uphillTileType != sinkTileType && Utils.isClocking(uphillTileType)) {
                     continue;
                 }
                 queue.add(uphill);

--- a/src/com/xilinx/rapidwright/util/Utils.java
+++ b/src/com/xilinx/rapidwright/util/Utils.java
@@ -350,6 +350,7 @@ public class Utils{
 
         clocking = EnumSet.of(
                 TileTypeEnum.RCLK_CLEM_CLKBUF_L,
+                TileTypeEnum.CMT_L,
                 // Versal
                 TileTypeEnum.CLK_REBUF_BUFGS_HSR_CORE,
                 TileTypeEnum.CLK_PLL_AND_PHY,

--- a/src/com/xilinx/rapidwright/util/Utils.java
+++ b/src/com/xilinx/rapidwright/util/Utils.java
@@ -1,7 +1,7 @@
 /*
  * Original work: Copyright (c) 2010-2011 Brigham Young University
  * Modified work: Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022-2023, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
@@ -59,6 +59,7 @@ public class TestRouterHelper {
             "xcvu3p,SLICE_X0Y0,A_O,CLEL_R_X0Y0/CLE_CLE_L_SITE_0_A_O",
             "xcvu3p,GTYE4_CHANNEL_X0Y12,TXOUTCLK_INT,null",
             "xcvu3p,IOB_X1Y95,I,INT_INTF_L_IO_X72Y109/LOGIC_OUTS_R23",
+            "xcvu3p,IOB_X1Y80,I,INT_INTF_L_IO_X72Y92/LOGIC_OUTS_R22",
             "xcvu3p,MMCM_X0Y0,LOCKED,INT_INTF_L_IO_X36Y54/LOGIC_OUTS_R0",
             "xcvp1002,MMCM_X2Y0,LOCKED,BLI_CLE_BOT_CORE_X27Y0/LOGIC_OUTS_D23"
     })

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
@@ -73,6 +73,7 @@ public class TestRouterHelper {
     @ParameterizedTest
     @CsvSource({
             "xcvu3p,MMCM_X0Y0,PSEN,INT_X36Y56/IMUX_W0",
+            "xcvu3p,BUFGCE_X0Y58,CLK_IN,INT_X36Y151/IMUX_W34",
             "xcvp1002,MMCM_X2Y0,PSEN,INT_X27Y0/IMUX_B_W24"
     })
     public void testProjectInputPinToINTNode(String partName, String siteName, String pinName, String nodeAsString) {


### PR DESCRIPTION
Without which `RouterHelper.projectOutputPinToINTNode()` will have its watchdog expire and cause a routing failure for the `boom_med_pb` benchmark from the [FPGA24 Routing Contest](https://github.com/Xilinx/fpga24_routing_contest)

Also `RouterHelper.projectInputPinToINTNode()` failed too which required a bit more fixing.