### PR TITLE
[CopyImplementation] Command-line version of DesignTools.copyImplementation()

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -37,6 +37,7 @@ import com.xilinx.rapidwright.design.blocks.ImplGuide;
 import com.xilinx.rapidwright.design.blocks.PBlock;
 import com.xilinx.rapidwright.design.blocks.PBlockGenerator;
 import com.xilinx.rapidwright.design.merge.MergeDesigns;
+import com.xilinx.rapidwright.design.tools.CopyImplementation;
 import com.xilinx.rapidwright.design.tools.DesignObfuscator;
 import com.xilinx.rapidwright.design.tools.LUTTools;
 import com.xilinx.rapidwright.design.tools.RegroupInstances;
@@ -137,6 +138,7 @@ public class MainEntrypoint {
         addFunction("CheckAccuracyUsingGnlDesigns", CheckAccuracyUsingGnlDesigns::main);
         addFunction("CompareRouteStatusReports", CompareRouteStatusReports::main);
         addFunction("CopyMMCMCell", CopyMMCMCell::main);
+        addFunction("CopyImplementation", CopyImplementation::main);
         addFunction("CountRoutedNets", CountRoutedNets::main);
         addFunction("CUFR", CUFR::main);
         addFunction("CustomRouting", CustomRouting::main);

--- a/src/com/xilinx/rapidwright/design/tools/CopyImplementation.java
+++ b/src/com/xilinx/rapidwright/design/tools/CopyImplementation.java
@@ -1,0 +1,116 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Advanced Research and Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.design.tools;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.DesignTools;
+import com.xilinx.rapidwright.util.MessageGenerator;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+
+/**
+ * Copies the placement and routing information from one or more cells in one
+ * design to corresponding cells in another design.
+ */
+public class CopyImplementation {
+
+    private static final List<String> SRC_DESIGN_OPTS = Arrays.asList("s", "src_design");
+    private static final List<String> DST_DESIGN_OPTS = Arrays.asList("d", "dst_design");
+    private static final List<String> OUT_DESIGN_OPTS = Arrays.asList("o", "out_design");
+    private static final List<String> HELP_OPTS = Arrays.asList("?", "h", "help");
+    private static final List<String> DONT_LOCK_PLACEMENT_OPTS = Arrays.asList("p", "dont_lock_placement");
+    private static final List<String> DONT_LOCK_ROUTING_OPTS = Arrays.asList("r", "dont_lock_routing");
+    private static final List<String> INST_MAPPINGS_OPTS = Arrays.asList("i", "src_dst_mappings");
+
+    private static void printHelp(OptionParser p) {
+        MessageGenerator.printHeader(CopyImplementation.class.getSimpleName());
+        System.out.println(
+                "Copies the placement and routing information from one or more cells in one design \n"
+                + "to corresponding cells in another design.");
+        try {
+            p.printHelpOn(System.out);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static OptionSet getOptions(String[] args) {
+
+        OptionParser p = new OptionParser() {
+            {
+                acceptsAll(SRC_DESIGN_OPTS, "Implementation Source Design DCP File Name").withRequiredArg();
+                acceptsAll(DST_DESIGN_OPTS, "Implementation Destination Design DCP File Name").withRequiredArg();
+                acceptsAll(OUT_DESIGN_OPTS, "Resulting Output Design DCP File Name").withRequiredArg();
+                acceptsAll(DONT_LOCK_PLACEMENT_OPTS, "Don't lock placement of resulting output design");
+                acceptsAll(DONT_LOCK_ROUTING_OPTS, "Don't lock routing of resulting output design");
+                acceptsAll(HELP_OPTS, "Print this help message").forHelp();
+                acceptsAll(INST_MAPPINGS_OPTS, "Instance name mappings to copy implementation, each "
+                        + "mapping separated by a comma (',') and src and dst names separated by a "
+                        + "colon (':') (src0:dst0,src1:dst1,...)").withRequiredArg();
+            }
+        };
+
+        OptionSet options = p.parse(args);
+        if (options.has(HELP_OPTS.get(0)) || args.length == 0) {
+            printHelp(p);
+            return null;
+        }
+
+        return options;
+    }
+
+    public static void main(String[] args) {
+        OptionSet options = getOptions(args);
+        if (options == null) {
+            // Help message was invoked
+            return;
+        }
+        
+        Design src = Design.readCheckpoint(options.valueOf(SRC_DESIGN_OPTS.get(0)).toString());
+        Design dst = Design.readCheckpoint(options.valueOf(DST_DESIGN_OPTS.get(0)).toString());
+        boolean lockPlacement = options.valueOf(DONT_LOCK_PLACEMENT_OPTS.get(0)) == null;
+        boolean lockRouting = options.valueOf(DONT_LOCK_ROUTING_OPTS.get(0)) == null;
+        Map<String,String> srcToDstInstNames = new HashMap<>();
+        
+        String[] mappings = options.valueOf(INST_MAPPINGS_OPTS.get(0)).toString().split(",");
+        // Parse src-to-dst instance name mappings(separated by ':') and put into map
+        for (String mapping : mappings) {
+            int idx = mapping.indexOf(':');
+            String srcName = mapping.substring(0, idx);
+            String dstName = mapping.substring(idx + 1);
+            srcToDstInstNames.put(srcName, dstName);
+        }
+
+        DesignTools.copyImplementation(src, dst, lockPlacement, lockRouting, srcToDstInstNames);
+        
+        dst.writeCheckpoint(options.valueOf(OUT_DESIGN_OPTS.get(0)).toString());
+    }
+}


### PR DESCRIPTION
This allows you to copy a portion of the implementation from an existing design that has been placed and routed to another design presumably one that has not been placed yet) for the purpose of preserving timing closed logic.  

For example, consider this design that has been fully placed and routed:
`wget https://github.com/eddieh-xlnx/eco_insert_route_debug/raw/refs/heads/master/files/boom_medium_routed.dcp`
![image](https://github.com/user-attachments/assets/65b0dd35-b73a-43c1-9554-b8dda760f8f7)

Suppose you want to transfer the placement and routing of the cell `system/subsystem_l2_wrapper` (leaf cells highlighted in magenta) into another variant of this same design.  We could do that by preparing an unplaced variant of this design and then running the following:

```
rapidwright CopyImplementation -s boom_medium_routed.dcp -d boom_medium_unplaced.dcp -o boom_medium_rw_copied.dcp -i system/subsystem_l2_wrapper:system/subsystem_l2_wrapper
```

In this case, the source and destination instance name are the same, but in other designs, they could have a different hierarchical instance name.  The key is that the cell interface must match in both source and destination netlists.  The destination netlist could be a black box, but it is not required.

The resulting DCP from this operation would look like this:
![image](https://github.com/user-attachments/assets/7eba56a4-1654-4ed1-9426-04becba51734)

The placement and routing from the `system/subsystem_l2_wrapper` cell has been applied, but the remainder of the design is left unimplemented.  If we run `place_design; route_design` in Vivado, we can get an another implementation, but with the `system/subsystem_l2_wrapper` implementation remaining the same (compare against the original):
![image](https://github.com/user-attachments/assets/f27ae0de-f0fb-45a6-a7d2-b2e21a127225)

This PR is partially a response to https://github.com/Xilinx/RapidWright/discussions/1188