### PR TITLE
Add getDiffCount, getDiffMap, and getDiffList to EDIFNetlistComparator

### DIFF
--- a/src/com/xilinx/rapidwright/edif/compare/EDIFNetlistComparator.java
+++ b/src/com/xilinx/rapidwright/edif/compare/EDIFNetlistComparator.java
@@ -85,6 +85,24 @@ public class EDIFNetlistComparator {
         diffCount = 0;
     }
 
+    /**
+     * Gets the total number of differences encountered since the last call of
+     * {@link #compareNetlists(EDIFNetlist, EDIFNetlist)}.
+     *
+     * @return Total number of design differences found.
+     */
+    public int getDiffCount() {
+        return diffCount;
+    }
+
+    public Map<EDIFDiffType, List<EDIFDiff>> getDiffMap() {
+        return diffMap;
+    }
+
+    public List<EDIFDiff> getDiffList(EDIFDiffType type) {
+        return diffMap.getOrDefault(type, Collections.emptyList());
+    }
+
     private static EDIFCell getParentCell(EDIFPropertyObject o) {
         if (o instanceof EDIFNet) {
             return ((EDIFNet) o).getParentCell();


### PR DESCRIPTION
Added the following public methods to EDIFNetlistComparator:
- getDiffCount()
- getDiffMap()
- getDiffList(EDIFDiffType)

These mirror the public methods in DesignComparator, providing access to the internal diff map and supporting more granular inspection of EDIF differences.