### PR TITLE
[DesignTools] fix infinite loop in updatePinsIsRouted

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -4476,8 +4476,14 @@ public class DesignTools {
             }
             queue.add(node);
         }
+        
+        HashSet<NetTools.NodeTree> visited = new HashSet<>();
         while (!queue.isEmpty()) {
             NetTools.NodeTree node = queue.poll();
+            if (visited.contains(node)) {
+                continue;
+            }
+            visited.add(node);
             SitePinInst spi = node2spi.remove(node);
             if (spi != null) {
                 spi.setRouted(true);

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1344,6 +1344,8 @@ public class EDIFTools {
             duplicateMultiInstCell(design, curr, toUniqueify);
         }
 
+        netlist.resetParentNetMap();
+
         return true;
     }
 


### PR DESCRIPTION
This is my trial fix to solve the infinite loop as mentioned in #1183, simply add a hashset to avoid the traversed nodes been pushed into queue again.