### PR TITLE
Adds an Override Flag for Advanced Flow Settings in Designs

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.2.1-rc4.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2024.2.1-rc5.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.2.1-rc4-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2024.2.1-rc5-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2024.2.1-rc4-beta
+  RAPIDWRIGHT_VERSION: v2024.2.1-rc5-beta
 
 jobs:
   build:

--- a/src/com/xilinx/rapidwright/util/Params.java
+++ b/src/com/xilinx/rapidwright/util/Params.java
@@ -36,6 +36,8 @@ public class Params {
 
     public static String RW_WRITE_DCP_2024_1_NAME = "RW_WRITE_DCP_2024_1";
 
+    public static String RW_DISABLE_WRITING_ADV_FLOW_DCPS_NAME = "RW_DISABLE_WRITING_ADV_FLOW_DCPS";
+
     /**
      * Flag to have RapidWright decompress gzipped EDIF files to disk prior to
      * parsing. This is a tradeoff where pre-decompression improves runtime over the
@@ -59,6 +61,14 @@ public class Params {
      * faster and will provide better support for the largest devices.
      */
     public static boolean RW_WRITE_DCP_2024_1 = isParamSet(RW_WRITE_DCP_2024_1_NAME);
+
+    /**
+     * Flag to disable RapidWright from writing any DCPs that target Vivado's
+     * Advanced Flow (starting in Vivado 2024.2). By default, RapidWright writes
+     * DCPs targeting Versal devices with the Advanced Flow compatibility flag set
+     * to true.
+     */
+    public static boolean RW_DISABLE_WRITING_ADV_FLOW_DCPS = isParamSet(RW_DISABLE_WRITING_ADV_FLOW_DCPS_NAME);
 
     /**
      * Checks if the named RapidWright parameter is set via an environment variable

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -22,15 +22,15 @@
 
 package com.xilinx.rapidwright.util;
 
-import com.xilinx.rapidwright.design.Design;
-import com.xilinx.rapidwright.edif.EDIFTools;
-
 import java.io.File;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.edif.EDIFTools;
 
 /**
  * Utility methods to provide access to vivado and parse logs
@@ -115,12 +115,12 @@ public class VivadoTools {
         final String vivadoCmd = FileTools.getVivadoPath() + " -log " + outputLog.toString() + " -nojournal -mode batch -source "
                 + tclScript.toString();
         Integer exitCode = FileTools.runCommand(vivadoCmd, verbose, environ, runDir);
-        if (exitCode != 0) {
-            if (Files.exists(outputLog)) {
-                for (String l : FileTools.getLinesFromTextFile(outputLog.toString())) {
-                    System.out.println("FAILED OUTPUT> " + l);
-                }
+        if (Files.exists(outputLog)) {
+            for (String l : FileTools.getLinesFromTextFile(outputLog.toString())) {
+                System.out.println("VIVADO OUTPUT> " + l);
             }
+        }
+        if (exitCode != 0) {
             throw new RuntimeException("Vivado exited with code: " + exitCode);
         }
         return FileTools.getLinesFromTextFile(outputLog.toString());

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -115,12 +115,12 @@ public class VivadoTools {
         final String vivadoCmd = FileTools.getVivadoPath() + " -log " + outputLog.toString() + " -nojournal -mode batch -source "
                 + tclScript.toString();
         Integer exitCode = FileTools.runCommand(vivadoCmd, verbose, environ, runDir);
-        if (Files.exists(outputLog)) {
-            for (String l : FileTools.getLinesFromTextFile(outputLog.toString())) {
-                System.out.println("VIVADO OUTPUT> " + l);
-            }
-        }
         if (exitCode != 0) {
+            if (Files.exists(outputLog)) {
+                for (String l : FileTools.getLinesFromTextFile(outputLog.toString())) {
+                    System.out.println("FAILED OUTPUT> " + l);
+                }
+            }
             throw new RuntimeException("Vivado exited with code: " + exitCode);
         }
         return FileTools.getLinesFromTextFile(outputLog.toString());

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -114,17 +114,13 @@ public class VivadoTools {
         }
         final String vivadoCmd = FileTools.getVivadoPath() + " -log " + outputLog.toString() + " -nojournal -mode batch -source "
                 + tclScript.toString();
-        System.out.println("Running VivadoTools.runTcl() at " + FileTools.getTimeStamp());
         Integer exitCode = FileTools.runCommand(vivadoCmd, verbose, environ, runDir);
         if (exitCode != 0) {
-            System.out.flush();
-            System.err.flush();
             if (Files.exists(outputLog)) {
                 for (String l : FileTools.getLinesFromTextFile(outputLog.toString())) {
                     System.out.println("FAILED OUTPUT> " + l);
                 }
             }
-
             throw new RuntimeException("Vivado exited with code: " + exitCode);
         }
         return FileTools.getLinesFromTextFile(outputLog.toString());

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -27,6 +27,7 @@ import com.xilinx.rapidwright.edif.EDIFTools;
 
 import java.io.File;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,8 +114,17 @@ public class VivadoTools {
         }
         final String vivadoCmd = FileTools.getVivadoPath() + " -log " + outputLog.toString() + " -nojournal -mode batch -source "
                 + tclScript.toString();
+        System.out.println("Running VivadoTools.runTcl() at " + FileTools.getTimeStamp());
         Integer exitCode = FileTools.runCommand(vivadoCmd, verbose, environ, runDir);
         if (exitCode != 0) {
+            System.out.flush();
+            System.err.flush();
+            if (Files.exists(outputLog)) {
+                for (String l : FileTools.getLinesFromTextFile(outputLog.toString())) {
+                    System.out.println("FAILED OUTPUT> " + l);
+                }
+            }
+
             throw new RuntimeException("Vivado exited with code: " + exitCode);
         }
         return FileTools.getLinesFromTextFile(outputLog.toString());

--- a/test/src/com/xilinx/rapidwright/design/TestDCPWrite.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDCPWrite.java
@@ -73,7 +73,8 @@ public class TestDCPWrite {
         design.writeCheckpoint(setFalseDCPPath);
 
         Design falseDCP = Design.readCheckpoint(setFalseDCPPath);
-        Assertions.assertFalse(falseDCP.isAdvancedFlow());
+        // Write DCP should revert flag to default case (true)
+        Assertions.assertTrue(falseDCP.isAdvancedFlow());
 
         falseDCP.setAdvancedFlow(true);
 
@@ -82,8 +83,5 @@ public class TestDCPWrite {
         Path overrideDCPPath = tempDir.resolve("override.dcp");
         Assertions.assertTrue(falseDCP.isAdvancedFlow());
         falseDCP.writeCheckpoint(overrideDCPPath);
-
-        Design overrideDCP = Design.readCheckpoint(overrideDCPPath);
-        Assertions.assertFalse(overrideDCP.isAdvancedFlow());
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDCPWrite.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDCPWrite.java
@@ -24,6 +24,7 @@ package com.xilinx.rapidwright.design;
 
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -52,5 +53,37 @@ public class TestDCPWrite {
         if (FileTools.isVivadoAtLeastVersion(2024, 1)) {
             VivadoToolsHelper.assertFullyRouted(dcp);
         }
+    }
+
+    @Test
+    public void testAdvancedFlowFlags(@TempDir Path tempDir) {
+        Design design = RapidWrightDCP.loadDCP("picoblaze_2022.2.dcp");
+
+        // Should be true since it is targeting Versal
+        Assertions.assertTrue(design.isAdvancedFlow());
+        Path defaultDCPPath = tempDir.resolve("default.dcp");
+        design.writeCheckpoint(defaultDCPPath);
+
+        Design defaultDCP = Design.readCheckpoint(defaultDCPPath);
+        Assertions.assertTrue(defaultDCP.isAdvancedFlow());
+
+        design.setAdvancedFlow(false);
+        Assertions.assertFalse(design.isAdvancedFlow());
+        Path setFalseDCPPath = tempDir.resolve("false.dcp");
+        design.writeCheckpoint(setFalseDCPPath);
+
+        Design falseDCP = Design.readCheckpoint(setFalseDCPPath);
+        Assertions.assertFalse(falseDCP.isAdvancedFlow());
+
+        falseDCP.setAdvancedFlow(true);
+
+        Params.RW_DISABLE_WRITING_ADV_FLOW_DCPS = true;
+
+        Path overrideDCPPath = tempDir.resolve("override.dcp");
+        Assertions.assertTrue(falseDCP.isAdvancedFlow());
+        falseDCP.writeCheckpoint(overrideDCPPath);
+
+        Design overrideDCP = Design.readCheckpoint(overrideDCPPath);
+        Assertions.assertFalse(overrideDCP.isAdvancedFlow());
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestDCPWrite.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDCPWrite.java
@@ -78,10 +78,11 @@ public class TestDCPWrite {
 
         falseDCP.setAdvancedFlow(true);
 
-        Params.RW_DISABLE_WRITING_ADV_FLOW_DCPS = true;
-
         Path overrideDCPPath = tempDir.resolve("override.dcp");
+        Params.RW_DISABLE_WRITING_ADV_FLOW_DCPS = true;
         Assertions.assertTrue(falseDCP.isAdvancedFlow());
         falseDCP.writeCheckpoint(overrideDCPPath);
+        // Return to default for other tests
+        Params.RW_DISABLE_WRITING_ADV_FLOW_DCPS = false;
     }
 }


### PR DESCRIPTION
Allows users to disable any Advanced Flow flags when writing out DCPs  by setting the param `RW_DISABLE_WRITING_ADV_FLOW_DCPS`. 