### PR TITLE
Changes to support new array-based sitewire-net changes 

### DIFF
--- a/test/src/com/xilinx/rapidwright/design/TestDesign.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesign.java
@@ -348,7 +348,7 @@ public class TestDesign {
         Assertions.assertTrue(si.routeIntraSiteNet(oldNet, si.getBELPin("A1", "A1"),
                 si.getBELPin(unisim.toString(), "DI0")));
         Assertions.assertEquals("[IN SLICE_X32Y73.A1, OUT SLICE_X32Y73.HQ]", oldNet.getPins().toString());
-        Assertions.assertEquals("[A1, HQ, A5LUT_O5]", si.getSiteWiresFromNet(oldNet).toString());
+        Assertions.assertEquals("[A1, A5LUT_O5, HQ]", si.getSiteWiresFromNet(oldNet).toString());
 
         Net newNet = d.createNet("newNet");
         SitePinInst h6 = newNet.createPin("H6", si);
@@ -362,7 +362,7 @@ public class TestDesign {
         Assertions.assertNull(d.getNet(oldNet.getName()));
         Assertions.assertSame(newNet, d.getNet(newNet.getName()));
         Assertions.assertEquals("[IN SLICE_X32Y73.H6, IN SLICE_X32Y73.A1, OUT SLICE_X32Y73.HQ]", newNet.getPins().toString());
-        Assertions.assertEquals("[H6, A1, HQ, A5LUT_O5]", si.getSiteWiresFromNet(newNet).toString());
+        Assertions.assertEquals("[A1, A5LUT_O5, H6, HQ]", si.getSiteWiresFromNet(newNet).toString());
         Assertions.assertEquals("[INT_X21Y73/INT.VCC_WIRE->>IMUX_E47]", newNet.getPIPs().toString());
     }
 
@@ -389,7 +389,7 @@ public class TestDesign {
         Assertions.assertNull(d.getNet(oldNet.getName()));
         Assertions.assertSame(newNet, d.getNet(newNet.getName()));
         Assertions.assertEquals("[IN SLICE_X32Y73.H6]", newNet.getPins().toString());
-        Assertions.assertEquals("[H6, B_O, FFMUXB1_OUT1]", si.getSiteWiresFromNet(newNet).toString());
+        Assertions.assertEquals("[B_O, FFMUXB1_OUT1, H6]", si.getSiteWiresFromNet(newNet).toString());
         Assertions.assertTrue(newNet.getPIPs().isEmpty());
     }
 

--- a/test/src/com/xilinx/rapidwright/design/compare/TestDesignComparator.java
+++ b/test/src/com/xilinx/rapidwright/design/compare/TestDesignComparator.java
@@ -149,7 +149,7 @@ public class TestDesignComparator {
         Assertions.assertTrue(net.hasPIPs());
         test2.removeNet(net);
 
-        compareDesign(22, 1, DesignDiffType.NET_MISSING, dc, gold, test2);
+        compareDesign(28, 1, DesignDiffType.NET_MISSING, dc, gold, test2);
 
         Net extra = new Net("extraNet");
         for (PIP p : net.getPIPs()) {
@@ -157,17 +157,17 @@ public class TestDesignComparator {
         }
         test2.addNet(extra);
 
-        compareDesign(23, 1, DesignDiffType.NET_EXTRA, dc, gold, test2);
+        compareDesign(29, 1, DesignDiffType.NET_EXTRA, dc, gold, test2);
 
         Assertions.assertTrue(extra.hasPIPs());
         clk.addPIP(extra.getPIPs().get(0));
 
-        compareDesign(24, 1, DesignDiffType.PIP_EXTRA, dc, gold, test2);
+        compareDesign(30, 1, DesignDiffType.PIP_EXTRA, dc, gold, test2);
 
         clk.getPIPs().remove(clk.getPIPs().size() - 1);
         clk.getPIPs().remove(clk.getPIPs().size() - 1);
 
-        compareDesign(24, 1, DesignDiffType.PIP_MISSING, dc, gold, test2);
+        compareDesign(30, 1, DesignDiffType.PIP_MISSING, dc, gold, test2);
 
         if (dc.comparePIPFlags()) {
             clk.getPIPs().get(clk.getPIPs().size() - 1).setIsStub(true);


### PR DESCRIPTION
This update tests to reflect bug fixes and minor behavior changes associated with a new storage method in `SiteInst` objects where instead of using maps, the `Net` to site wire now uses an array.  This led to a change in iteration order and also a bug was discovered when `SiteInst` are renamed, they were not getting updated in the `Set<SiteInst>` class members of `Net` objects.  This led to some failures to fully remove the references when prompted in some of the tests.