### PR TITLE
[DesignTools] Handle case when Cell.getAllPhysicalPinMappings() is null

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1548,7 +1548,11 @@ public class DesignTools {
      */
     public static List<SitePinInst> unrouteCellPinSiteRouting(Cell cell, String logicalPinName) {
         List<SitePinInst> sitePinsToRemove = new ArrayList<>();
-        for (String physPinName : cell.getAllPhysicalPinMappings(logicalPinName)) {
+        Set<String> physPinNames = cell.getAllPhysicalPinMappings(logicalPinName);
+        if (physPinNames == null) {
+            physPinNames = Collections.singleton(cell.getDefaultPinMapping(logicalPinName));
+        }
+        for (String physPinName : physPinNames) {
             if (physPinName == null) {
                 physPinName = cell.getDefaultPinMapping(logicalPinName);
             }


### PR DESCRIPTION
Fixes a bug introduced in #1151.