### PR TITLE
[EDIF] Fix Export of Single Bit Busses

### DIFF
--- a/src/com/xilinx/rapidwright/design/RTLStubGenerator.java
+++ b/src/com/xilinx/rapidwright/design/RTLStubGenerator.java
@@ -79,7 +79,7 @@ public class RTLStubGenerator {
             for (int i=0; i < ports.length; i++) {
                 EDIFPort p = ports[i];
                 String dir = p.getDirection().name().toLowerCase();
-                String range = p.getWidth() == 1 ? "" : "[" + p.getLeft() + ":" + p.getRight() +"]";
+                String range = p.isBus() ? "[" + p.getLeft() + ":" + p.getRight() + "]" : "";
                 out.write(("  " + dir + " " + range + p.getBusName() + ";\n").getBytes());
             }
             out.write("endmodule\n".getBytes());
@@ -101,7 +101,7 @@ public class RTLStubGenerator {
                 EDIFPort p = ports[i];
                 String dir = p.getDirection().name().toLowerCase().replace("put", "");
                 String type = " STD_LOGIC";
-                if (p.getWidth() > 1) {
+                if (p.isBus()) {
                     String endian = p.getLeft() > p.getRight() ? " downto " : " to ";
                     type = " STD_LOGIC_VECTOR ( " + p.getLeft() + endian + p.getRight() + " )";
                 }

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -259,14 +259,14 @@ public class EDIFPort extends EDIFPropertyObject {
     public void exportEDIF(OutputStream os, EDIFWriteLegalNameCache<?> cache, boolean stable) throws IOException{
         os.write(EXPORT_CONST_INDENT);
         os.write(EXPORT_CONST_PORT_BEGIN);
-        if (width > 1) os.write(EXPORT_CONST_ARRAY_BEGIN);
         if (isBus()) {
+            os.write(EXPORT_CONST_ARRAY_BEGIN);
             exportEDIFBusName(os, cache);
         } else {
             exportEDIFName(os, cache);
         }
 
-        if (width > 1) {
+        if (isBus()) {
             os.write(' ');
             os.write(Integer.toString(width).getBytes(StandardCharsets.UTF_8));
             os.write(')');


### PR DESCRIPTION
If a single-bit bus was declared, it was not being exported properly by the EDIF writer.  This attempts to fix this issue.