### PR TITLE
[DesignTools] updatePinsIsRouted() to return num unrouted sinks

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -4414,14 +4414,17 @@ public class DesignTools {
      * Update the SitePinInst.isRouted() value of all sink pins in the given
      * Design. See {@link #updatePinsIsRouted(Net)}.
      * @param design Design in which pins are to be updated.
-     * @return Number of unrouted sink pins across design.
+     * @return Number of unrouted sink pins (not driven by hierarchical ports) across design.
      */
     public static int updatePinsIsRouted(Design design) {
-        int numUnroutedSinkPins = 0;
+        int totalUnroutedSinkPins = 0;
         for (Net net : design.getNets()) {
-            numUnroutedSinkPins += updatePinsIsRouted(net);
+            int numUnroutedSinkPins = updatePinsIsRouted(net);
+            if (!DesignTools.isNetDrivenByHierPort(net)) {
+                totalUnroutedSinkPins += numUnroutedSinkPins;
+            }
         }
-        return numUnroutedSinkPins;
+        return totalUnroutedSinkPins;
     }
 
     /**

--- a/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
+++ b/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
@@ -187,7 +187,7 @@ public class TestECOTools {
         EDIFNetlist netlist = design.getNetlist();
         Map<Net, Set<SitePinInst>> deferredRemovals = new HashMap<>();
 
-        DesignTools.updatePinsIsRouted(design);
+        Assertions.assertEquals(0, DesignTools.updatePinsIsRouted(design));
 
         // Disconnect the ILA inputs
         List<EDIFHierPortInst> disconnectPins = new ArrayList<>();
@@ -253,7 +253,7 @@ public class TestECOTools {
         EDIFNetlist netlist = design.getNetlist();
         Map<Net, Set<SitePinInst>> deferredRemovals = new HashMap<>();
 
-        DesignTools.updatePinsIsRouted(design);
+        Assertions.assertEquals(0, DesignTools.updatePinsIsRouted(design));
 
         // Disconnect the outputs
         List<EDIFHierPortInst> disconnectPins = new ArrayList<>();
@@ -386,7 +386,7 @@ public class TestECOTools {
         Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
         EDIFNetlist netlist = design.getNetlist();
 
-        DesignTools.updatePinsIsRouted(design);
+        Assertions.assertEquals(0, DesignTools.updatePinsIsRouted(design));
 
         EDIFCell reference = netlist.getCell("kcpsm6");
         List<String> instNames = Arrays.asList("processor2", "processor3");
@@ -474,7 +474,7 @@ public class TestECOTools {
         Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
         EDIFNetlist netlist = design.getNetlist();
 
-        DesignTools.updatePinsIsRouted(design);
+        Assertions.assertEquals(0, DesignTools.updatePinsIsRouted(design));
 
         List<String> netNames = Arrays.asList("processor/foo", "your_program/bar");
         ECOTools.createNet(design, netNames);

--- a/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
+++ b/test/src/com/xilinx/rapidwright/interchange/TestPhysNetlistWriter.java
@@ -331,7 +331,7 @@ public class TestPhysNetlistWriter {
             inputDesign = null;
 
             Assertions.assertTrue(LUTTools.swapLutPinsFromPIPs(outputDesign) > 0);
-            DesignTools.updatePinsIsRouted(outputDesign);
+            Assertions.assertEquals(0, DesignTools.updatePinsIsRouted(outputDesign));
             TestRWRoute.assertAllSourcesRoutedFlagSet(outputDesign);
             TestRWRoute.assertAllPinsRouted(outputDesign);
             VivadoToolsHelper.assertFullyRouted(outputDesign);

--- a/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
@@ -339,7 +339,7 @@ public class TestGlobalSignalRouting {
                     if (node != null) used.add(node);
                 }
             }
-            DesignTools.updatePinsIsRouted(net);
+            Assertions.assertEquals(0, DesignTools.updatePinsIsRouted(net));
             for (SitePinInst spi : net.getPins()) {
                 Assertions.assertTrue(spi.isRouted());
             }


### PR DESCRIPTION
Previously returned `void`. 

Helpful for determining if anything needs to be routed.