### PR TITLE
[RWRoute] Preserve nodes of Laguna sinks

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -605,8 +605,6 @@ public class GlobalSignalRouting {
             currNet.addPin(spi, updateSiteRouting);
             spi.setRouted(true);
         }
-
-        currNet.setPIPs(netPIPs);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -405,7 +405,6 @@ public class GlobalSignalRouting {
         nodesToRoute.sort(Comparator.comparing((n) -> n.getTile().getUniqueAddress()));
 
         NetType netType = currNet.getType();
-        Set<PIP> netPIPs = new HashSet<>(currNet.getPIPs());
         for (Node node : nodesToRoute) {
             int watchdog = 10000;
             SitePinInst sink = nodeToRouteToSink.get(node);
@@ -566,8 +565,7 @@ public class GlobalSignalRouting {
                     // Note that the static net router goes backward from sinks to sources,
                     // requiring the srcToSinkOrder parameter to be set to true below
                     for (PIP pip : RouterHelper.getPIPsFromNodes(pathNodes, true)) {
-                        boolean added = netPIPs.add(pip);
-                        assert(added);
+                        currNet.addPIP(pip);
                     }
 
                     pathNodes.clear();

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -388,7 +388,8 @@ public class GlobalSignalRouting {
             } else {
                 assert(currNet == sink.getNet());
             }
-            if (sink.isRouted() || sink.isOutPin()) {
+            assert(!sink.isOutPin());
+            if (sink.isRouted()) {
                 continue;
             }
 

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -393,7 +393,7 @@ public class GlobalSignalRouting {
             }
 
             Node node = sink.getConnectedNode();
-            if (getNodeState.apply(node) == NodeStatus.UNAVAILABLE) {
+            if (getNodeState.apply(node) != NodeStatus.INUSE) {
                 throw new RuntimeException("ERROR: Site pin " + sink + " is not available for net " + currNet);
             }
             nodeToRouteToSink.put(node, sink);
@@ -531,18 +531,6 @@ public class GlobalSignalRouting {
                                 node = uphillNode;
                                 break search;
                             }
-
-                            // uphillNode must be a sink to be routed; preserve only the current routing, clear the queue,
-                            // and restart routing from this new sink to encourage reuse
-                            assert(!uphillSink.isRouted());
-                            do {
-                                usedRoutingNodes.add(node);
-                                node = prevNode.get(node);
-                            } while (node != INVALID_NODE);
-                            prevNode.keySet().removeIf((n) -> !usedRoutingNodes.contains(n) && !n.equals(uphillNode));
-                            q.clear();
-                            q.add(uphillNode);
-                            continue search;
                         }
 
                         q.add(uphillNode);

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -332,7 +332,7 @@ public class GlobalSignalRouting {
 
     /**
      * Routes a static net (GND or VCC).
-     * @param currNet The current static net to be routed.
+     * @param pins A list of static pins to be routed.
      * @param getNodeState Lambda to get a node's status (available, unavailable, already in-use).
      * @param design The {@link Design} instance to use.
      * @param routeThruHelper The {@link RouteThruHelper} instance to use.

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -331,8 +331,8 @@ public class GlobalSignalRouting {
     }
 
     /**
-     * Routes a static net (GND or VCC).
-     * @param pins A list of static pins to be routed.
+     * Routes pins from a static net (GND or VCC).
+     * @param pins A list of static pins to be routed (must all be on the same net).
      * @param getNodeState Lambda to get a node's status (available, unavailable, already in-use).
      * @param design The {@link Design} instance to use.
      * @param routeThruHelper The {@link RouteThruHelper} instance to use.

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -344,7 +344,7 @@ public class GlobalSignalRouting {
         Set<Node> usedRoutingNodes = new HashSet<>();
         Map<Node, Node> prevNode = new HashMap<>();
         List<Node> pathNodes = new ArrayList<>();
-        Set<SitePin> sitePinsToCreate = new HashSet<>();
+        List<SitePin> sitePinsToCreate = new ArrayList<>();
         final Node INVALID_NODE = new Node(null, Integer.MAX_VALUE);
         assert(INVALID_NODE.isInvalidNode());
 
@@ -577,6 +577,7 @@ public class GlobalSignalRouting {
             }
         }
 
+        assert(sitePinsToCreate.stream().distinct().count() == sitePinsToCreate.size());
         for (SitePin sitePin : sitePinsToCreate) {
             Site site = sitePin.getSite();
             SiteInst si = design.getSiteInstFromSite(site);

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -317,7 +317,7 @@ public class PartialRouter extends RWRoute {
         }
         List<SitePinInst> pinsToPreserve;
         if (pinsToRoute == null) {
-            pinsToPreserve = net.getSinkPins();
+            pinsToPreserve = net.getPins();
         } else {
             pinsToPreserve = new ArrayList<>();
             Set<SitePinInst> pinsToRouteSet = new HashSet<>(pinsToRoute);

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -290,7 +290,6 @@ public class PartialRouter extends RWRoute {
 
     @Override
     protected void addStaticNetRoutingTargets(Net staticNet) {
-        preserveNet(staticNet, true);
         if (staticNet.hasPIPs()) {
             numPreservedStaticNets++;
         }

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -311,7 +311,8 @@ public class PartialRouter extends RWRoute {
     protected void preserveNet(Net net, boolean async) {
         List<SitePinInst> pinsToRoute = null;
         if (!net.isStaticNet()) {
-            // Only preserve those pins that are not to be routed
+            // For signal nets, only preserve those pins that are not to be routed
+            // All sink pins must be preserved for static nets since the static router does not resolve conflicts
             pinsToRoute = netToPins.get(net);
         }
         List<SitePinInst> pinsToPreserve;

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -291,6 +291,16 @@ public class PartialRouter extends RWRoute {
     @Override
     protected void addStaticNetRoutingTargets(Net staticNet) {
         if (staticNet.hasPIPs()) {
+            // Preserve only the static net's PIPs and its output pins; its input pins will be
+            // preserved by routeStaticNets()
+            List<SitePinInst> outputPins = new ArrayList<>();
+            for (SitePinInst spi : staticNet.getPins()) {
+                if (!spi.isOutPin()) {
+                    continue;
+                }
+                outputPins.add(spi);
+            }
+            routingGraph.preserveAsync(staticNet, outputPins);
             numPreservedStaticNets++;
         }
 

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -317,7 +317,7 @@ public class PartialRouter extends RWRoute {
         }
         List<SitePinInst> pinsToPreserve;
         if (pinsToRoute == null) {
-            pinsToPreserve = net.getPins();
+            pinsToPreserve = net.getSinkPins();
         } else {
             pinsToPreserve = new ArrayList<>();
             Set<SitePinInst> pinsToRouteSet = new HashSet<>(pinsToRoute);

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -310,8 +310,11 @@ public class PartialRouter extends RWRoute {
 
     @Override
     protected void preserveNet(Net net, boolean async) {
-        List<SitePinInst> pinsToRoute = netToPins.get(net);
-        // Only preserve those pins that are not to be routed
+        List<SitePinInst> pinsToRoute = null;
+        if (!net.isStaticNet()) {
+            // Only preserve those pins that are not to be routed
+            pinsToRoute = netToPins.get(net);
+        }
         List<SitePinInst> pinsToPreserve;
         if (pinsToRoute == null) {
             pinsToPreserve = net.getPins();

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -552,7 +552,7 @@ public class RWRoute {
             List<SitePinInst> pins = e.getValue();
 
             // For some encrypted designs, it's possible that RapidWright cannot infer all SitePinInst-s leading to
-            // some site pins (e.g. CKEN) to default to a static net. Detect such cases -- when signal nets are
+            // some site pins (e.g. CKEN) defaulting those to static nets. Detect such cases -- when signal nets are
             // already routed to and preserved at those uninferrable SitePinInst-s -- and remove them from being a
             // static net sink
             Function<Node, NodeStatus> gns = (node) -> getGlobalRoutingNodeStatus(staticNet, node);

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -543,13 +543,6 @@ public class RWRoute {
                 gndPins.removeAll(newVccPins);
                 staticNetAndRoutingTargets.computeIfAbsent(vccNet, (net) -> new ArrayList<>())
                         .addAll(newVccPins);
-                // Re-preserve these new VCC sinks
-                for (SitePinInst spi : newVccPins) {
-                    Node node = spi.getConnectedNode();
-                    assert(routingGraph.getPreservedNet(node) == gndNet);
-                    routingGraph.unpreserve(node);
-                    routingGraph.preserve(node, vccNet);
-                }
             }
         }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -520,7 +520,7 @@ public class RWRoute {
             // Remove all output pins from unrouted net as those used will be repopulated
             staticNet.setPins(sinks);
 
-            staticNetAndRoutingTargets.put(staticNet, sinks);
+            staticNetAndRoutingTargets.put(staticNet, new ArrayList<>(sinks));
         } else {
             numNotNeedingRoutingNets++;
         }

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -530,19 +530,20 @@ public class RWRoute {
      * Routes static nets.
      */
     protected void routeStaticNets() {
-        if (staticNetAndRoutingTargets.isEmpty())
-            return;
-
         Net vccNet = design.getVccNet();
         Net gndNet = design.getGndNet();
-        List<SitePinInst> gndPins = staticNetAndRoutingTargets.get(gndNet);
-        if (gndPins != null) {
-            boolean invertGndToVccForLutInputs = config.isInvertGndToVccForLutInputs();
-            Set<SitePinInst> newVccPins = RouterHelper.invertPossibleGndPinsToVccPins(design, gndPins, invertGndToVccForLutInputs);
-            if (!newVccPins.isEmpty()) {
-                gndPins.removeAll(newVccPins);
-                staticNetAndRoutingTargets.computeIfAbsent(vccNet, (net) -> new ArrayList<>())
-                        .addAll(newVccPins);
+
+        boolean noStaticRouting = staticNetAndRoutingTargets.isEmpty();
+        if (!noStaticRouting) {
+            List<SitePinInst> gndPins = staticNetAndRoutingTargets.get(gndNet);
+            if (gndPins != null) {
+                boolean invertGndToVccForLutInputs = config.isInvertGndToVccForLutInputs();
+                Set<SitePinInst> newVccPins = RouterHelper.invertPossibleGndPinsToVccPins(design, gndPins, invertGndToVccForLutInputs);
+                if (!newVccPins.isEmpty()) {
+                    gndPins.removeAll(newVccPins);
+                    staticNetAndRoutingTargets.computeIfAbsent(vccNet, (net) -> new ArrayList<>())
+                            .addAll(newVccPins);
+                }
             }
         }
 
@@ -566,6 +567,10 @@ public class RWRoute {
                 return pins.isEmpty() ? null : pins;
             });
             preserveNet(staticNet, false);
+        }
+
+        if (noStaticRouting) {
+            return;
         }
 
         for (Map.Entry<Net,List<SitePinInst>> e : staticNetAndRoutingTargets.entrySet()) {

--- a/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
@@ -126,9 +126,9 @@ public class TestGlobalSignalRouting {
 
         GlobalSignalRouting.routeStaticNet(gndPins, (n) -> getNodeState(design, NetType.GND, n), design, routeThruHelper);
         gndPins = gndNet.getPins();
-        Assertions.assertEquals(857, gndPins.stream().filter((spi) -> spi.isOutPin()).count());
+        Assertions.assertEquals(737, gndPins.stream().filter((spi) -> spi.isOutPin()).count());
         Assertions.assertEquals(19010, gndPins.stream().filter((spi) -> !spi.isOutPin()).count());
-        Assertions.assertEquals(33201, gndNet.getPIPs().size());
+        Assertions.assertEquals(33429, gndNet.getPIPs().size());
 
         GlobalSignalRouting.routeStaticNet(vccPins, (n) -> getNodeState(design, NetType.VCC, n), design, routeThruHelper);
         vccPins = vccNet.getPins();

--- a/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
@@ -124,13 +124,13 @@ public class TestGlobalSignalRouting {
 
         RouteThruHelper routeThruHelper = new RouteThruHelper(design.getDevice());
 
-        GlobalSignalRouting.routeStaticNet(gndNet, (n) -> getNodeState(design, NetType.GND, n), design, routeThruHelper);
+        GlobalSignalRouting.routeStaticNet(gndPins, (n) -> getNodeState(design, NetType.GND, n), design, routeThruHelper);
         gndPins = gndNet.getPins();
         Assertions.assertEquals(857, gndPins.stream().filter((spi) -> spi.isOutPin()).count());
         Assertions.assertEquals(19010, gndPins.stream().filter((spi) -> !spi.isOutPin()).count());
         Assertions.assertEquals(33201, gndNet.getPIPs().size());
 
-        GlobalSignalRouting.routeStaticNet(vccNet, (n) -> getNodeState(design, NetType.VCC, n), design, routeThruHelper);
+        GlobalSignalRouting.routeStaticNet(vccPins, (n) -> getNodeState(design, NetType.VCC, n), design, routeThruHelper);
         vccPins = vccNet.getPins();
         Assertions.assertEquals(0, vccPins.stream().filter((spi) -> spi.isOutPin()).count());
         Assertions.assertEquals(23099, vccPins.stream().filter((spi) -> !spi.isOutPin()).count());
@@ -209,12 +209,12 @@ public class TestGlobalSignalRouting {
         RouteThruHelper routeThruHelper = new RouteThruHelper(design.getDevice());
 
         Design finalDesign = design;
-        GlobalSignalRouting.routeStaticNet(gndNet, (n) -> getNodeState(finalDesign, NetType.GND, n), design, routeThruHelper);
+        GlobalSignalRouting.routeStaticNet(gndPins, (n) -> getNodeState(finalDesign, NetType.GND, n), design, routeThruHelper);
         Assertions.assertEquals(8, gndPins.stream().filter((spi) -> spi.isOutPin()).count());
         Assertions.assertEquals(123, gndPins.stream().filter((spi) -> !spi.isOutPin()).count());
         Assertions.assertEquals(436, gndNet.getPIPs().size());
 
-        GlobalSignalRouting.routeStaticNet(vccNet, (n) -> getNodeState(finalDesign, NetType.VCC, n), design, routeThruHelper);
+        GlobalSignalRouting.routeStaticNet(vccPins, (n) -> getNodeState(finalDesign, NetType.VCC, n), design, routeThruHelper);
         Assertions.assertEquals(0, vccPins.stream().filter((spi) -> spi.isOutPin()).count());
         Assertions.assertEquals(232, vccPins.stream().filter((spi) -> !spi.isOutPin()).count());
         Assertions.assertEquals(464, vccNet.getPIPs().size());


### PR DESCRIPTION
Sinks in Laguna tiles must be Laguna registers (but will be projected into the INT tile) however, it's possible for another net to sneak in and use that sink node as a bounce -- this PR prevents that.