### PR TITLE
Changes to support new array-based cell pin mappings

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -289,7 +289,7 @@ public class DesignTools {
                     Net net = inst.getNetFromSiteWire(siteWireName);
                     if (net == null) continue;
                     if (net.isStaticNet()) continue;
-                    if (!cell.getPinMappingsP2L().containsKey(pin.getName())) continue;
+                    if (!cell.getUsedPhysicalPins().contains(pin.getName())) continue;
                     inputs.add(pin);
                 }
                 break;
@@ -325,7 +325,8 @@ public class DesignTools {
             if (net == null) continue;
             if (net.isStaticNet()) continue;
             if (net.getName().equals(Net.USED_NET)) continue;
-            if (!cell.getPinMappingsP2L().containsKey(pin.getName())) continue;
+            if (!cell.getUsedPhysicalPins().contains(pin.getName()))
+                continue;
             outputs.add(pin);
         }
 
@@ -445,7 +446,7 @@ public class DesignTools {
         long oldVal = new BigInteger(hexValueStr, 16).longValue();
         int numLutRows = Integer.parseInt(numLutRowsStr);
         int numInput = (int)(Math.log(numLutRows)/Math.log(2));
-        String logicalPinName = lut.getPinMappingsP2L().get(physicalPinName);
+        String logicalPinName = lut.getLogicalPinMapping(physicalPinName);
         int invertCol = getInvertCol(logicalPinName.substring(logicalPinName.length()-1));
         if (invertCol == -1) {
             System.err.println("Inverted Column is -1 is Function DesignTools.invertLutInput");
@@ -1563,12 +1564,11 @@ public class DesignTools {
                             if (otherCell.isRoutethru()) {
                                 BELPin otherPin = null;
                                 if (pin.isOutput()) {
-                                    assert(otherCell.getPinMappingsP2L().size() == 1);
-                                    String otherPinName = otherCell.getPinMappingsP2L().keySet().iterator().next();
-                                    otherPin = pin.getBEL().getPin(otherPinName);
+                                    assert (otherCell.getPhysicalPinMappingCount() == 1);
+                                    otherPin = otherCell.getFirstPhysicalPinMapping().getFirst();
                                 } else {
                                     // Make sure we are coming in on the routed-thru pin
-                                    String otherPinName = otherCell.getPinMappingsP2L().keySet().iterator().next();
+                                    String otherPinName = otherCell.getFirstPhysicalPinMapping().getFirst().getName();
                                     if (pin.getName().equals(otherPinName)) {
                                         otherPin = LUTTools.getLUTOutputPin(pin.getBEL());
                                     }
@@ -1777,7 +1777,8 @@ public class DesignTools {
             }
 
             // Remove all physical nets first
-            for (String logPin : c.getPinMappingsP2L().values()) {
+            for (String logPin : c.getPhysicalPinMappings()) {
+                if (logPin == null) continue;
                 List<SitePinInst> removePins = unrouteCellPinSiteRouting(c, logPin);
                 for (SitePinInst pin : removePins) {
                     pinsToRemove.computeIfAbsent(pin.getNet(), $ -> new HashSet<>()).add(pin);
@@ -1971,7 +1972,7 @@ public class DesignTools {
                     }
 
                     Cell newCell = c.copyCell(newCellName, cellInst);
-                    design.placeCell(newCell, newSiteInst.getSite(), c.getBEL(), c.getPinMappingsP2L());
+                    design.placeCell(newCell, newSiteInst.getSite(), c.getBEL(), c.getPhysicalPinMappings());
                 }
 
                 for (SitePIP sitePIP : si.getUsedSitePIPs()) {
@@ -2299,8 +2300,8 @@ public class DesignTools {
                             bel.getName().endsWith("_IMR")) {
                         Cell possibleRouteThru = inst.getCell(bel);
                         if (possibleRouteThru != null && possibleRouteThru.isRoutethru()) {
-                            String routeThru = possibleRouteThru.getPinMappingsP2L().keySet().iterator().next();
-                            queue.add(bel.getPin(routeThru));
+                            BELPin routeThru = possibleRouteThru.getFirstPhysicalPinMapping().getFirst();
+                            queue.add(routeThru);
                         }
                     }
                 }
@@ -2977,14 +2978,19 @@ public class DesignTools {
         }
 
         EDIFHierCellInst cellInst = destNetlist.getHierCellInstFromName(copy.getName());
-        for (Entry<String,String> e : copy.getPinMappingsP2L().entrySet()) {
-            EDIFPortInst portInst = cellInst.getInst().getPortInst(e.getValue());
+        String[] physPinNames = copy.getPhysicalPinMappings();
+        for (int i = 0; i < physPinNames.length; i++) {
+            String logPinName = physPinNames[i];
+            if (logPinName == null) continue;
+            String physPinName = copy.getBEL().getPin(i).getName();
+
+            EDIFPortInst portInst = cellInst.getInst().getPortInst(logPinName);
             if (portInst == null) continue;
             EDIFNet edifNet = portInst.getNet();
 
             String netName = new EDIFHierNet(cellInst.getParent(), edifNet).getHierarchicalNetName();
 
-            String siteWireName = orig.getSiteWireNameFromPhysicalPin(e.getKey());
+            String siteWireName = orig.getSiteWireNameFromPhysicalPin(physPinName);
             Net origNet = origSiteInst.getNetFromSiteWire(siteWireName);
             if (origNet == null) continue;
             Net net = null;
@@ -3001,7 +3007,7 @@ public class DesignTools {
                 }
             }
 
-            BELPin curr = copy.getBEL().getPin(e.getKey());
+            BELPin curr = copy.getBEL().getPin(physPinName);
             dstSiteInst.routeIntraSiteNet(net, curr, curr);
             boolean routingForward = curr.isOutput();
             Queue<BELPin> q = new LinkedList<BELPin>();
@@ -3040,7 +3046,7 @@ public class DesignTools {
                             Cell rtCopy = tmpCell
                                     .copyCell(newCellName, tmpCell.getEDIFHierCellInst(), dstSiteInst);
                             dstSiteInst.getCellMap().put(belName, rtCopy);
-                            for (String belPinName : rtCopy.getPinMappingsP2L().keySet()) {
+                            for (String belPinName : rtCopy.getUsedPhysicalPins()) {
                                 BELPin tmp = rtCopy.getBEL().getPin(belPinName);
                                 if (tmp.isInput()) {
                                     curr = tmp;

--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -390,9 +390,9 @@ public class LUTTools {
      */
     public static String getLUTEquation(Cell c) {
         if (c.isRoutethru()) {
-            Set<Entry<String, String>> entrySet = c.getPinMappingsP2L().entrySet();
-            assert (entrySet.size() == 1);
-            return "O" + c.getBELName().charAt(1) + "=" + entrySet.iterator().next().getKey();
+            BELPin rtEntry = c.getFirstPhysicalPinMapping().getFirst();
+            assert (c.getPhysicalPinMappingCount() == 1);
+            return "O" + c.getBELName().charAt(1) + "=" + rtEntry.getName();
         }
         return getLUTEquation(c.getEDIFCellInst());
     }

--- a/src/com/xilinx/rapidwright/tests/PinMapTester.java
+++ b/src/com/xilinx/rapidwright/tests/PinMapTester.java
@@ -26,29 +26,25 @@
 package com.xilinx.rapidwright.tests;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
+import com.xilinx.rapidwright.design.Cell;
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.design.Unisim;
+import com.xilinx.rapidwright.design.VivadoProp;
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Part;
 import com.xilinx.rapidwright.device.PartNameTools;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.SiteTypeEnum;
-
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFDesign;
-import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFLibrary;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
-
-import com.xilinx.rapidwright.design.Design;
-import com.xilinx.rapidwright.design.Cell;
-import com.xilinx.rapidwright.design.Unisim;
-import com.xilinx.rapidwright.design.SiteInst;
-import com.xilinx.rapidwright.design.VivadoProp;
 
 public class PinMapTester {
 
@@ -127,13 +123,14 @@ public class PinMapTester {
 
         System.out.printf("Cell type %s at %s/%s in part %s, pin map:\n",
                 cellTypeName, site.getName(), belName, partName);
-        for (Map.Entry<String, String> pinMap : physCell.getPinMappingsP2L().entrySet()) {
-            System.out.printf(" - %s <= %s\n", pinMap.getKey(), pinMap.getValue());
+        String[] physPinNames = physCell.getPhysicalPinMappings();
+        for (int i = 0; i < physPinNames.length; i++) {
+            String logPinName = physPinNames[i];
+            if (logPinName == null)
+                continue;
+            String physPinName = physCell.getBEL().getPin(i).getName();
+            System.out.printf(" - %s <= %s\n", physPinName, logPinName);
         }
-
-        //for (Map.Entry<String, Set<String>> pinMap : physCell.getPinMappingsL2P().entrySet()) {
-        //    System.out.printf("
-        //}
     }
 }
 

--- a/src/com/xilinx/rapidwright/timing/TimingGraph.java
+++ b/src/com/xilinx/rapidwright/timing/TimingGraph.java
@@ -1573,7 +1573,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                     physPinName = cell.getPhysicalPinMapping(portName);
                 } else {
                     BEL lut = cell.getBEL();
-                    for (String pin : cell.getPinMappingsP2L().keySet()) {
+                    for (String pin : cell.getUsedPhysicalPins()) {
                         BELPin belPin = lut.getPin(pin);
                         if (belPin.isInput()) {
                             physPinName = belPin.getConnectedSitePinName();

--- a/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDCPSave.java
@@ -24,22 +24,20 @@ package com.xilinx.rapidwright.design;
 
 import java.nio.file.Path;
 
-import com.xilinx.rapidwright.edif.EDIFNetlist;
-import com.xilinx.rapidwright.edif.EDIFTools;
-import com.xilinx.rapidwright.support.RapidWrightDCP;
-import com.xilinx.rapidwright.util.VivadoTools;
-import com.xilinx.rapidwright.util.VivadoToolsHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.SiteTypeEnum;
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFLibrary;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 
 public class TestDCPSave {
 
@@ -72,15 +70,15 @@ public class TestDCPSave {
         c1.addPinMapping("A3", "I2");
         c1.addPinMapping("A4", "I3");
         c1.addPinMapping("A5", "I4");
-        c1.addPinMapping("O6", "O");
-        c1.addPinMapping("GE", "GE");
+        c1.addPinMapping("O5", "O");
 
+        c2.addPinMapping("GE", "GE");
         c2.addPinMapping("A1", "I0");
         c2.addPinMapping("A2", "I1");
         c2.addPinMapping("A3", "I2");
         c2.addPinMapping("A4", "I3");
         c2.addPinMapping("A5", "I4");
-        c2.addPinMapping("O5", "O");
+        c2.addPinMapping("O6", "O");
 
         if (detachNetlist) {
             EDIFTools.writeEDIFFile(tempDir.resolve("tmp.edf"), n, d.getPartName());

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -35,8 +35,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.xilinx.rapidwright.device.BEL;
-import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,6 +43,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.xilinx.rapidwright.design.blocks.PBlock;
 import com.xilinx.rapidwright.design.blocks.UtilizationType;
+import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.PIP;
@@ -53,6 +52,7 @@ import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFDirection;
 import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFPort;
@@ -1201,7 +1201,7 @@ public class TestDesignTools {
 
             for(Cell c : cells) {
                 DesignTools.placeCell(c, d);
-                Assertions.assertFalse(c.getPinMappingsP2L().isEmpty());
+                Assertions.assertFalse(c.getUsedPhysicalPins().isEmpty());
                 Assertions.assertNotNull(c.getBEL());
                 Assertions.assertNotNull(c.getSiteInst());
             }

--- a/test/src/com/xilinx/rapidwright/design/tools/TestLUTTools.java
+++ b/test/src/com/xilinx/rapidwright/design/tools/TestLUTTools.java
@@ -28,31 +28,31 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
 import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
 import com.xilinx.rapidwright.design.Unisim;
-import com.xilinx.rapidwright.device.Node;
-import com.xilinx.rapidwright.device.PIP;
-import com.xilinx.rapidwright.rwroute.RWRoute;
-import com.xilinx.rapidwright.rwroute.TestRWRoute;
-import com.xilinx.rapidwright.support.LargeTest;
-import com.xilinx.rapidwright.support.RapidWrightDCP;
-import com.xilinx.rapidwright.util.VivadoToolsHelper;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Node;
+import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.Part;
 import com.xilinx.rapidwright.device.PartNameTools;
 import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.SiteTypeEnum;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import com.xilinx.rapidwright.rwroute.RWRoute;
+import com.xilinx.rapidwright.rwroute.TestRWRoute;
+import com.xilinx.rapidwright.support.LargeTest;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+import com.xilinx.rapidwright.util.VivadoToolsHelper;
 
 public class TestLUTTools {
 
@@ -90,9 +90,14 @@ public class TestLUTTools {
         SiteInst si = design.createSiteInst("SLICE_X0Y0");
         // Create and place on both A6LUT and A5LUT
         Cell cell6 = design.createAndPlaceCell("lut6", Unisim.LUT2, "SLICE_X0Y0/A6LUT");
-        cell6.getPinMappingsP2L().clear(); // Clear default pin mappings
+        // Clear default pin mappings
+        for (String physPin : cell6.getUsedPhysicalPins()) {
+            cell6.removePinMapping(physPin);
+        }
         Cell cell5 = design.createAndPlaceCell("lut5", Unisim.LUT2, "SLICE_X0Y0/A5LUT");
-        cell5.getPinMappingsP2L().clear();
+        for (String physPin : cell5.getUsedPhysicalPins()) {
+            cell5.removePinMapping(physPin);
+        }
 
         // Net with a single sink pin used by both LUTs that needs swapping
         Net netNeedsPinSwap = design.createNet("netNeedsPinSwap");


### PR DESCRIPTION
Instead of using a `HashMap<String,String>` to store cell-based physical to logical pin mappings, a new scheme using a `String[]` where the length of the array is the number of `BELPin`s on the `BEL` upon the cell is placed.  Therefore, the physical pin name is not explicitly stored and only the logical pin name is in the array.  