### PR TITLE
[EDIFTools] Enables downward hierarchy traversal when connecting logical nets

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFHierPortInst.java
@@ -72,6 +72,15 @@ public class EDIFHierPortInst {
     }
 
     /**
+     * Gets the full instance, including the instance of the EDIFPortInst.
+     * 
+     * @return
+     */
+    public EDIFHierCellInst getFullHierarchicalInst() {
+        return hierarchicalInst.getChild(portInst.getCellInst());
+    }
+
+    /**
      * Gets the net on the port inst
      * @return The net on the port inst
      */

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -532,9 +532,40 @@ public class EDIFTools {
             EDIFHierCellInst hierParentInst = hierPortInst.getHierarchicalInst();
             EDIFNet currNet = hierPortInst.getNet();
             if (currNet == null && !(hierParentInst.equals(commonAncestor) && hierPortInst == snk)) {
-                if (hierPortInst == src) createdSrcNet = true;
-                currNet = createUniqueNet(hierParentInst.getCellType(), newName);
-                currNet.addPortInst(hierPortInst.getPortInst());
+                // The snk pin is not connected to a net, let's start with the common ancestor
+                // and search downward
+                List<EDIFCellInst> sinkHier = snk.getFullHierarchicalInst().getFullHierarchy();
+                boolean foundPath = false;
+                do {
+                    foundPath = false;
+                    EDIFCellInst nextTargetInst = sinkHier.get(commonAncestor.getDepth());
+                    EDIFNet evalNet = finalSrc.getPortInst().getNet();
+                    if (evalNet != null) {
+                        for (EDIFPortInst pi : evalNet.getEDIFPortInstList()) {
+                            // Does this net connect to the next instance in hierarchy?
+                            if (pi.getCellInst() == nextTargetInst) {
+                                EDIFNet internalNet = pi.getInternalNet();
+                                // Is there a net inside the cell we can follow?
+                                if (internalNet != null) {
+                                    EDIFHierCellInst nextParent = finalSrc.getHierarchicalInst()
+                                            .getChild(pi.getCellInst());
+                                    EDIFPortInst internalPortInst = internalNet.getPortInst(null, pi.getName());
+                                    finalSrc = new EDIFHierPortInst(nextParent, internalPortInst);
+                                    commonAncestor = commonAncestor.getChild(pi.getCellInst());
+                                    foundPath = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                } while (foundPath && snk.getHierarchicalInst().getInst() != finalSrc.getHierarchicalInst().getInst());
+                if (!foundPath) {
+                    // We still need to create some ports to get us to the end
+                    if (hierPortInst == src)
+                        createdSrcNet = true;
+                    currNet = createUniqueNet(hierParentInst.getCellType(), newName);
+                    currNet.addPortInst(hierPortInst.getPortInst());
+                }
             }
 
             while (hierParentInst.getInst() != commonAncestor.getInst()) {


### PR DESCRIPTION
When making logical net connections through hierarchy, it was previously only searching up from the target pins to connect.  This resulted in may unnecessary port creations.  This change enables the downward traversal to reuse existing ports if the are logically connected nets are already there.

For example, this:
![image](https://github.com/user-attachments/assets/82a028d9-3229-473b-8ae2-e559156be22b)

becomes:
![image](https://github.com/user-attachments/assets/103ba540-32b9-4715-be26-ce8579b0ab5e)

