### PR TITLE
Routing Heat Map Example

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -85,6 +85,7 @@ import com.xilinx.rapidwright.placer.handplacer.HandPlacer;
 import com.xilinx.rapidwright.placer.handplacer.ModuleOptimizer;
 import com.xilinx.rapidwright.router.RouteThruHelper;
 import com.xilinx.rapidwright.router.Router;
+import com.xilinx.rapidwright.router.RoutingHeatMap;
 import com.xilinx.rapidwright.rwroute.CUFR;
 import com.xilinx.rapidwright.rwroute.PartialCUFR;
 import com.xilinx.rapidwright.rwroute.PartialRouter;
@@ -191,6 +192,7 @@ public class MainEntrypoint {
         addFunction("ReportTimingExample", ReportTimingExample::main);
         addFunction("Router", Router::main);
         addFunction("RouteThruHelper", RouteThruHelper::main);
+        addFunction("RoutingHeatMap", RoutingHeatMap::main);
         addFunction("RunSATRouterExample", RunSATRouterExample::main);
         addFunction("RWRoute", RWRoute::main);
         addFunction("SLRCrosserGenerator", SLRCrosserGenerator::main);

--- a/src/com/xilinx/rapidwright/router/RoutingHeatMap.java
+++ b/src/com/xilinx/rapidwright/router/RoutingHeatMap.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.router;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.device.PIP;
+import com.xilinx.rapidwright.device.Tile;
+import com.xilinx.rapidwright.device.TileTypeEnum;
+
+/**
+ * Simple tool for generating a routing heat map as a CSV for a given DCP.
+ */
+public class RoutingHeatMap {
+
+    public static void main(String[] args) {
+        if (args.length != 2) {
+            System.out.println("USAGE: <routed_input.dcp> <output.csv>");
+            return;
+        }
+        Design d = Design.readCheckpoint(args[0]);
+        Map<Tile, Integer> heatMap = new HashMap<>();
+
+        for (Net n : d.getNets()) {
+            for (PIP p : n.getPIPs()) {
+                if (p.getTile().getTileTypeEnum() == TileTypeEnum.INT) {
+                    heatMap.merge(p.getTile(), 1, Integer::sum);
+                }
+            }
+        }
+
+        Tile[][] intTiles = d.getDevice().getTilesByRootName(TileTypeEnum.INT.name());
+
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(args[1]))) {
+            for (int i = 0; i < intTiles.length; i++) {
+                Tile[] intArray = intTiles[i];
+                for (int j = 0; j < intArray.length; j++) {
+                    Tile t = intArray[j];
+                    Integer val = heatMap.get(t);
+                    bw.write((val == null ? 0 : val) + ",");
+                }
+                bw.write("\n");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
A simple example application that reads in a DCP and outputs a CSV of the routing used in each INT tile of the design.  This can be imported into Excel and using the conditional coloring option by selecting all of the non-empty cells:

![image](https://github.com/user-attachments/assets/06240132-fc75-4e94-8cb8-756866bb72a0)

This can then generate a heat map of routing congestion:

![image](https://github.com/user-attachments/assets/2c1d14a7-a374-4db4-b151-118b5c46831b)

To run this example from scratch:

```
git clone -b routing_heat_map --recursive https://github.com/Xilinx/RapidWright.git
cd RapidWright
./gradlew compileJava
bin/rapidwright RoutingHeatMap test/RapidWrightDCP/picoblaze_2022.2.dcp picoblaze_2022.2.csv
```
Then you can open the csv in Excel or a similar tool.
