### PR TITLE
[NetTools] Add check for net driving clock sinks

### DIFF
--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -144,4 +144,18 @@ public class NetTools {
 
         return subtrees;
     }
+    
+    /**
+     * Checks if the provided net drives a clock site pin input.
+     * 
+     * @param net The net to examine.
+     * @return True if the net has a site pin clock input, false otherwise.
+     */
+    public static boolean hasClockSinks(Net net) {
+        for (SitePinInst sink : net.getPins()) { 
+            if (sink.isOutPin()) continue;
+            if (sink.getName().contains("CLK")) return true;
+        }
+        return false;
+    }
 }

--- a/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/RelocationTools.java
@@ -39,6 +39,7 @@ import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.DesignTools;
 import com.xilinx.rapidwright.design.Module;
 import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.NetTools;
 import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
 import com.xilinx.rapidwright.design.blocks.PBlock;
@@ -284,7 +285,7 @@ public class RelocationTools {
                 }
             }
 
-            boolean isClockNet = n.isClockNet() || n.hasGapRouting();
+            boolean isClockNet = n.isClockNet() || NetTools.hasClockSinks(n);
             n.getPIPs().removeIf((sp) -> {
                 Tile st = sp.getTile();
                 Tile dt = st.getTileXYNeighbor(tileColOffset, tileRowOffset);


### PR DESCRIPTION
This avoid looking for gap routing as a proxy check to see if a net is a clock.