### PR TITLE
[RouterHelper] Invert logical connection of LUT input pins

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -1,7 +1,7 @@
 /*
  *
  * Copyright (c) 2021 Ghent University.
- * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2025, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Yun Zhou, Ghent University.
@@ -430,8 +430,8 @@ public class RouterHelper {
                     EDIFHierPortInst ehpi = ehci.getPortInst(logicalPinName);
                     EDIFHierNet ehn = ehpi.getHierarchicalNet();
                     EDIFHierNet parentEhn = netlist.getParentNet(ehn);
-                    if (parentEhn == null || !parentEhn.getNet().isGND()) {
-                        throw new RuntimeException("ERROR: Cell " + cell.getName() + EDIFTools.EDIF_HIER_SEP + logicalPinName +
+                    if (parentEhn != null && !parentEhn.getNet().isGND()) {
+                        throw new RuntimeException("ERROR: Pin " + cell.getName() + EDIFTools.EDIF_HIER_SEP + logicalPinName +
                                 " is not connected to GND");
                     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -422,7 +422,7 @@ public class RouterHelper {
                     EDIFHierNet ehn = ehpi.getHierarchicalNet();
                     EDIFHierNet parentEhn = netlist.getParentNet(ehn);
                     if (parentEhn == null || !parentEhn.getNet().isGND()) {
-                        // Unable to be confirm (e.g. due to a partially encrypted design) that this
+                        // Unable to be sure (e.g. due to a partially encrypted design) that this
                         // pin is also logically connected to GND
                         continue nextSitePin;
                     }

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -431,7 +431,7 @@ public class RouterHelper {
                     if (cellBelPin == null) {
                         cellBelPin = cell.getBELPin(ehpi);
                     } else {
-                        assert(cellBelPin == cell.getBELPin(ehpi));
+                        assert(cellBelPin.getSiteWireIndex() == cell.getBELPin(ehpi).getSiteWireIndex());
                     }
                 }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -59,11 +59,11 @@ import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.device.SiteTypeEnum;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.TileTypeEnum;
-import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFHierNet;
+import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
-import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.timing.TimingEdge;
 import com.xilinx.rapidwright.timing.TimingManager;
@@ -425,10 +425,11 @@ public class RouterHelper {
                     String logicalPinName = cell.getLogicalPinMapping(physicalPinName);
 
                     // Check the logical pin connection
-                    EDIFCellInst eci = cell.getEDIFCellInst();
-                    EDIFPortInst epi = eci.getPortInst(logicalPinName);
-                    EDIFNet en = epi.getNet();
-                    if (!en.isGND()) {
+                    EDIFHierCellInst ehci = cell.getEDIFHierCellInst();
+                    EDIFHierPortInst ehpi = ehci.getPortInst(logicalPinName);
+                    EDIFHierNet ehn = ehpi.getHierarchicalNet();
+                    EDIFHierNet parentEhn = netlist.getParentNet(ehn);
+                    if (parentEhn == null || !parentEhn.getNet().isGND()) {
                         throw new RuntimeException("ERROR: Cell " + cell + EDIFTools.EDIF_HIER_SEP + logicalPinName +
                                 " is not connected to GND");
                     }
@@ -444,8 +445,8 @@ public class RouterHelper {
                             .replace("!!", "");
                     LUTTools.configureLUT(cell, newLutEquation);
 
-                    EDIFNet const1 = EDIFTools.getStaticNet(NetType.VCC, eci.getParentCell(), netlist);
-                    epi.setParentNet(const1);
+                    EDIFNet const1 = EDIFTools.getStaticNet(NetType.VCC, ehci.getParent().getCellType(), netlist);
+                    ehpi.getPortInst().setParentNet(const1);
                 }
             } else {
                 BELPin[] belPins = si.getSiteWirePins(siteWireName);

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -431,7 +431,7 @@ public class RouterHelper {
                     EDIFHierNet ehn = ehpi.getHierarchicalNet();
                     EDIFHierNet parentEhn = netlist.getParentNet(ehn);
                     if (parentEhn == null || !parentEhn.getNet().isGND()) {
-                        throw new RuntimeException("ERROR: Cell " + cell + EDIFTools.EDIF_HIER_SEP + logicalPinName +
+                        throw new RuntimeException("ERROR: Cell " + cell.getName() + EDIFTools.EDIF_HIER_SEP + logicalPinName +
                                 " is not connected to GND");
                     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -430,6 +430,8 @@ public class RouterHelper {
 
                     if (cellBelPin == null) {
                         cellBelPin = cell.getBELPin(ehpi);
+                    } else {
+                        assert(cellBelPin == cell.getBELPin(ehpi));
                     }
                 }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -451,7 +451,7 @@ public class RouterHelper {
                     EDIFHierCellInst ehci = cell.getEDIFHierCellInst();
                     EDIFHierPortInst ehpi = ehci.getPortInst(logicalPinName);
                     EDIFPortInst epi = ehpi.getPortInst();
-                    ehpi.getNet().removePortInst(epi);
+                    epi.getNet().removePortInst(epi);
 
                     EDIFNet const1 = EDIFTools.getStaticNet(NetType.VCC, ehci.getParent().getCellType(), netlist);
                     const1.addPortInst(epi);

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -397,6 +397,7 @@ public class RouterHelper {
                 }
 
                 String physicalPinName = "A" + spi.getName().charAt(1);
+                BELPin cellBelPin = null;
                 for (Cell cell : connectedCells) {
                     if (!LUTTools.isCellALUT(cell)) {
                         continue nextSitePin;
@@ -426,12 +427,16 @@ public class RouterHelper {
                         // pin is also logically connected to GND
                         continue nextSitePin;
                     }
+
+                    if (cellBelPin == null) {
+                        cellBelPin = cell.getBELPin(ehpi);
+                    }
                 }
 
                 toInvertPins.add(spi);
                 // Re-paint the intra-site routing from GND to VCC
                 // (no intra site routing will occur during Net.addPin() later)
-                si.routeIntraSiteNet(vccNet, spi.getBELPin(), spi.getBELPin());
+                si.routeIntraSiteNet(vccNet, spi.getBELPin(), cellBelPin);
 
                 for (Cell cell : connectedCells) {
                     String logicalPinName = cell.getLogicalPinMapping(physicalPinName);

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -64,6 +64,7 @@ import com.xilinx.rapidwright.edif.EDIFHierNet;
 import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.timing.TimingEdge;
 import com.xilinx.rapidwright.timing.TimingManager;
@@ -445,8 +446,11 @@ public class RouterHelper {
                             .replace("!!", "");
                     LUTTools.configureLUT(cell, newLutEquation);
 
+                    EDIFPortInst epi = ehpi.getPortInst();
+                    ehn.getNet().removePortInst(epi);
+
                     EDIFNet const1 = EDIFTools.getStaticNet(NetType.VCC, ehci.getParent().getCellType(), netlist);
-                    ehpi.getPortInst().setParentNet(const1);
+                    const1.addPortInst(epi);
                 }
             } else {
                 BELPin[] belPins = si.getSiteWirePins(siteWireName);


### PR DESCRIPTION
Where #910 inverted the physical connection of LUT input pins, the logical connection was not inverted.

Now fixed in this PR, with an updated test.