### PR TITLE
[DesignTools] Unroutes both CLK pins on a BRAM when requested

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -4356,7 +4356,7 @@ public class DesignTools {
             }
         }
 
-        // addProhibitConstraint(design, bels);
+        addProhibitConstraint(design, bels);
     }
 
     private static boolean isUsingSLICEGND(BELPin input, SiteInst si) {

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1595,7 +1595,7 @@ public class DesignTools {
                                     if (pin.getName().equals(otherPinName)) {
                                         otherPin = LUTTools.getLUTOutputPin(pin.getBEL());
                                     }
-                                    }
+                                }
                                 if (otherPin != null) {
                                     Net otherNet = siteInst.getNetFromSiteWire(otherPin.getSiteWireName());
                                     if (otherNet != null && net.getName().equals(otherNet.getName())) {
@@ -1612,41 +1612,40 @@ public class DesignTools {
                                                     siteInst.removeCell(otherCell.getBEL());
                                                     siteInst.unrouteIntraSiteNet(pin, pin);
                                                 }
-                                                }
-
                                             }
-                                        } else {
-                                            // site routing terminates here or is invalid
+
                                         }
-                                    }
-
-                                } else if (otherCell != cell && otherCell.getLogicalPinMapping(pin.getName()) != null) {
-                                    // Don't search farther, we don't need to unroute anything else
-                                    if (pin.isInput() && belPin.isInput()) {
-                                        internalSinks.add(pin);
                                     } else {
-                                        internalTerminals.add(pin);
+                                        // site routing terminates here or is invalid
                                     }
-
                                 }
-                            }
-                            break;
-                        }
-                        case RBEL: {
-                            // We found a routing BEL, follow its sitepip
-                            SitePIP sitePIP = siteInst.getUsedSitePIP(pin);
-                            if (sitePIP != null) {
-                                BELPin otherPin = pin.isInput() ? sitePIP.getOutputPin() : sitePIP.getInputPin();
-                                Net otherNet = siteInst.getNetFromSiteWire(otherPin.getSiteWireName());
-                                if (otherNet != null && net.getName().equals(otherNet.getName())) {
-                                    queue.add(otherPin);
-                                    unrouteSegment = otherPin;
+                            } else if (otherCell != cell && otherCell.getLogicalPinMapping(pin.getName()) != null) {
+                                // Don't search farther, we don't need to unroute anything else
+                                if (pin.isInput() && belPin.isInput()) {
+                                    internalSinks.add(pin);
                                 } else {
-                                    // site routing terminates here or is invalid
+                                    internalTerminals.add(pin);
                                 }
+
                             }
-                            break;
                         }
+                        break;
+                    }
+                    case RBEL: {
+                        // We found a routing BEL, follow its sitepip
+                        SitePIP sitePIP = siteInst.getUsedSitePIP(pin);
+                        if (sitePIP != null) {
+                            BELPin otherPin = pin.isInput() ? sitePIP.getOutputPin() : sitePIP.getInputPin();
+                            Net otherNet = siteInst.getNetFromSiteWire(otherPin.getSiteWireName());
+                            if (otherNet != null && net.getName().equals(otherNet.getName())) {
+                                queue.add(otherPin);
+                                unrouteSegment = otherPin;
+                            } else {
+                                // site routing terminates here or is invalid
+                            }
+                        }
+                        break;
+                    }
                     }
                     visited.add(pin);
                 }

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -1534,4 +1534,18 @@ public class TestDesignTools {
         String sitePinName = DesignTools.getRoutedSitePin(cell, net, ehpi.getPortInst().getName());
         Assertions.assertEquals(expected, sitePinName == null ? "null" : sitePinName);
     }
+
+    @Test
+    public void testUnrouteCellPinSiteRoutingBRAMClkPins() {
+        Design d = RapidWrightDCP.loadDCP("microblazeAndILA_3pblocks.dcp");
+        Cell c = d.getCell(
+                "base_mb_i/microblaze_0_local_memory/lmb_bram/U0/inst_blk_mem_gen/gnbram.gnative_mem_map_bmg.native_mem_map_blk_mem_gen/valid.cstr/ramloop[5].ram.r/prim_noinit.ram/DEVICE_8SERIES.WITH_BMM_INFO.TRUE_DP.SIMPLE_PRIM36.SERIES8_TDP_SP36_NO_ECC_ATTR.ram");
+
+        List<SitePinInst> unrouted = DesignTools.unrouteCellPinSiteRouting(c, "CLKARDCLK");
+        Assertions.assertEquals(2, unrouted.size());
+        for (SitePinInst p : unrouted) {
+            Assertions.assertTrue(p.getName().equals("CLKAU_X") || p.getName().equals("CLKAL_X"));
+        }
+
+    }
 }


### PR DESCRIPTION
When unrouting cell pins, the clock pins `CLKARDCLK` and `CLKBWRCLK` often fanout to two BEL pins  `CLKARDCLK=[CLKARDCLKU, CLKARDCLKL]`, for example.  This change ensures that both pins are unrouted when requested in `DesignTools.unrouteCellPinSiteRouting()`