### PR TITLE
Get Partial Routed Net Examples

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -50,6 +50,7 @@ import com.xilinx.rapidwright.edif.EDIFPropertyValue;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.examples.AddSubGenerator;
 import com.xilinx.rapidwright.examples.CopyMMCMCell;
+import com.xilinx.rapidwright.examples.CountRoutedNets;
 import com.xilinx.rapidwright.examples.CustomRouting;
 import com.xilinx.rapidwright.examples.DecomposeLUT;
 import com.xilinx.rapidwright.examples.ExampleNetlistCreation;
@@ -131,6 +132,7 @@ public class MainEntrypoint {
         addFunction("CheckAccuracyUsingGnlDesigns", CheckAccuracyUsingGnlDesigns::main);
         addFunction("CompareRouteStatusReports", CompareRouteStatusReports::main);
         addFunction("CopyMMCMCell", CopyMMCMCell::main);
+        addFunction("CountRoutedNets", CountRoutedNets::main);
         addFunction("CUFR", CUFR::main);
         addFunction("CustomRouting", CustomRouting::main);
         addFunction("DcpToInterchange", DcpToInterchange::main);

--- a/src/com/xilinx/rapidwright/examples/CountRoutedNets.java
+++ b/src/com/xilinx/rapidwright/examples/CountRoutedNets.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Coherent Ho, Synopsys, Inc.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.examples;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.DesignTools;
+import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SitePinInst;
+
+
+/**
+ * Simple tool for get the partially routed nets in a design.
+ */
+public class CountRoutedNets {
+
+    public static void main(String[] args) {
+        if (args.length != 1) {
+            System.out.println("Usage: <input DCP>");
+            return;
+        }
+
+        Design design = Design.readCheckpoint(args[0]);
+
+        DesignTools.makePhysNetNamesConsistent(design);
+        DesignTools.createMissingSitePinInsts(design);
+        DesignTools.updatePinsIsRouted(design);
+
+        int fullyRoutedNetCount = 0;
+        int partiallyRoutedNetCount = 0;
+
+        for (Net net : design.getNets()) {
+            if (!net.hasPIPs()) continue;
+
+            boolean isPartiallyRouted = false;
+            ArrayList<String> unroutedPins = new ArrayList<>();
+
+            for (SitePinInst pin : net.getPins()) {
+                if (!pin.isRouted() && !pin.isOutPin()) {
+                    unroutedPins.add(pin.getName());
+                    isPartiallyRouted = true;
+                }
+            }
+
+            if (!unroutedPins.isEmpty()) {
+                System.out.println("Net " + net.getName() + " has unrouted pins: " + unroutedPins);
+            }
+
+            if (isPartiallyRouted) {
+                partiallyRoutedNetCount++;
+            } else {
+                fullyRoutedNetCount++;
+            }
+        }
+
+        System.out.println("Fully routed nets: " + fullyRoutedNetCount);
+        System.out.println("Partially routed nets: " + partiallyRoutedNetCount);
+    }
+}


### PR DESCRIPTION
This simple tool discussed in [#1152] & [#1161] to help user get the partial routed net (site pin conflict) to further debug with the route fail case from Vivado.

The # of nets reported in RapidWright is the same as the tcl command ```report_route_status``` in Vivado.

1. Fully placed & route design:
![image](https://github.com/user-attachments/assets/fb77904a-e5db-48db-bdec-1cbf8658a8bd)
![image](https://github.com/user-attachments/assets/a5318561-5f6e-4e4e-bdf8-79d6306450e6)
The number match in the Vivado report_route_status # of routable nets

2. Route fail design:
![image](https://github.com/user-attachments/assets/65a35316-b173-4e57-ae46-88380243a2e2)
![image](https://github.com/user-attachments/assets/7d880d86-4a58-429a-b23e-6ea2ddf48206)
The code snippet in GetRouteNets.java will get the number of site pin conflict as report in # of nets with unrouted pins in Vivado report_route_status command and also show the detail info about the net and the pins.

Thanks

