### PR TITLE
[Actions] Update test-rapidwright-wrapper to setup-java@v4

### DIFF
--- a/.github/workflows/test-rapidwright-wrapper.yml
+++ b/.github/workflows/test-rapidwright-wrapper.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
 
       - name: Setup JDK 1.11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'


### PR DESCRIPTION
Same as for the `build` workflow, otherwise we were getting:
```
Error: Cache service responded with 422
```
failures.