### PR TITLE
[DesignTools] Fix routethru corner case in fullyUnplaceCellHelper()

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1300,9 +1300,10 @@ public class DesignTools {
                     Cell otherCell = siteInst.getCell(otherPin.getBEL());
                     if (otherCell == null) continue;
                     if (otherCell.isRoutethru()) {
+                        String otherCellType = otherCell.getType();
                         // Ensure the routethru cell is servicing this cell's connection
-                        if (otherCell.getType().equals(cell.getType())
-                                && pin.getName().equals(otherCell.getFirstPhysicalPinMapping().getFirst().getName())) {
+                        if (otherCellType.equals(Cell.FF_ROUTETHRU_TYPE) || (otherCellType.equals(cell.getType())
+                                && pin.getName().equals(otherCell.getFirstPhysicalPinMapping().getFirst().getName()))) {
                             // This will be handled outside of the loop in SiteInst.unrouteIntraSiteNet()
                             continue;
                         }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1300,8 +1300,12 @@ public class DesignTools {
                     Cell otherCell = siteInst.getCell(otherPin.getBEL());
                     if (otherCell == null) continue;
                     if (otherCell.isRoutethru()) {
-                        // This will be handled outside of the loop in SiteInst.unrouteIntraSiteNet()
-                        continue;
+                        // Ensure the routethru cell is servicing this cell's connection
+                        if (otherCell.getType().equals(cell.getType())
+                                && pin.getName().equals(otherCell.getFirstPhysicalPinMapping().getFirst().getName())) {
+                            // This will be handled outside of the loop in SiteInst.unrouteIntraSiteNet()
+                            continue;
+                        }
                     }
                     String logicalPinName = otherCell.getLogicalPinMapping(otherPin.getName());
                     if (logicalPinName == null) continue;

--- a/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
+++ b/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
@@ -622,7 +622,7 @@ public class TestECOTools {
         remove.add(lut1.getEDIFHierCellInst());
         ECOTools.removeCell(d, remove, null);
 
-        // Ensure the net stays routed after LUT1 is remove from A6LUT
+        // Ensure the net stays routed after LUT1 is removed from A6LUT
         Assertions.assertEquals(si.getNetFromSiteWire("H6"), routethruNet);
     }
 }


### PR DESCRIPTION
Discovered an issue when removing A6LUT cell (LUT1) before CARRY8 cell caused the site routing to be left in undesirable state to fully remove the routethru in H6LUT.  
![image](https://github.com/user-attachments/assets/b3b51214-edbc-48a3-bf5e-98d904c00d28)

This change checks to make sure when traversing other potential sinks that it only continues if the routethru cell encountered is servicing the currently explored cell's pin.  