### PR TITLE
[ECOTools] Fix connectNet() for pins that don't need routing

### DIFF
--- a/src/com/xilinx/rapidwright/eco/ECOTools.java
+++ b/src/com/xilinx/rapidwright/eco/ECOTools.java
@@ -364,7 +364,8 @@ public class ECOTools {
         // Modify the physical netlist
         EDIFCell ecGnd = netlist.getHDIPrimitive(Unisim.GND);
         EDIFCell ecVcc = netlist.getHDIPrimitive(Unisim.VCC);
-        nextNet: for (EDIFHierNet ehn : netToPortInsts.keySet()) {
+        nextNet: for (Map.Entry<EDIFHierNet,List<EDIFHierPortInst>> e : netToPortInsts.entrySet()) {
+            EDIFHierNet ehn = e.getKey();
             Net newPhysNet = null;
 
             // Find the one and only source pin
@@ -414,6 +415,7 @@ public class ECOTools {
                 }
             }
 
+            // Now go through all sink pins
             nextLeafPin: for (EDIFHierPortInst ehpi : leafEdifPins) {
                 if (ehpi.isOutput()) {
                     continue;
@@ -514,8 +516,15 @@ public class ECOTools {
                     if (cell.getAllPhysicalPinMappings(logicalPinName) != null) {
                         createExitSitePinInst(design, ehpi, newPhysNet);
                     } else {
-                        // TODO: Find a new physical pin mapping
-                        throw new RuntimeException("ERROR: No logical-physical pin mapping found for pin '" + ehpi + "'");
+                        if (LUTTools.isCellALUT(cell)) {
+                            // TODO: Find a new physical pin mapping
+                            throw new RuntimeException("ERROR: No logical-physical pin mapping found for pin '" + ehpi + "'");
+                        } else {
+                            // Assume that sink does not need routing (e.g. CARRY8.CIN can be connected to VCC but does
+                            // not need physically routing)
+                            assert(ehn.getNet().isVCC() || ehn.getNet().isGND());
+                            assert(!e.getValue().contains(ehpi));
+                        }
                     }
                 }
             }

--- a/src/com/xilinx/rapidwright/eco/ECOTools.java
+++ b/src/com/xilinx/rapidwright/eco/ECOTools.java
@@ -520,8 +520,8 @@ public class ECOTools {
                             // TODO: Find a new physical pin mapping
                             throw new RuntimeException("ERROR: No logical-physical pin mapping found for pin '" + ehpi + "'");
                         } else {
-                            // Assume that sink does not need routing (e.g. CARRY8.CIN can be connected to VCC but does
-                            // not need physically routing)
+                            // Assume that sink does not need routing (e.g. CARRY8.CIN may already be connected to VCC
+                            //  but does not need physically routing)
                             assert(ehn.getNet().isVCC() || ehn.getNet().isGND());
                             assert(!e.getValue().contains(ehpi));
                         }


### PR DESCRIPTION
`CARRY8.CIN` can be logically connected to `VCC`, but does not physically need routing since it can be sourced from inside the BEL.

Do not error out in such cases.