### PR TITLE
[DesignTools] getAllRoutedSitePinsFromPhysicalPin() fix

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -2318,6 +2318,10 @@ public class DesignTools {
         SiteInst inst = cell.getSiteInst();
         List<String> sitePins = new ArrayList<>();
         Set<String> siteWires = new HashSet<>(inst.getSiteWiresFromNet(net));
+        if (net.isGNDNet()) {
+            // Since GND sitewires may be inverted for easier routing, also accept VCC sitewires
+            siteWires.addAll(inst.getSiteWiresFromNet(net.getDesign().getVccNet()));
+        }
         Queue<BELPin> queue = new LinkedList<>();
         queue.add(cell.getBEL().getPin(belPinName));
         while (!queue.isEmpty()) {

--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -43,6 +43,7 @@ public class NetTools {
         clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFGCE_DIV);   // US/US+ and Versal
         clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFG_GT);      // US/US+ and Versal
         clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFG_PS);      // US/US+ and Versal
+        clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFGCE_HDIO);  // US+ and Versal
         clkSrcSiteTypeEnums.add(SiteTypeEnum.BUFG_FABRIC);  // Versal
     }
 


### PR DESCRIPTION
To accept VCC sitewires when searching for GND sitewires, since the latter will invert to the former