### PR TITLE
[BlockStitcher] Work arounds to address stitching issues in latest Vivado 2024.2

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -481,26 +481,41 @@ public class EDIFNetlist extends EDIFName {
     }
 
     /**
-     * Migrates all cells in the provided library
-     * into the standard work library.
-     * @param library The library with cells to be migrated to work.
+     * Migrates all cells in the provided library into the standard work library.
+     * 
+     * @param library          The library with cells to be migrated to work.
+     * @param renameCollisions Flag to rename cells upon name collision
      */
-    public void migrateToWorkLibrary(String library) {
+    public void migrateToWorkLibrary(String library, boolean renameCollisions) {
         EDIFLibrary work = getWorkLibrary();
         EDIFLibrary oldWork = getLibrary(library);
         List<EDIFCell> toRemove = new ArrayList<>(oldWork.getCells());
         for (EDIFCell c : toRemove) {
             oldWork.removeCell(c);
-            work.addCell(c);
+            if (renameCollisions) {
+                work.addCellRenameDuplicates(c, "Work");
+            } else {
+                work.addCell(c);
+            }
         }
         removeLibrary(library);
     }
 
     /**
-     * Migrates all libraries except HDI primitives and work to
-     * the work library.
+     * Migrates all cells in the provided library into the standard work library.
+     * 
+     * @param library The library with cells to be migrated to work.
      */
-    public void consolidateAllToWorkLibrary() {
+    public void migrateToWorkLibrary(String library) {
+        migrateToWorkLibrary(library, false);
+    }
+
+    /**
+     * Migrates all libraries except HDI primitives and work to the work library.
+     * 
+     * @param renameCollisions Flag to rename cells upon name collision
+     */
+    public void consolidateAllToWorkLibrary(boolean renameCollisions) {
         List<EDIFLibrary> librariesToMigrate = new ArrayList<>();
         for (EDIFLibrary l : getLibraries()) {
             if (!l.isHDIPrimitivesLibrary() && !l.isWorkLibrary()) {
@@ -508,8 +523,15 @@ public class EDIFNetlist extends EDIFName {
             }
         }
         for (EDIFLibrary l : librariesToMigrate) {
-            migrateToWorkLibrary(l.getName());
+            migrateToWorkLibrary(l.getName(), renameCollisions);
         }
+    }
+
+    /**
+     * Migrates all libraries except HDI primitives and work to the work library.
+     */
+    public void consolidateAllToWorkLibrary() {
+        consolidateAllToWorkLibrary(false);
     }
 
     private EDIFCell migrateCellAndSubCellsWorker(EDIFCell cell) {


### PR DESCRIPTION
This is a few fixes/work arounds to enable the `BlockStitcher` to run on 2024.2 designs from Vivado.  

1. Consolidate the final netlist set of cells to the `work` library and update all references of the work library to the canonical instance in the netlist.
2. Change the name of the design to match the incoming netlist top cell name.
3. Works around a reference issue for pass-thru port connections where the `EDIFPortInst` has a null reference to its `EDIFCellInst`.  It works around this issue by referencing the `EDIFCellInst` in the `EDIFHierCellInst` instead.
4. The BlockStitcher relies on operating on a null netlist, however, modern changes do not allow this.  A work around is added that puts a temporary 'dummy' netlist in place and then removes it.

See also #1124.