### PR TITLE
[EDIFNetlist] exportEDIF() to use getLibrariesInExportOrder()

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -802,14 +802,7 @@ public class EDIFNetlist extends EDIFName {
             }
             os.write(EXPORT_CONST_DOUBLE_CLOSE);
 
-            List<EDIFLibrary> librariesToWrite = new ArrayList<>();
-            librariesToWrite.add(getHDIPrimitivesLibrary());
-            for (EDIFLibrary lib : EDIFTools.sortIfStable(getLibrariesMap().values(), stable)) {
-                if (lib.isHDIPrimitivesLibrary()) {
-                    continue;
-                }
-                librariesToWrite.add(lib);
-            }
+            List<EDIFLibrary> librariesToWrite = getLibrariesInExportOrder();
 
             if (dos != null) {
                 Deque<Future<ParallelDCPInput>> streamFutures = new ArrayDeque<>();


### PR DESCRIPTION
`EDIFNetlist.getLibrariesInExportOrder()` is called by `BinaryEDIFWriter.writeBinaryEDIF()` already.

Without this, after generating an array of particular instances the output DCP contains an incorrectly ordered EDIF that does not get accepted by Vivado.