### PR TITLE
RWRoute preprocessing fixes

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3324,16 +3324,13 @@ public class DesignTools {
                     if ("SRLC32E".equals(cell.getPropertyValueString("XILINX_LEGACY_PRIM"))) {
                         expectGndNet = true;
                         staticNet = gndNet;
-                        // Expect sitewire to be VCC or GND
-                        if (!a6Net.isStaticNet()) {
-                            throw new RuntimeException("ERROR: Site pin " + si.getSiteName() + "/" + belName.charAt(0) + "6 is not a static net");
-                        }
+                        assert(a6Net.isGNDNet());
                     }
 
                     // [A-H]6 input already has a (static) net
                     spi = si.getSitePinInst(belName.charAt(0) + "6");
                     if (spi != null) {
-                        assert(spi.getNet().isStaticNet());
+                        assert(LUTTools.getCompanionLUT(cell) != null ? a6Net.isVCCNet() : a6Net.isGNDNet());
                         continue;
                     }
                 }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3329,6 +3329,13 @@ public class DesignTools {
                             throw new RuntimeException("ERROR: Site pin " + si.getSiteName() + "/" + belName.charAt(0) + "6 is not a static net");
                         }
                     }
+
+                    // [A-H]6 input already has a (static) net
+                    spi = si.getSitePinInst(belName.charAt(0) + "6");
+                    if (spi != null) {
+                        assert(spi.getNet().isStaticNet());
+                        continue;
+                    }
                 }
 
                 // Tie A6 to staticNet only if sitewire says so

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3331,8 +3331,8 @@ public class DesignTools {
 
                     spi = si.getSitePinInst(belName.charAt(0) + "6");
                     if (spi != null) {
-                        // [A-H]6 input already a static net
-                        assert(spi.getNet() == a6Net);
+                        // [A-H]6 input already a static net (which may not match the sitewire)
+                        assert(spi.getNet().isStaticNet());
                         assert(a6Net.isStaticNet());
                         continue;
                     }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3331,8 +3331,9 @@ public class DesignTools {
 
                     spi = si.getSitePinInst(belName.charAt(0) + "6");
                     if (spi != null) {
-                        // [A-H]6 input already has this static net
-                        assert(a6Net == staticNet);
+                        // [A-H]6 input already a static net
+                        assert(spi.getNet() == a6Net);
+                        assert(a6Net.isStaticNet());
                         continue;
                     }
                 } else {

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -427,7 +427,9 @@ public class GlobalSignalRouting {
         assertIntentCodeOfPoppedNodesOnVcc = EnumSet.of(
                 IntentCode.NODE_PINFEED,
                 IntentCode.NODE_PINBOUNCE,
-                IntentCode.INTENT_DEFAULT);
+                IntentCode.INTENT_DEFAULT,
+                IntentCode.NODE_GLOBAL_GCLK // e.g. MMCM_CLKIN2, MMCM_CLKFBIN
+        );
         boolean isVersal = false;
         if (series == Series.UltraScale) {
             // On UltraScale, certain site pins (e.g. SLICE/CKEN_B1[1-4], SLICE/SRST_B[12])

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -461,9 +461,11 @@ public class RouterHelper {
         gndNet.getPins().removeAll(toInvertPins);
 
         Net vccNet = design.getVccNet();
-        for (SitePinInst toinvert:toInvertPins) {
+        for (SitePinInst toinvert : toInvertPins) {
             assert(toinvert.getSiteInst() != null);
-            if (!vccNet.addPin(toinvert)) {
+            SiteInst si = toinvert.getSiteInst();
+            si.unrouteIntraSiteNet(toinvert.getBELPin(), toinvert.getBELPin());
+            if (!vccNet.addPin(toinvert, false)) {
                   throw new RuntimeException("ERROR: Couldn't invert site pin " +
                           toinvert);
             }

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -444,7 +444,8 @@ public class RouterHelper {
                     }
                     // Emulate Vivado's behaviour and do not invert CLK* site pins
                     if (Utils.isBRAM(spi.getSiteInst()) &&
-                            belPin.getBELName().startsWith("CLK")) {
+                            belPin.getBELName().startsWith("CLK") &&
+                            !isVersal) {
                         continue;
                     }
                     toInvertPins.add(spi);

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -444,8 +444,7 @@ public class RouterHelper {
                     }
                     // Emulate Vivado's behaviour and do not invert CLK* site pins
                     if (Utils.isBRAM(spi.getSiteInst()) &&
-                            belPin.getBELName().startsWith("CLK") &&
-                            !isVersal) {
+                            belPin.getBELName().startsWith("CLK")) {
                         continue;
                     }
                     toInvertPins.add(spi);


### PR DESCRIPTION
1. Tie off `MMCM.CLKFBIN` and `MMCM.CLKIN2` site pins to VCC if unused.
2. `RouterHelper.invertPossibleGndPinsToVccPins()`: Unroute intra-site net when inverting (and do not reroute)
  When inverting `SitePinInst`s from being on the GND net to the VCC net, unpaint the sitewire if there's an inverter.
