### PR TITLE
[ModuleInst] Fix placement behavior when requesting no overlaps

### DIFF
--- a/src/com/xilinx/rapidwright/design/ModuleInst.java
+++ b/src/com/xilinx/rapidwright/design/ModuleInst.java
@@ -39,9 +39,6 @@ import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.SiteTypeEnum;
 import com.xilinx.rapidwright.device.Tile;
-import com.xilinx.rapidwright.edif.EDIFNet;
-import com.xilinx.rapidwright.edif.EDIFPortInst;
-import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.util.MessageGenerator;
 import com.xilinx.rapidwright.util.Utils;
 
@@ -356,6 +353,11 @@ public class ModuleInst extends AbstractModuleInst<Module, Site, ModuleInst>{
                         }
                     }
                 }
+            }
+
+            if (existingSiteInst != null && !allowOverlap) {
+                unplace();
+                return false;
             }
 
             if (newSite == null || existingSiteInst != null) {

--- a/src/com/xilinx/rapidwright/design/ModuleInst.java
+++ b/src/com/xilinx/rapidwright/design/ModuleInst.java
@@ -353,12 +353,12 @@ public class ModuleInst extends AbstractModuleInst<Module, Site, ModuleInst>{
                         }
                     }
                 }
+                if (existingSiteInst != null) {
+                    unplace();
+                    return false;
+                }
             }
 
-            if (existingSiteInst != null && !allowOverlap) {
-                unplace();
-                return false;
-            }
 
             if (newSite == null || existingSiteInst != null) {
                 //MessageGenerator.briefError("ERROR: No matching site found." +

--- a/src/com/xilinx/rapidwright/design/ModuleInst.java
+++ b/src/com/xilinx/rapidwright/design/ModuleInst.java
@@ -359,7 +359,6 @@ public class ModuleInst extends AbstractModuleInst<Module, Site, ModuleInst>{
                 }
             }
 
-
             if (newSite == null || existingSiteInst != null) {
                 //MessageGenerator.briefError("ERROR: No matching site found." +
                 //    " (Template Site:"    + templateSite.getName() +


### PR DESCRIPTION
`ModuleInst.place()` has a flag to request that no overlapping modules should be allowed.  There was a bug where this was not behaving as expected.  This attempts to align the behavior with the intent of the method.