### PR TITLE
[DesignTools] Ensure cell pin has a logical connection before attempting to unroute it

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1556,6 +1556,13 @@ public class DesignTools {
             Net net = siteInst.getNetFromSiteWire(belPin.getSiteWireName());
             if (net == null)
                 return Collections.emptyList();
+            else {
+                // Check if net is connected to logical cell
+                EDIFPortInst portInst = cell.getEDIFCellInst().getPortInst(logicalPinName);
+                if (portInst == null || portInst.getNet() == null) {
+                    return Collections.emptyList();
+                }
+            }
 
             List<String> sitePinNames = new ArrayList<>();
             List<BELPin> internalTerminals = new ArrayList<>();
@@ -4152,7 +4159,7 @@ public class DesignTools {
         lockRouting(design, false);
     }
 
-    /***
+    /**
      * Unroutes the GND net of a design and unroutes the site routing of any LUT GND
      * sources while leaving other site routing inputs intact.
      * 

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1558,7 +1558,8 @@ public class DesignTools {
                 return Collections.emptyList();
             else {
                 // Check if net is connected to logical cell
-                EDIFPortInst portInst = cell.getEDIFCellInst().getPortInst(logicalPinName);
+                EDIFCellInst cellInst = cell.getEDIFCellInst();
+                EDIFPortInst portInst = cellInst != null ? cellInst.getPortInst(logicalPinName) : null;
                 if (portInst == null || portInst.getNet() == null) {
                     return Collections.emptyList();
                 }

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -1325,9 +1325,7 @@ public class TestDesignTools {
         net5.connect(lut5, "O");
 
         Assertions.assertEquals(net5, carry5.getSiteInst().getNetFromSiteWire("D_O"));
-
         List<SitePinInst> pinsToRemove = DesignTools.unrouteCellPinSiteRouting(carry5, "S[3]");
-
         Assertions.assertEquals(0, pinsToRemove.size());
     }
 

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -1317,6 +1317,18 @@ public class TestDesignTools {
         Assertions.assertNull(si4.getNetFromSiteWire("FFMUXB1_OUT1"));
         Assertions.assertNull(si4.getUsedSitePIP("FFMUXB1"));
         Assertions.assertNull(si4.getNetFromSiteWire("B_O"));
+
+        // Test false connection when logical pin is not connected
+        Cell carry5 = design.createAndPlaceCell("carry5", Unisim.CARRY8, "SLICE_X0Y5/CARRY8");
+        Cell lut5 = design.createAndPlaceCell("lut5", Unisim.LUT1, "SLICE_X0Y5/D6LUT");
+        Net net5 = design.createNet("lut5_output");
+        net5.connect(lut5, "O");
+
+        Assertions.assertEquals(net5, carry5.getSiteInst().getNetFromSiteWire("D_O"));
+
+        List<SitePinInst> pinsToRemove = DesignTools.unrouteCellPinSiteRouting(carry5, "S[3]");
+
+        Assertions.assertEquals(0, pinsToRemove.size());
     }
 
     @Test


### PR DESCRIPTION
This is a less common case that can occur around a CARRY's inputs.  Previously, the method was mistaking the fact that a LUT output was simply driving an input pin on the CARRY that led to it being unrouted, but in reality, they are not connected.