### PR TITLE
[NetTools] Recognize BUFGCE_HDIO as a clock src site

### DIFF
--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -43,6 +43,7 @@ public class NetTools {
         clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFGCE_DIV);   // US/US+ and Versal
         clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFG_GT);      // US/US+ and Versal
         clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFG_PS);      // US/US+ and Versal
+        clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFGCE_HDIO);  // US+ and Versal
         clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFG_FABRIC);  // Versal
     }
 


### PR DESCRIPTION
First found in the Kria KR260.