### PR TITLE
[LUTTools] Versal pin swapping fixes

### DIFF
--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -51,7 +51,6 @@ import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.device.PIP;
-import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.device.Site;
 import com.xilinx.rapidwright.device.SitePin;
 import com.xilinx.rapidwright.edif.EDIFCell;

--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -482,7 +482,6 @@ public class LUTTools {
      */
     public static int swapMultipleLutPins(Map<SitePinInst, String> oldPinToNewPins) {
         Map<String,Map<String,PinSwap>> pinSwaps = new HashMap<>();
-        Boolean isVersal = null;
 
         for (Map.Entry<SitePinInst, String> e : oldPinToNewPins.entrySet()) {
             SitePinInst oldSinkSpi = e.getKey();
@@ -497,18 +496,7 @@ public class LUTTools {
                 continue;
             }
 
-            if (isVersal == null) {
-                isVersal = si.getDesign().getSeries() == Series.Versal;
-            }
-
             Set<Cell> cells = DesignTools.getConnectedCells(oldSinkSpi);
-            if (isVersal) {
-                assert(cells.size() == 1);
-                Cell cell = cells.iterator().next();
-                BEL bel = cell.getBEL();
-                assert(bel.isIMR());
-                cells = DesignTools.getConnectedCells(bel.getPin("Q"), si);
-            }
             if (cells.isEmpty()) {
                 continue;
             }

--- a/src/com/xilinx/rapidwright/design/tools/LUTTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/LUTTools.java
@@ -645,21 +645,12 @@ public class LUTTools {
             copyOnWritePinSwaps.add(ps);
         }
 
-        Boolean isVersal = null;
         // Prepares pins for swapping by removing them
         Queue<SitePinInst> q = new LinkedList<>();
         for (PinSwap ps : copyOnWritePinSwaps) {
             Cell cell = ps.getCell();
+            String oldSitePinName = cell.getBELName().substring(0, 1) + ps.getOldPhysicalName().charAt(1);
             SiteInst si = cell.getSiteInst();
-            if (isVersal == null) {
-                isVersal = si.getDesign().getSeries() == Series.Versal;
-            }
-            String oldSitePinName;
-            if (isVersal) {
-                oldSitePinName = cell.getBELName().substring(0, 1) + ps.getOldPhysicalName().charAt(1);
-            } else {
-                oldSitePinName = cell.getSiteWireNameFromPhysicalPin(ps.getOldPhysicalName());
-            }
             SitePinInst pinToMove = si.getSitePinInst(oldSitePinName);
             q.add(pinToMove);
             if (pinToMove == null) {
@@ -697,8 +688,7 @@ public class LUTTools {
             pinToMove.setPinName(ps.getNewNetPinName());
             SiteInst si = cell.getSiteInst();
             pinToMove.setSiteInst(si);
-            Net net = pinToMove.getNet();
-            si.routeIntraSiteNet(net, pinToMove.getBELPin(), cell.getBEL().getPin(ps.getNewPhysicalName()));
+            si.routeIntraSiteNet(pinToMove.getNet(), pinToMove.getBELPin(), cell.getBEL().getPin(ps.getNewPhysicalName()));
         }
 
         assert(q.isEmpty());


### PR DESCRIPTION
* Alternate way to extract site pin name despite presence of Versal IMRs
* Update intra-site routing when pin swapping (necessary for Versal due to those IMRs)