### PR TITLE
[DesignTools] updatePinIsRouted() to handle routing loops

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017-2022, Xilinx, Inc.
- * Copyright (c) 2022-2024, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2025, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -41,6 +41,7 @@ import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -4451,6 +4452,21 @@ public class DesignTools {
      * @return Number of unrouted sink pins on net.
      */
     public static int updatePinsIsRouted(Net net) {
+        return updatePinsIsRouted(net, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    /**
+     * Update the SitePinInst.isRouted() value of all pins on the given
+     * Net. A sink pin will be marked as being routed if it is reachable from the
+     * Net's source pins (or in the case of static nets, also from nodes
+     * tied to GND or VCC) when following the Net's PIPs.
+     * A source pin will be marked as being routed if it drives at least one PIP.
+     * @param net Net on which pins are to be updated.
+     * @param multiplyDrivenNodesVisited Set to be used to track multiply-driven nodes.
+     * @return Number of unrouted sink pins on net.
+     */
+    public static int updatePinsIsRouted(Net net,
+                                         Set<Node> multiplyDrivenNodesVisited) {
         int numUnroutedSinkPins = 0;
         for (SitePinInst spi : net.getPins()) {
             spi.setRouted(false);
@@ -4475,6 +4491,7 @@ public class DesignTools {
                 continue;
             }
             queue.add(node);
+            assert(!node.multiplyDriven);
         }
         while (!queue.isEmpty()) {
             NetTools.NodeTree node = queue.poll();
@@ -4486,7 +4503,13 @@ public class DesignTools {
                     numUnroutedSinkPins--;
                 }
             }
-            queue.addAll(node.fanouts);
+            for (NetTools.NodeTree fanout : node.fanouts) {
+                if (fanout.multiplyDriven && !multiplyDrivenNodesVisited.add(fanout)) {
+                    // fanout is a multiply-driven node that has already been visited, skip
+                    continue;
+                }
+                queue.add(fanout);
+            }
         }
         return numUnroutedSinkPins;
     }
@@ -4499,11 +4522,13 @@ public class DesignTools {
      */
     public static int updatePinsIsRouted(Design design) {
         int totalUnroutedSinkPins = 0;
+        Set<Node> multiplyDrivenNodesVisited = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Net net : design.getNets()) {
-            int numUnroutedSinkPins = updatePinsIsRouted(net);
+            int numUnroutedSinkPins = updatePinsIsRouted(net, multiplyDrivenNodesVisited);
             if (!DesignTools.isNetDrivenByHierPort(net)) {
                 totalUnroutedSinkPins += numUnroutedSinkPins;
             }
+            multiplyDrivenNodesVisited.clear();
         }
         return totalUnroutedSinkPins;
     }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -4466,7 +4466,7 @@ public class DesignTools {
      * @return Number of unrouted sink pins on net.
      */
     public static int updatePinsIsRouted(Net net,
-                                         Set<Node> multiplyDrivenNodesVisited) {
+                                         Set<NetTools.NodeTree> multiplyDrivenNodesVisited) {
         int numUnroutedSinkPins = 0;
         for (SitePinInst spi : net.getPins()) {
             spi.setRouted(false);
@@ -4522,7 +4522,7 @@ public class DesignTools {
      */
     public static int updatePinsIsRouted(Design design) {
         int totalUnroutedSinkPins = 0;
-        Set<Node> multiplyDrivenNodesVisited = Collections.newSetFromMap(new IdentityHashMap<>());
+        Set<NetTools.NodeTree> multiplyDrivenNodesVisited = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Net net : design.getNets()) {
             int numUnroutedSinkPins = updatePinsIsRouted(net, multiplyDrivenNodesVisited);
             if (!DesignTools.isNetDrivenByHierPort(net)) {

--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Wenhao Lin, Advanced Micro Devices, Inc.
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +61,7 @@ public class NetTools {
         public NodeTree(Node node) {
             super(node);
         }
+        public boolean multiplyDriven = false;
 
         public void addFanout(NodeTree node) {
             if (fanouts.isEmpty()) {
@@ -73,17 +75,33 @@ public class NetTools {
                                  boolean branchStart,
                                  boolean branchEndIfNoFanouts,
                                  boolean subTreeEndIfNoFanouts) {
+            buildString(sb, subtreeStart, branchStart, branchEndIfNoFanouts, subTreeEndIfNoFanouts,
+                    Collections.newSetFromMap(new IdentityHashMap<>()));
+        }
+
+
+        private void buildString(StringBuilder sb,
+                                 boolean subtreeStart,
+                                 boolean branchStart,
+                                 boolean branchEndIfNoFanouts,
+                                 boolean subTreeEndIfNoFanouts,
+                                 Set<Node> multiplyDrivenNodesVisited) {
             // Adopt the same spacing as Vivado's report_route_status
             sb.append("    ");
             sb.append(subtreeStart ? "[" : " ");
             sb.append(branchStart ? "{" : " ");
             sb.append("   ");
-            boolean branchEnd = branchEndIfNoFanouts && fanouts.isEmpty();
+            boolean notFirstTimeVisitingThisMultiplyDrivenNode = multiplyDriven && !multiplyDrivenNodesVisited.add(this);
+            boolean branchEnd = (branchEndIfNoFanouts && fanouts.isEmpty()) || notFirstTimeVisitingThisMultiplyDrivenNode;
             sb.append(branchEnd ? "}" : " ");
             boolean subtreeEnd = subTreeEndIfNoFanouts && branchEnd;
             sb.append(subtreeEnd ? "]" : " ");
             sb.append(String.format("  %30s", super.toString()));
             sb.append("\n");
+
+            if (notFirstTimeVisitingThisMultiplyDrivenNode) {
+                return;
+            }
 
             subtreeStart = false;
             for (int i = 0; i < fanouts.size(); i++) {
@@ -92,7 +110,8 @@ public class NetTools {
                 branchStart = !lastFanout && (fanouts.size() > 1);
                 branchEndIfNoFanouts = lastFanout || branchStart;
                 fanout.buildString(sb, subtreeStart, branchStart, branchEndIfNoFanouts,
-                        subTreeEndIfNoFanouts && !branchStart && lastFanout);
+                        subTreeEndIfNoFanouts && !branchStart && lastFanout,
+                        multiplyDrivenNodesVisited);
             }
         }
 
@@ -110,9 +129,10 @@ public class NetTools {
 
     /**
      * Compute the node routing tree of the given Net by examining its PIPs.
-     * Note that this method: (a) assumes that no loops are present, (b) only discovers subtrees that start at an
-     * output SitePinInst or a node tied to VCC/GND (i.e. gaps and islands will be ignored).
-     * @param net Net to analyze
+     * Note that this method only discovers subtrees that start at an output SitePinInst or a node tied to VCC/GND
+     * (i.e. gaps and islands will be ignored).
+     * Nodes that are multiply-driven (indicative of routing loops) will have their NodeTree.multiplyDriven flag set.
+     * @param net Net to analyze.
      * @return A list of NodeTree objects, corresponding to the root of each subtree.
      */
     public static List<NodeTree> getNodeTrees(Net net) {
@@ -124,7 +144,15 @@ public class NetTools {
             }
             boolean isReversed = pip.isReversed();
             NodeTree startNode = nodeMap.computeIfAbsent(isReversed ? pip.getEndNode() : pip.getStartNode(), NodeTree::new);
-            NodeTree endNode = nodeMap.computeIfAbsent(isReversed ? pip.getStartNode() : pip.getEndNode(), NodeTree::new);
+            NodeTree endNode = nodeMap.compute(isReversed ? pip.getStartNode() : pip.getEndNode(), (k,v) -> {
+                if (v == null) {
+                    v = new NodeTree(k);
+                } else {
+                    // This node already exists in our map thus must be multiply-driven
+                    v.multiplyDriven = true;
+                }
+                return v;
+            });
             startNode.addFanout(endNode);
             if (!pip.isBidirectional()) {
                 if ((net.getType() == NetType.GND && startNode.isTiedToGnd()) ||

--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -85,7 +85,7 @@ public class NetTools {
                                  boolean branchStart,
                                  boolean branchEndIfNoFanouts,
                                  boolean subTreeEndIfNoFanouts,
-                                 Set<Node> multiplyDrivenNodesVisited) {
+                                 Set<NetTools.NodeTree> multiplyDrivenNodesVisited) {
             // Adopt the same spacing as Vivado's report_route_status
             sb.append("    ");
             sb.append(subtreeStart ? "[" : " ");

--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -79,7 +79,6 @@ public class NetTools {
                     Collections.newSetFromMap(new IdentityHashMap<>()));
         }
 
-
         private void buildString(StringBuilder sb,
                                  boolean subtreeStart,
                                  boolean branchStart,

--- a/test/src/com/xilinx/rapidwright/design/TestNetTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestNetTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Wenhao Lin, AMD Research and Advanced Development.
@@ -21,9 +21,14 @@
  */
 package com.xilinx.rapidwright.design;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Node;
+import com.xilinx.rapidwright.device.PIP;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -119,73 +124,76 @@ public class TestNetTools {
         Net net = design.getNet("processor/data_path_loop[0].output_data.sy_kk_mux_lut/O5");
         List<NetTools.NodeTree> trees = NetTools.getNodeTrees(net);
         Assertions.assertEquals(1, trees.size());
-
-        // Taken directly from Vivado's report_route_status
-        String[] expected = new String(
+        assertEqualToVivadoReportRouteStatus(trees.get(0),
+                // Taken directly from Vivado's report_route_status
                 "    [{       CLEL_R_X10Y236/CLE_CLE_L_SITE_0_AMUX (65535) \n" +
-                        "     {       INT_X10Y236/INT_NODE_SDQ_27_INT_OUT1 ( 3) INT_X10Y236/INT.LOGIC_OUTS_E21->INT_NODE_SDQ_27_INT_OUT1\n" +
-                        "                     INT_X10Y236/SS1_E_BEG5 ( 0) INT_X10Y236/INT.INT_NODE_SDQ_27_INT_OUT1->>SS1_E_BEG5\n" +
-                        "     {       INT_X10Y235/INT_NODE_IMUX_16_INT_OUT0 ( 5) INT_X10Y235/INT.SS1_E_END5->>INT_NODE_IMUX_16_INT_OUT0\n" +
-                        "                     INT_X10Y235/BYPASS_E10 ( 3) INT_X10Y235/INT.INT_NODE_IMUX_16_INT_OUT0->>BYPASS_E10\n" +
-                        "     {       INT_X10Y235/INT_NODE_IMUX_9_INT_OUT1 ( 0) INT_X10Y235/INT.BYPASS_E10->>INT_NODE_IMUX_9_INT_OUT1\n" +
-                        "         }             INT_X10Y235/IMUX_E23 ( 6) INT_X10Y235/INT.INT_NODE_IMUX_9_INT_OUT1->>IMUX_E23\n" +
-                        "             INT_X10Y235/INT_NODE_IMUX_8_INT_OUT1 ( 0) INT_X10Y235/INT.BYPASS_E10->>INT_NODE_IMUX_8_INT_OUT1\n" +
-                        "         }             INT_X10Y235/IMUX_E26 ( 6) INT_X10Y235/INT.INT_NODE_IMUX_8_INT_OUT1->>IMUX_E26\n" +
-                        "     {       INT_X10Y235/INT_NODE_SDQ_28_INT_OUT0 ( 2) INT_X10Y235/INT.SS1_E_END5->INT_NODE_SDQ_28_INT_OUT0\n" +
-                        "                     INT_X10Y235/EE1_E_BEG4 ( 3) INT_X10Y235/INT.INT_NODE_SDQ_28_INT_OUT0->>EE1_E_BEG4\n" +
-                        "             INT_X11Y235/INT_NODE_IMUX_48_INT_OUT0 ( 1) INT_X11Y235/INT.EE1_E_END4->>INT_NODE_IMUX_48_INT_OUT0\n" +
-                        "         }             INT_X11Y235/IMUX_W37 ( 3) INT_X11Y235/INT.INT_NODE_IMUX_48_INT_OUT0->>IMUX_W37\n" +
-                        "             INT_X10Y235/INT_NODE_IMUX_16_INT_OUT1 ( 5) INT_X10Y235/INT.SS1_E_END5->>INT_NODE_IMUX_16_INT_OUT1\n" +
-                        "     {   }             INT_X10Y235/IMUX_E30 ( 3) INT_X10Y235/INT.INT_NODE_IMUX_16_INT_OUT1->>IMUX_E30\n" +
-                        "         }             INT_X10Y235/IMUX_E31 ( 3) INT_X10Y235/INT.INT_NODE_IMUX_16_INT_OUT1->>IMUX_E31\n" +
-                        "             INT_X10Y236/INT_NODE_SDQ_29_INT_OUT1 ( 1) INT_X10Y236/INT.LOGIC_OUTS_E21->INT_NODE_SDQ_29_INT_OUT1\n" +
-                        "     {               INT_X10Y236/NN2_E_BEG5 ( 0) INT_X10Y236/INT.INT_NODE_SDQ_29_INT_OUT1->>NN2_E_BEG5\n" +
-                        "     {       INT_X10Y238/INT_NODE_IMUX_18_INT_OUT1 ( 4) INT_X10Y238/INT.NN2_E_END5->>INT_NODE_IMUX_18_INT_OUT1\n" +
-                        "         }             INT_X10Y238/IMUX_E10 ( 4) INT_X10Y238/INT.INT_NODE_IMUX_18_INT_OUT1->>IMUX_E10\n" +
-                        "     {       INT_X10Y238/INT_NODE_SDQ_30_INT_OUT1 ( 2) INT_X10Y238/INT.NN2_E_END5->INT_NODE_SDQ_30_INT_OUT1\n" +
-                        "                     INT_X10Y238/EE1_E_BEG5 ( 0) INT_X10Y238/INT.INT_NODE_SDQ_30_INT_OUT1->>EE1_E_BEG5\n" +
-                        "     {       INT_X11Y238/INT_NODE_SDQ_79_INT_OUT0 ( 0) INT_X11Y238/INT.EE1_E_END5->INT_NODE_SDQ_79_INT_OUT0\n" +
-                        "                     INT_X11Y238/SS1_W_BEG5 ( 2) INT_X11Y238/INT.INT_NODE_SDQ_79_INT_OUT0->>SS1_W_BEG5\n" +
-                        "             INT_X11Y237/INT_NODE_IMUX_49_INT_OUT1 ( 4) INT_X11Y237/INT.SS1_W_END5->>INT_NODE_IMUX_49_INT_OUT1\n" +
-                        "                      INT_X11Y237/BYPASS_W8 ( 5) INT_X11Y237/INT.INT_NODE_IMUX_49_INT_OUT1->>BYPASS_W8\n" +
-                        "     {       INT_X11Y237/INT_NODE_IMUX_36_INT_OUT0 ( 0) INT_X11Y237/INT.BYPASS_W8->>INT_NODE_IMUX_36_INT_OUT0\n" +
-                        "         }              INT_X11Y237/IMUX_W6 ( 2) INT_X11Y237/INT.INT_NODE_IMUX_36_INT_OUT0->>IMUX_W6\n" +
-                        "     {       INT_X11Y237/INT_NODE_IMUX_37_INT_OUT0 ( 0) INT_X11Y237/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8\n" +
-                        "         }              INT_X11Y237/IMUX_W7 ( 1) INT_X11Y237/INT.INT_NODE_IMUX_37_INT_OUT0->>IMUX_W7\n" +
-                        "             INT_X11Y237/INT_NODE_IMUX_36_INT_OUT1 ( 0) INT_X11Y237/INT.BYPASS_W8->>INT_NODE_IMUX_36_INT_OUT1\n" +
-                        "     {   }              INT_X11Y237/IMUX_W2 ( 4) INT_X11Y237/INT.INT_NODE_IMUX_36_INT_OUT1->>IMUX_W2\n" +
-                        "     {   }              INT_X11Y237/IMUX_W3 ( 2) INT_X11Y237/INT.INT_NODE_IMUX_36_INT_OUT1->>IMUX_W3\n" +
-                        "                 INT_X11Y237/BOUNCE_W_2_FT1 ( 4) INT_X11Y237/INT.INT_NODE_IMUX_36_INT_OUT1->>BOUNCE_W_2_FT1\n" +
-                        "                 INT_X11Y236/INODE_W_58_FT0 ( 0) INT_X11Y236/INT.BOUNCE_W_BLS_2_FT0->>INODE_W_58_FT0\n" +
-                        "     {   }              INT_X11Y237/IMUX_W0 ( 4) INT_X11Y237/INT.INODE_W_BLN_58_FT1->>IMUX_W0\n" +
-                        "         }              INT_X11Y237/IMUX_W1 ( 2) INT_X11Y237/INT.INODE_W_BLN_58_FT1->>IMUX_W1\n" +
-                        "             INT_X11Y238/INT_NODE_IMUX_50_INT_OUT1 ( 1) INT_X11Y238/INT.EE1_E_END5->>INT_NODE_IMUX_50_INT_OUT1\n" +
-                        "     {               INT_X11Y238/BYPASS_W10 ( 4) INT_X11Y238/INT.INT_NODE_IMUX_50_INT_OUT1->>BYPASS_W10\n" +
-                        "             INT_X11Y238/INT_NODE_IMUX_40_INT_OUT1 ( 0) INT_X11Y238/INT.BYPASS_W10->>INT_NODE_IMUX_40_INT_OUT1\n" +
-                        "         }             INT_X11Y238/IMUX_W26 ( 4) INT_X11Y238/INT.INT_NODE_IMUX_40_INT_OUT1->>IMUX_W26\n" +
-                        "         }             INT_X11Y238/IMUX_W36 ( 4) INT_X11Y238/INT.INT_NODE_IMUX_50_INT_OUT1->>IMUX_W36\n" +
-                        "             INT_X10Y238/INT_NODE_SDQ_30_INT_OUT0 ( 3) INT_X10Y238/INT.NN2_E_END5->INT_NODE_SDQ_30_INT_OUT0\n" +
-                        "                     INT_X10Y238/NN1_E_BEG5 ( 2) INT_X10Y238/INT.INT_NODE_SDQ_30_INT_OUT0->>NN1_E_BEG5\n" +
-                        "             INT_X10Y239/INT_NODE_SDQ_30_INT_OUT0 ( 2) INT_X10Y239/INT.NN1_E_END5->INT_NODE_SDQ_30_INT_OUT0\n" +
-                        "                     INT_X10Y239/EE2_E_BEG5 ( 3) INT_X10Y239/INT.INT_NODE_SDQ_30_INT_OUT0->>EE2_E_BEG5\n" +
-                        "             INT_X11Y239/INT_NODE_SDQ_27_INT_OUT0 ( 0) INT_X11Y239/INT.EE2_E_END5->INT_NODE_SDQ_27_INT_OUT0\n" +
-                        "             INT_X11Y239/INT_INT_SDQ_74_INT_OUT0 ( 2) INT_X11Y239/INT.INT_NODE_SDQ_27_INT_OUT0->>INT_INT_SDQ_74_INT_OUT0\n" +
-                        "             INT_X11Y239/INT_NODE_SDQ_73_INT_OUT0 ( 0) INT_X11Y239/INT.INT_INT_SDQ_74_INT_OUT0->INT_NODE_SDQ_73_INT_OUT0\n" +
-                        "                     INT_X11Y239/SS1_W_BEG4 ( 3) INT_X11Y239/INT.INT_NODE_SDQ_73_INT_OUT0->>SS1_W_BEG4\n" +
-                        "             INT_X11Y238/INT_NODE_SDQ_72_INT_OUT0 ( 2) INT_X11Y238/INT.SS1_W_END4->INT_NODE_SDQ_72_INT_OUT0\n" +
-                        "                     INT_X11Y238/SS1_W_BEG4 ( 2) INT_X11Y238/INT.INT_NODE_SDQ_72_INT_OUT0->>SS1_W_BEG4\n" +
-                        "             INT_X11Y237/INT_NODE_IMUX_46_INT_OUT0 ( 4) INT_X11Y237/INT.SS1_W_END4->>INT_NODE_IMUX_46_INT_OUT0\n" +
-                        "     {   }             INT_X11Y237/IMUX_W10 ( 2) INT_X11Y237/INT.INT_NODE_IMUX_46_INT_OUT0->>IMUX_W10\n" +
-                        "         }             INT_X11Y237/IMUX_W11 ( 2) INT_X11Y237/INT.INT_NODE_IMUX_46_INT_OUT0->>IMUX_W11\n" +
-                        "             INT_X10Y236/INT_INT_SDQ_34_INT_OUT1 ( 0) INT_X10Y236/INT.INT_NODE_SDQ_29_INT_OUT1->>INT_INT_SDQ_34_INT_OUT1\n" +
-                        "             INT_X10Y236/INT_NODE_SDQ_82_INT_OUT0 ( 0) INT_X10Y236/INT.INT_INT_SDQ_34_INT_OUT1->INT_NODE_SDQ_82_INT_OUT0\n" +
-                        "             INT_X10Y236/INT_INT_SDQ_6_INT_OUT0 ( 2) INT_X10Y236/INT.INT_NODE_SDQ_82_INT_OUT0->>INT_INT_SDQ_6_INT_OUT0\n" +
-                        "     {       INT_X10Y236/INT_NODE_GLOBAL_6_INT_OUT1 ( 4) INT_X10Y236/INT.INT_INT_SDQ_6_INT_OUT0->>INT_NODE_GLOBAL_6_INT_OUT1\n" +
-                        "             INT_X10Y236/INT_NODE_IMUX_9_INT_OUT0 ( 2) INT_X10Y236/INT.INT_NODE_GLOBAL_6_INT_OUT1->>INT_NODE_IMUX_9_INT_OUT0\n" +
-                        "         }             INT_X10Y236/IMUX_E30 ( 6) INT_X10Y236/INT.INT_NODE_IMUX_9_INT_OUT0->>IMUX_E30\n" +
-                        "             INT_X10Y236/INT_NODE_IMUX_18_INT_OUT1 ( 1) INT_X10Y236/INT.INT_INT_SDQ_6_INT_OUT0->>INT_NODE_IMUX_18_INT_OUT1\n" +
-                        "         }]            INT_X10Y236/IMUX_E35 ( 3) INT_X10Y236/INT.INT_NODE_IMUX_18_INT_OUT1->>IMUX_E35\n").split("\n");
-        String[] actual = trees.get(0).toString().split("\n");
+                "     {       INT_X10Y236/INT_NODE_SDQ_27_INT_OUT1 ( 3) INT_X10Y236/INT.LOGIC_OUTS_E21->INT_NODE_SDQ_27_INT_OUT1\n" +
+                "                     INT_X10Y236/SS1_E_BEG5 ( 0) INT_X10Y236/INT.INT_NODE_SDQ_27_INT_OUT1->>SS1_E_BEG5\n" +
+                "     {       INT_X10Y235/INT_NODE_IMUX_16_INT_OUT0 ( 5) INT_X10Y235/INT.SS1_E_END5->>INT_NODE_IMUX_16_INT_OUT0\n" +
+                "                     INT_X10Y235/BYPASS_E10 ( 3) INT_X10Y235/INT.INT_NODE_IMUX_16_INT_OUT0->>BYPASS_E10\n" +
+                "     {       INT_X10Y235/INT_NODE_IMUX_9_INT_OUT1 ( 0) INT_X10Y235/INT.BYPASS_E10->>INT_NODE_IMUX_9_INT_OUT1\n" +
+                "         }             INT_X10Y235/IMUX_E23 ( 6) INT_X10Y235/INT.INT_NODE_IMUX_9_INT_OUT1->>IMUX_E23\n" +
+                "             INT_X10Y235/INT_NODE_IMUX_8_INT_OUT1 ( 0) INT_X10Y235/INT.BYPASS_E10->>INT_NODE_IMUX_8_INT_OUT1\n" +
+                "         }             INT_X10Y235/IMUX_E26 ( 6) INT_X10Y235/INT.INT_NODE_IMUX_8_INT_OUT1->>IMUX_E26\n" +
+                "     {       INT_X10Y235/INT_NODE_SDQ_28_INT_OUT0 ( 2) INT_X10Y235/INT.SS1_E_END5->INT_NODE_SDQ_28_INT_OUT0\n" +
+                "                     INT_X10Y235/EE1_E_BEG4 ( 3) INT_X10Y235/INT.INT_NODE_SDQ_28_INT_OUT0->>EE1_E_BEG4\n" +
+                "             INT_X11Y235/INT_NODE_IMUX_48_INT_OUT0 ( 1) INT_X11Y235/INT.EE1_E_END4->>INT_NODE_IMUX_48_INT_OUT0\n" +
+                "         }             INT_X11Y235/IMUX_W37 ( 3) INT_X11Y235/INT.INT_NODE_IMUX_48_INT_OUT0->>IMUX_W37\n" +
+                "             INT_X10Y235/INT_NODE_IMUX_16_INT_OUT1 ( 5) INT_X10Y235/INT.SS1_E_END5->>INT_NODE_IMUX_16_INT_OUT1\n" +
+                "     {   }             INT_X10Y235/IMUX_E30 ( 3) INT_X10Y235/INT.INT_NODE_IMUX_16_INT_OUT1->>IMUX_E30\n" +
+                "         }             INT_X10Y235/IMUX_E31 ( 3) INT_X10Y235/INT.INT_NODE_IMUX_16_INT_OUT1->>IMUX_E31\n" +
+                "             INT_X10Y236/INT_NODE_SDQ_29_INT_OUT1 ( 1) INT_X10Y236/INT.LOGIC_OUTS_E21->INT_NODE_SDQ_29_INT_OUT1\n" +
+                "     {               INT_X10Y236/NN2_E_BEG5 ( 0) INT_X10Y236/INT.INT_NODE_SDQ_29_INT_OUT1->>NN2_E_BEG5\n" +
+                "     {       INT_X10Y238/INT_NODE_IMUX_18_INT_OUT1 ( 4) INT_X10Y238/INT.NN2_E_END5->>INT_NODE_IMUX_18_INT_OUT1\n" +
+                "         }             INT_X10Y238/IMUX_E10 ( 4) INT_X10Y238/INT.INT_NODE_IMUX_18_INT_OUT1->>IMUX_E10\n" +
+                "     {       INT_X10Y238/INT_NODE_SDQ_30_INT_OUT1 ( 2) INT_X10Y238/INT.NN2_E_END5->INT_NODE_SDQ_30_INT_OUT1\n" +
+                "                     INT_X10Y238/EE1_E_BEG5 ( 0) INT_X10Y238/INT.INT_NODE_SDQ_30_INT_OUT1->>EE1_E_BEG5\n" +
+                "     {       INT_X11Y238/INT_NODE_SDQ_79_INT_OUT0 ( 0) INT_X11Y238/INT.EE1_E_END5->INT_NODE_SDQ_79_INT_OUT0\n" +
+                "                     INT_X11Y238/SS1_W_BEG5 ( 2) INT_X11Y238/INT.INT_NODE_SDQ_79_INT_OUT0->>SS1_W_BEG5\n" +
+                "             INT_X11Y237/INT_NODE_IMUX_49_INT_OUT1 ( 4) INT_X11Y237/INT.SS1_W_END5->>INT_NODE_IMUX_49_INT_OUT1\n" +
+                "                      INT_X11Y237/BYPASS_W8 ( 5) INT_X11Y237/INT.INT_NODE_IMUX_49_INT_OUT1->>BYPASS_W8\n" +
+                "     {       INT_X11Y237/INT_NODE_IMUX_36_INT_OUT0 ( 0) INT_X11Y237/INT.BYPASS_W8->>INT_NODE_IMUX_36_INT_OUT0\n" +
+                "         }              INT_X11Y237/IMUX_W6 ( 2) INT_X11Y237/INT.INT_NODE_IMUX_36_INT_OUT0->>IMUX_W6\n" +
+                "     {       INT_X11Y237/INT_NODE_IMUX_37_INT_OUT0 ( 0) INT_X11Y237/INT.INT_NODE_IMUX_37_INT_OUT0<<->>BYPASS_W8\n" +
+                "         }              INT_X11Y237/IMUX_W7 ( 1) INT_X11Y237/INT.INT_NODE_IMUX_37_INT_OUT0->>IMUX_W7\n" +
+                "             INT_X11Y237/INT_NODE_IMUX_36_INT_OUT1 ( 0) INT_X11Y237/INT.BYPASS_W8->>INT_NODE_IMUX_36_INT_OUT1\n" +
+                "     {   }              INT_X11Y237/IMUX_W2 ( 4) INT_X11Y237/INT.INT_NODE_IMUX_36_INT_OUT1->>IMUX_W2\n" +
+                "     {   }              INT_X11Y237/IMUX_W3 ( 2) INT_X11Y237/INT.INT_NODE_IMUX_36_INT_OUT1->>IMUX_W3\n" +
+                "                 INT_X11Y237/BOUNCE_W_2_FT1 ( 4) INT_X11Y237/INT.INT_NODE_IMUX_36_INT_OUT1->>BOUNCE_W_2_FT1\n" +
+                "                 INT_X11Y236/INODE_W_58_FT0 ( 0) INT_X11Y236/INT.BOUNCE_W_BLS_2_FT0->>INODE_W_58_FT0\n" +
+                "     {   }              INT_X11Y237/IMUX_W0 ( 4) INT_X11Y237/INT.INODE_W_BLN_58_FT1->>IMUX_W0\n" +
+                "         }              INT_X11Y237/IMUX_W1 ( 2) INT_X11Y237/INT.INODE_W_BLN_58_FT1->>IMUX_W1\n" +
+                "             INT_X11Y238/INT_NODE_IMUX_50_INT_OUT1 ( 1) INT_X11Y238/INT.EE1_E_END5->>INT_NODE_IMUX_50_INT_OUT1\n" +
+                "     {               INT_X11Y238/BYPASS_W10 ( 4) INT_X11Y238/INT.INT_NODE_IMUX_50_INT_OUT1->>BYPASS_W10\n" +
+                "             INT_X11Y238/INT_NODE_IMUX_40_INT_OUT1 ( 0) INT_X11Y238/INT.BYPASS_W10->>INT_NODE_IMUX_40_INT_OUT1\n" +
+                "         }             INT_X11Y238/IMUX_W26 ( 4) INT_X11Y238/INT.INT_NODE_IMUX_40_INT_OUT1->>IMUX_W26\n" +
+                "         }             INT_X11Y238/IMUX_W36 ( 4) INT_X11Y238/INT.INT_NODE_IMUX_50_INT_OUT1->>IMUX_W36\n" +
+                "             INT_X10Y238/INT_NODE_SDQ_30_INT_OUT0 ( 3) INT_X10Y238/INT.NN2_E_END5->INT_NODE_SDQ_30_INT_OUT0\n" +
+                "                     INT_X10Y238/NN1_E_BEG5 ( 2) INT_X10Y238/INT.INT_NODE_SDQ_30_INT_OUT0->>NN1_E_BEG5\n" +
+                "             INT_X10Y239/INT_NODE_SDQ_30_INT_OUT0 ( 2) INT_X10Y239/INT.NN1_E_END5->INT_NODE_SDQ_30_INT_OUT0\n" +
+                "                     INT_X10Y239/EE2_E_BEG5 ( 3) INT_X10Y239/INT.INT_NODE_SDQ_30_INT_OUT0->>EE2_E_BEG5\n" +
+                "             INT_X11Y239/INT_NODE_SDQ_27_INT_OUT0 ( 0) INT_X11Y239/INT.EE2_E_END5->INT_NODE_SDQ_27_INT_OUT0\n" +
+                "             INT_X11Y239/INT_INT_SDQ_74_INT_OUT0 ( 2) INT_X11Y239/INT.INT_NODE_SDQ_27_INT_OUT0->>INT_INT_SDQ_74_INT_OUT0\n" +
+                "             INT_X11Y239/INT_NODE_SDQ_73_INT_OUT0 ( 0) INT_X11Y239/INT.INT_INT_SDQ_74_INT_OUT0->INT_NODE_SDQ_73_INT_OUT0\n" +
+                "                     INT_X11Y239/SS1_W_BEG4 ( 3) INT_X11Y239/INT.INT_NODE_SDQ_73_INT_OUT0->>SS1_W_BEG4\n" +
+                "             INT_X11Y238/INT_NODE_SDQ_72_INT_OUT0 ( 2) INT_X11Y238/INT.SS1_W_END4->INT_NODE_SDQ_72_INT_OUT0\n" +
+                "                     INT_X11Y238/SS1_W_BEG4 ( 2) INT_X11Y238/INT.INT_NODE_SDQ_72_INT_OUT0->>SS1_W_BEG4\n" +
+                "             INT_X11Y237/INT_NODE_IMUX_46_INT_OUT0 ( 4) INT_X11Y237/INT.SS1_W_END4->>INT_NODE_IMUX_46_INT_OUT0\n" +
+                "     {   }             INT_X11Y237/IMUX_W10 ( 2) INT_X11Y237/INT.INT_NODE_IMUX_46_INT_OUT0->>IMUX_W10\n" +
+                "         }             INT_X11Y237/IMUX_W11 ( 2) INT_X11Y237/INT.INT_NODE_IMUX_46_INT_OUT0->>IMUX_W11\n" +
+                "             INT_X10Y236/INT_INT_SDQ_34_INT_OUT1 ( 0) INT_X10Y236/INT.INT_NODE_SDQ_29_INT_OUT1->>INT_INT_SDQ_34_INT_OUT1\n" +
+                "             INT_X10Y236/INT_NODE_SDQ_82_INT_OUT0 ( 0) INT_X10Y236/INT.INT_INT_SDQ_34_INT_OUT1->INT_NODE_SDQ_82_INT_OUT0\n" +
+                "             INT_X10Y236/INT_INT_SDQ_6_INT_OUT0 ( 2) INT_X10Y236/INT.INT_NODE_SDQ_82_INT_OUT0->>INT_INT_SDQ_6_INT_OUT0\n" +
+                "     {       INT_X10Y236/INT_NODE_GLOBAL_6_INT_OUT1 ( 4) INT_X10Y236/INT.INT_INT_SDQ_6_INT_OUT0->>INT_NODE_GLOBAL_6_INT_OUT1\n" +
+                "             INT_X10Y236/INT_NODE_IMUX_9_INT_OUT0 ( 2) INT_X10Y236/INT.INT_NODE_GLOBAL_6_INT_OUT1->>INT_NODE_IMUX_9_INT_OUT0\n" +
+                "         }             INT_X10Y236/IMUX_E30 ( 6) INT_X10Y236/INT.INT_NODE_IMUX_9_INT_OUT0->>IMUX_E30\n" +
+                "             INT_X10Y236/INT_NODE_IMUX_18_INT_OUT1 ( 1) INT_X10Y236/INT.INT_INT_SDQ_6_INT_OUT0->>INT_NODE_IMUX_18_INT_OUT1\n" +
+                "         }]            INT_X10Y236/IMUX_E35 ( 3) INT_X10Y236/INT.INT_NODE_IMUX_18_INT_OUT1->>IMUX_E35\n");
+    }
+
+    private static void assertEqualToVivadoReportRouteStatus(NetTools.NodeTree tree, String reportRouteStatus) {
+        String[] expected = reportRouteStatus.split("\n");
+        String[] actual = tree.toString().split("\n");
         Assertions.assertEquals(expected.length, actual.length);
         for (int i = 0; i < expected.length; i++) {
             // Remove all text after the first round bracket
@@ -193,5 +201,49 @@ public class TestNetTools {
             String expectedNodeOnly = expected[i].substring(0, firstRoundBracket - 1);
             Assertions.assertEquals(expectedNodeOnly, actual[i]);
         }
+    }
+
+    @Test
+    public void testGetRouteTreesLoop() {
+        Design design = new Design("top", "xcvu3p");
+
+        Net net = design.createNet("net");
+        SiteInst si = design.createSiteInst("SLICE_X13Y235");
+        net.createPin("A_O", si);
+
+        String nodesPath =
+                // find_routing_path -from [get_site_pins SLICE_X13Y235/A_O] -to [get_site_pins SLICE_X13Y235/AX]
+                "CLEM_X9Y235/CLE_CLE_M_SITE_0_A_O INT_X9Y235/INODE_W_1_FT1 INT_X9Y235/BOUNCE_W_0_FT1 " +
+                // find_routing_path -from [get_site_pins SLICE_X13Y235/AX] -to [get_nodes INT_X9Y235/INODE_E_1_FT1]
+                "INT_X9Y235/BOUNCE_W_0_FT1 INT_X9Y234/INT_NODE_IMUX_55_INT_OUT1 INT_X9Y234/BYPASS_W10 INT_X9Y234/INT_NODE_IMUX_40_INT_OUT0 INT_X9Y234/BYPASS_W9 INT_X9Y234/INODE_W_54_FT0 INT_X9Y235/BYPASS_W1 INT_X9Y235/INT_NODE_IMUX_39_INT_OUT1 INT_X9Y235/BYPASS_W4 INT_X9Y235/INODE_W_1_FT1";
+             // ^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate (will get skipped below)
+        Device device = design.getDevice();
+        List<Node> nodes = Arrays.stream(nodesPath.split(" ")).map(device::getNode).collect(Collectors.toList());
+        Node startNode = nodes.get(0);
+        for (Node endNode : nodes.subList(1, nodes.size())) {
+            if (!startNode.equals(endNode)) {
+                PIP pip = PIP.getArbitraryPIP(startNode, endNode);
+                net.addPIP(pip);
+            } else {
+                // Skip duplicated nodes
+            }
+            startNode = endNode;
+        }
+
+        List<NetTools.NodeTree> trees = NetTools.getNodeTrees(net);
+        Assertions.assertEquals(1, trees.size());
+        assertEqualToVivadoReportRouteStatus(trees.get(0),
+                "    [{       CLEM_X9Y235/CLE_CLE_M_SITE_0_A_O (65535) \n" +
+                "                   INT_X9Y235/INODE_W_1_FT1 ( 2) INT_X9Y235/INT.LOGIC_OUTS_W0->>INODE_W_1_FT1\n" +
+                "                  INT_X9Y235/BOUNCE_W_0_FT1 ( 1) INT_X9Y235/INT.INODE_W_1_FT1->>BOUNCE_W_0_FT1\n" +
+                "             INT_X9Y234/INT_NODE_IMUX_55_INT_OUT1 ( 0) INT_X9Y234/INT.BOUNCE_W_BLS_0_FT0->>INT_NODE_IMUX_55_INT_OUT1\n" +
+                "                      INT_X9Y234/BYPASS_W10 ( 6) INT_X9Y234/INT.INT_NODE_IMUX_55_INT_OUT1->>BYPASS_W10\n" +
+                "             INT_X9Y234/INT_NODE_IMUX_40_INT_OUT0 ( 0) INT_X9Y234/INT.BYPASS_W10->>INT_NODE_IMUX_40_INT_OUT0\n" +
+                "                       INT_X9Y234/BYPASS_W9 ( 1) INT_X9Y234/INT.INT_NODE_IMUX_40_INT_OUT0->>BYPASS_W9\n" +
+                "                  INT_X9Y234/INODE_W_54_FT0 ( 0) INT_X9Y234/INT.BYPASS_W9->>INODE_W_54_FT0\n" +
+                "                       INT_X9Y235/BYPASS_W1 ( 1) INT_X9Y235/INT.INODE_W_BLN_54_FT1->>BYPASS_W1\n" +
+                "             INT_X9Y235/INT_NODE_IMUX_39_INT_OUT1 ( 0) INT_X9Y235/INT.BYPASS_W1->>INT_NODE_IMUX_39_INT_OUT1\n" +
+                "                       INT_X9Y235/BYPASS_W4 ( 4) INT_X9Y235/INT.INT_NODE_IMUX_39_INT_OUT1->>BYPASS_W4\n" +
+                "         }]        INT_X9Y235/INODE_W_1_FT1 ( 0) INT_X9Y235/INT.BYPASS_W4->>INODE_W_1_FT1");
     }
 }


### PR DESCRIPTION
Also fixing the `NetTools.getNodeTrees()` that it depends on, by identifying nodes that are multiply-driven so that consumers (e.g. `updatePinIsRouted()`) will not repeatedly descend down routing loops.

Fixes #1183.