### PR TITLE
[RWRoute] Connection.setAllTargets() to always set primary sink

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -464,17 +464,7 @@ public class Connection implements Comparable<Connection>{
     }
 
     public void setAllTargets(RWRoute.ConnectionState state) {
-        if (sinkRnode.countConnectionsOfUser(netWrapper) == 1 ||
-            sinkRnode.getIntentCode() == IntentCode.NODE_PINBOUNCE) {
-            // Since this connection will have been ripped up, only mark a node
-            // as a target if it's not already used by this net.
-            // This prevents -- for the case where the same net needs to be routed
-            // to the same LUT more than once -- the illegal case of the same
-            // physical pin servicing more than one logical pin
-            sinkRnode.markTarget(state);
-        } else {
-            assert(altSinkRnodes != null && !altSinkRnodes.isEmpty());
-        }
+        sinkRnode.markTarget(state);
         if (altSinkRnodes != null) {
             for (RouteNode rnode : altSinkRnodes) {
                 // Same condition as above: only allow this as an alternate sink


### PR DESCRIPTION
A problem surfaces when LUT pin swapping is enabled for RWRoute. Under this feature, LUT sinks are no longer exclusive (and marked as being used) to the associated net and so the condition `sinkRnode.countConnectionsOfUser(netWrapper) == 1` will not be true; the primary sink will not be marked as being a viable target, however only the alternate sinks will be marked.

In the rare situation (as seen for the FPGA24 routing contest's `finn_radioml` benchmark) where the primary sink is the only sink that is reachable, this leads to an unroutable situation.

The comment in the removed code appears to be stale and the outer `if` condition was modified as part of #1107: https://github.com/Xilinx/RapidWright/commit/4f38f60537e0c6d63c0beecd7ba899113b703e80#diff-c35f040a5ca8f8a23765deeb2575531451fec53b686e920c49d0122523d460ddL471-L475