### PR TITLE
[RWRoute] Small cleanup; enable CUFR by default

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/CUFR.java
+++ b/src/com/xilinx/rapidwright/rwroute/CUFR.java
@@ -200,7 +200,7 @@ public class CUFR extends RWRoute {
             System.err.println("WARNING: Hybrid Updating Strategy (HUS) is not enabled.");
         }
 
-        return routeDesign(design, new CUFR(design, config));
+        return routeDesign(new CUFR(design, config));
     }
 
     /**
@@ -229,7 +229,10 @@ public class CUFR extends RWRoute {
         } else {
             input = Design.readCheckpoint(args[0]);
         }
-        Design routed = routeDesignWithUserDefinedArguments(input, rwrouteArgs);
+
+        RWRouteConfig config = new RWRouteConfig(rwrouteArgs);
+        config.setHus(true);
+        Design routed = routeDesign(new CUFR(input, config));
 
         // Writes out the routed design checkpoint
         routed.writeCheckpoint(routedDCPfileName,t);

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -381,7 +381,7 @@ public class PartialRouter extends RWRoute {
 
                     // Do not include arcs that the router wouldn't explore
                     // e.g. those that leave the INT tile, since we project pins to their INT tile
-                    if (routingGraph.isExcludedTile(end)) {
+                    if (RouteNodeGraph.isExcludedTile(end)) {
                         continue;
                     }
 
@@ -554,7 +554,7 @@ public class PartialRouter extends RWRoute {
 
                 // Do not include arcs that the router wouldn't explore
                 // e.g. those that leave the INT tile, since we project pins to their INT tile
-                if (routingGraph.isExcludedTile(end))
+                if (RouteNodeGraph.isExcludedTile(end))
                     continue;
 
                 // Since net already exists, all the nodes it uses must already
@@ -585,7 +585,7 @@ public class PartialRouter extends RWRoute {
 
                 // Do not include arcs that the router wouldn't explore
                 // e.g. those that leave the INT tile, since we project pins to their INT tile
-                if (routingGraph.isExcludedTile(end))
+                if (RouteNodeGraph.isExcludedTile(end))
                     continue;
 
                 boolean startPreserved = routingGraph.unpreserve(start);
@@ -712,7 +712,7 @@ public class PartialRouter extends RWRoute {
             System.out.println("WARNING: Masking nodes across RCLK for partial routing could result in routability problems.");
         }
 
-        return routeDesign(design, new PartialRouter(design, config, pinsToRoute, softPreserve));
+        return routeDesign(new PartialRouter(design, config, pinsToRoute, softPreserve));
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -2285,15 +2285,14 @@ public class RWRoute {
             System.out.println("WARNING: Not masking nodes across RCLK could result in delay optimism.");
         }
 
-        return routeDesign(design, new RWRoute(design, config));
+        return routeDesign(new RWRoute(design, config));
     }
 
     /**
      * Routes a design after pre-processing.
-     * @param design The {@link Design} instance to be routed.
      * @param router A {@link RWRoute} object to be used to route the design.
      */
-    protected static Design routeDesign(Design design, RWRoute router) {
+    protected static Design routeDesign(RWRoute router) {
         router.preprocess();
 
         // Initialize router object
@@ -2325,7 +2324,7 @@ public class RWRoute {
 
         // Reads in a design and routes it
         String[] rwrouteArgs = Arrays.copyOfRange(args, 2, args.length);
-        Design input = null;
+        Design input;
         if (Interchange.isInterchangeFile(args[0])) {
             input = Interchange.readInterchangeDesign(args[0]);
         } else {

--- a/src/com/xilinx/rapidwright/rwroute/RapidStreamRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RapidStreamRoute.java
@@ -181,6 +181,6 @@ public class RapidStreamRoute extends PartialRouter {
                 "--enlargeBoundingBox",
                 "--useUTurnNodes",
                 "--verbose"});
-        return routeDesign(design, new RapidStreamRoute(design, config, pinsToRoute));
+        return routeDesign(new RapidStreamRoute(design, config, pinsToRoute));
     }
 }


### PR DESCRIPTION
In particular, calling `CUFR.main()` and `PartialCUFR.main()` (as you would do when invoking from the command line) should have [HUS](https://github.com/Xilinx/RapidWright/pull/1043) enabled by default.

Plus some smaller cleanups.