### PR TITLE
Inline Flop Insertion/Removal Tool 

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2025.1.0.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2025.1.1-rc1.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2025.1.0-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2025.1.1-rc1-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2025.1.1-rc1.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2025.1.1-rc2.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2025.1.1-rc1-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2025.1.1-rc2-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2025.1.1-rc1-beta
+  RAPIDWRIGHT_VERSION: v2025.1.1-rc2-beta
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2025.1.0-beta
+  RAPIDWRIGHT_VERSION: v2025.1.1-rc1-beta
 
 jobs:
   build:

--- a/src/com/xilinx/rapidwright/design/tools/InlineFlopTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/InlineFlopTools.java
@@ -68,7 +68,7 @@ public class InlineFlopTools {
 
     /**
      * Add flip flops inline on all the top-level ports of an out-of-context design.
-     * This is useful for placed out-of-context kernels prior to routing so that
+     * This is useful for out-of-context kernels prior to placement and routing so that
      * after the flops have been placed, the router is forced to route connections
      * of each of the ports to each of the flops. This can help alleviate congestion
      * when the kernels are placed/relocated in context. Note this assumes the

--- a/src/com/xilinx/rapidwright/design/tools/InlineFlopTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/InlineFlopTools.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Advanced Research and Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.design.tools;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.xilinx.rapidwright.design.Cell;
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.DesignTools;
+import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.design.SitePinInst;
+import com.xilinx.rapidwright.design.Unisim;
+import com.xilinx.rapidwright.design.blocks.PBlock;
+import com.xilinx.rapidwright.device.BEL;
+import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.eco.ECOPlacementHelper;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFHierNet;
+import com.xilinx.rapidwright.edif.EDIFNet;
+import com.xilinx.rapidwright.edif.EDIFPort;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
+import com.xilinx.rapidwright.util.Pair;
+import com.xilinx.rapidwright.util.StringTools;
+
+/**
+ * Set of tools to add/remove flip flops inline to top level port connections.
+ * This is targeted at kernel replication preparation prior to routing to ensure
+ * that connections are routed outside of the pblock of the out-of-context
+ * kernel.
+ * 
+ */
+public class InlineFlopTools {
+
+    private static final String CLK_OPT = "--clk";
+    private static final String PBLOCK_OPT = "--pblock";
+    private static final String REMOVE_FLOPS_OPT = "--remove_flops";
+
+    private static final String INLINE_SUFFIX = "_rw_inline_flop";
+
+    /**
+     * Add flip flops inline on all the top-level ports of an out-of-context design.
+     * This is useful for placed out-of-context kernels prior to routing so that
+     * after the flops have been placed, the router is forced to route connections
+     * of each of the ports to each of the flops. This can help alleviate congestion
+     * when the kernels are placed/relocated in context.
+     * 
+     * @param design  The design to modify
+     * @param clkNet  Name of the clock net to use on which to add the flops
+     * @param keepOut The pblock used to contain the kernel and the added flops will
+     *                not be placed inside this area.
+     */
+    public static void createAndPlaceFlopsInlineOnTopPorts(Design design, String clkNet, PBlock keepOut) {
+        EDIFCell top = design.getTopEDIFCell();
+        Site start = keepOut.getAllSites("SLICE").iterator().next(); // TODO this is a bit wasteful
+        boolean exclude = true;
+        Iterator<Site> siteItr = ECOPlacementHelper.spiralOutFrom(start, keepOut, exclude).iterator();
+        siteItr.next(); // Skip the first site, as we are suggesting one inside the pblock
+
+        Net clk = design.getNet(clkNet);
+
+        Set<SiteInst> siteInstsToRoute = new HashSet<>();
+
+        for (EDIFPort port : top.getPorts()) {
+            if (port.isBus()) {
+                for (int i : port.getBitBlastedIndicies()) {
+                    EDIFPortInst inst = port.getInternalPortInstFromIndex(i);
+                    Pair<Site, BEL> loc = nextAvailPlacement(design, siteItr);
+                    Cell flop = createAndPlaceFlopInlineOnTopPortInst(design, inst, loc, clk);
+                    siteInstsToRoute.add(flop.getSiteInst());
+                }
+            } else {
+                EDIFPortInst inst = port.getInternalPortInst();
+                Pair<Site, BEL> loc = nextAvailPlacement(design, siteItr);
+                Cell flop = createAndPlaceFlopInlineOnTopPortInst(design, inst, loc, clk);
+                siteInstsToRoute.add(flop.getSiteInst());
+            }
+        }
+        for (SiteInst si : siteInstsToRoute) {
+            si.routeSite();
+        }
+    }
+
+    private static Pair<Site, BEL> nextAvailPlacement(Design design, Iterator<Site> itr) {
+        while (itr.hasNext()) {
+            Site curr = itr.next();
+            SiteInst candidate = design.getSiteInstFromSite(curr);
+            if (candidate == null) {
+                // Empty site, let's use it
+                return new Pair<Site, BEL>(curr, curr.getBEL("AFF"));
+            }
+        }
+        return null;
+    }
+
+    private static Cell createAndPlaceFlopInlineOnTopPortInst(Design design, EDIFPortInst portInst, Pair<Site, BEL> loc,
+            Net clk) {
+        String name = portInst.getFullName() + INLINE_SUFFIX;
+        Cell flop = design.createAndPlaceCell(design.getTopEDIFCell(), name, Unisim.FDRE, loc.getFirst(),
+                loc.getSecond());
+        Net net = design.createNet(name);
+        net.connect(flop, portInst.isInput() ? "D" : "Q");
+        design.getGndNet().connect(flop, "R");
+        design.getVccNet().connect(flop, "CE");
+        clk.connect(flop, "C");
+        EDIFNet origNet = portInst.getNet();
+        origNet.removePortInst(portInst);
+        net.getLogicalNet().addPortInst(portInst);
+        Net origPhysNet = design.getNet(origNet.getName());
+        if (origPhysNet == null) {
+            if (origNet.isGND()) {
+                origPhysNet = design.getGndNet();
+            } else if (origNet.isVCC()) {
+                origPhysNet = design.getVccNet();
+            } else {
+                origPhysNet = design.createNet(new EDIFHierNet(design.getNetlist().getTopHierCellInst(), origNet));
+            }
+        }
+        origPhysNet.connect(flop, portInst.isInput() ? "Q" : "D");
+        return flop;
+    }
+
+    /**
+     * Removes the inline flops added by
+     * {@link #createAndPlaceFlopsInlineOnTopPorts(Design, String, PBlock)}
+     * 
+     * @param design The current design from which to remove the flops
+     */
+    public static void removeInlineFlops(Design design) {
+        Map<Net, Set<SitePinInst>> pinsToRemove = new HashMap<>();
+        List<SiteInst> siteInstToRemove = new ArrayList<>();
+        List<EDIFCellInst> cellsToRemove = new ArrayList<>();
+        Net vcc = design.getVccNet();
+        Set<SitePinInst> vccPins = new HashSet<>();
+        pinsToRemove.put(vcc, vccPins);
+        for (EDIFCellInst inst : design.getTopEDIFCell().getCellInsts()) {
+            if (inst.getName().endsWith(INLINE_SUFFIX)) {
+                Cell flop = design.getCell(inst.getName());
+                SiteInst si = flop.getSiteInst();
+                // Assume we only placed one flop per SiteInst
+                siteInstToRemove.add(si);
+                for (SitePinInst pin : si.getSitePinInsts()) {
+                    pinsToRemove.computeIfAbsent(pin.getNet(), p -> new HashSet<>()).add(pin);
+                }
+                vccPins.add(vcc.createPin("CKEN1", si));
+                vccPins.add(vcc.createPin("RST", si));
+
+                cellsToRemove.add(inst);
+            }
+        }
+
+        for (SiteInst si : siteInstToRemove) {
+            design.removeSiteInst(si);
+        }
+        DesignTools.batchRemoveSitePins(pinsToRemove, true);
+
+        String[] ctrlPins = new String[] { "C", "R", "CE" };
+        EDIFCell top = design.getTopEDIFCell();
+        for (EDIFCellInst c : cellsToRemove) {
+            // Remove control set pins
+            for (String pin : ctrlPins) {
+                EDIFPortInst p = c.getPortInst(pin);
+                p.getNet().removePortInst(p);
+            }
+            // Merge 'D' sources and 'Q' sinks, restore original net
+            EDIFPortInst d = c.getPortInst("D");
+            EDIFNet dNet = d.getNet();
+            EDIFPortInst q = c.getPortInst("Q");
+            EDIFNet qNet = q.getNet();
+            if (dNet.getName().endsWith(INLINE_SUFFIX)) {
+                // Input port
+                for (EDIFPortInst pi : new ArrayList<>(d.getNet().getPortInsts())) {
+                    if (pi.getCellInst() != c) {
+                        dNet.removePortInst(pi);
+                        qNet.addPortInst(pi);
+                    }
+                }
+                qNet.removePortInst(q);
+                top.removeNet(dNet);
+            } else {
+                // Output port
+                for (EDIFPortInst pi : new ArrayList<>(q.getNet().getPortInsts())) {
+                    if (pi.getCellInst() != c) {
+                        qNet.removePortInst(pi);
+                        dNet.addPortInst(pi);
+                    }
+                }
+                top.removeNet(qNet);
+                dNet.removePortInst(d);
+            }
+
+            top.removeCellInst(c);
+        }
+
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 3 || args.length > 4) {
+            System.out.println("USAGE (to add flops)   : <input.dcp> <output.dcp> "+CLK_OPT+"=<clkName> "+PBLOCK_OPT+"=<pblock range(s)>");
+            System.out.println("USAGE (to remove flops): <input.dcp> <output.dcp> " + REMOVE_FLOPS_OPT);
+            return;
+        }
+        
+        Design d = Design.readCheckpoint(args[0]);
+
+        if (args[2].startsWith(CLK_OPT) || args[2].startsWith(PBLOCK_OPT)) {
+            d.unplaceDesign();
+            String clkName = StringTools.getOptionValue(CLK_OPT, args);
+            String pblockRange = StringTools.getOptionValue(PBLOCK_OPT, args);
+            if (clkName == null || pblockRange == null) {
+                throw new RuntimeException("ERROR: Missing value(s) for option(s): " 
+                        + CLK_OPT + "=" + clkName + ", " + PBLOCK_OPT + "=" + pblockRange);
+            }
+            PBlock pblock = new PBlock(d.getDevice(), pblockRange);
+            createAndPlaceFlopsInlineOnTopPorts(d, clkName, pblock);
+        } else if (args[2].equals(REMOVE_FLOPS_OPT)) {
+            removeInlineFlops(d);
+        } else {
+            System.err.println("ERROR: Unrecognized option '" + args[2] +"'");
+        }
+        
+        
+        d.writeCheckpoint(args[1]);
+    }
+}

--- a/src/com/xilinx/rapidwright/eco/ECOPlacementHelper.java
+++ b/src/com/xilinx/rapidwright/eco/ECOPlacementHelper.java
@@ -328,9 +328,28 @@ public class ECOPlacementHelper {
      * @param site   Originating Site.
      * @param pblock Also check to ensure the proposed sites are inside the provided
      *               pblock.
+     * 
      * @return Iterable<Site> of neighbouring sites.
      */
     public static Iterable<Site> spiralOutFrom(Site site, PBlock pblock) {
+        return spiralOutFrom(site, pblock, false);
+    }
+
+    /**
+     * Given a home Site, return an Iterable that yields the neighbouring sites
+     * encountered when walking outwards in a spiral fashion. To be used in
+     * conjunction with {@link #getUnusedLUT(SiteInst)} and
+     * {@link #getUnusedFlop(SiteInst, Net)}.
+     * 
+     * @param site    Originating Site.
+     * @param pblock  Also check to ensure the proposed sites are inside the
+     *                provided pblock.
+     * @param exclude If this flag is true, any sites inside the pblock are
+     *                excluded.
+     * 
+     * @return Iterable<Site> of neighbouring sites.
+     */
+    public static Iterable<Site> spiralOutFrom(Site site, PBlock pblock, boolean exclude) {
         return new Iterable<Site>() {
             @NotNull
             @Override
@@ -379,7 +398,7 @@ public class ECOPlacementHelper {
                                 break;
                             }
                             nextSite = home.getNeighborSite(dx, dy);
-                        } while (nextSite == null || !insidePblock(nextSite));
+                        } while (nextSite == null || (exclude ? insidePblock(nextSite) : !insidePblock(nextSite)));
                         return retSite;
                     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import com.xilinx.rapidwright.design.Cell;
+import com.xilinx.rapidwright.design.NetType;
 import com.xilinx.rapidwright.design.Unisim;
 
 /**
@@ -406,6 +407,29 @@ public class EDIFNet extends EDIFPropertyObject {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Checks if this net is a GND or VCC net and if so returns the appropriate
+     * NetType. If it is not a static net, it returns NetType.UNKNOWN.
+     * 
+     * @return The static source type or UNKNOWN if it is not a static net.
+     */
+    public NetType getPhysStaticSourceType() {
+        if (getName().equals(EDIFTools.LOGICAL_GND_NET_NAME))
+            return NetType.GND;
+        if (getName().equals(EDIFTools.LOGICAL_VCC_NET_NAME))
+            return NetType.VCC;
+        for (EDIFPortInst portInst : getSourcePortInsts(false)) {
+            String cellType = portInst.getCellInst().getCellType().getName();
+            if (cellType.equals(Unisim.GND.name())) {
+                return NetType.GND;
+            }
+            if (cellType.equals(Unisim.VCC.name())) {
+                return NetType.VCC;
+            }
+        }
+        return NetType.UNKNOWN;
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1146,10 +1146,10 @@ public class EDIFNetlist extends EDIFName {
         }
 
         Map<EDIFHierNet,EDIFHierNet> parentNetMap = getParentNetMap();
-        EDIFHierNet parentNetName = parentNetMap.get(p.getHierarchicalNet());
-        Net n = parentNetName == null ? null : d.getNet(parentNetName.getHierarchicalNetName());
+        EDIFHierNet parentNet = parentNetMap.get(p.getHierarchicalNet());
+        Net n = parentNet == null ? null : d.getNet(parentNet.getHierarchicalNetName());
         if (n == null) {
-            if (parentNetName == null) {
+            if (parentNet == null) {
                 // Maybe it is GND/VCC
                 List<EDIFPortInst> src = p.getNet().getSourcePortInsts(false);
                 if (src.size() > 0 && src.get(0).getCellInst() != null) {
@@ -1158,12 +1158,12 @@ public class EDIFNetlist extends EDIFName {
                     if (cellType.equals("VCC")) return d.getVccNet();
                 }
             }
-            if (parentNetName == null) {
+            if (parentNet == null) {
                 System.err.println("WARNING: Could not find parent of net \"" + p.getHierarchicalNet() +
                         "\", please check that the netlist is fully connected through all levels of "
                         + "hierarchy for this net.");
             }
-            EDIFNet logicalNet = parentNetName.getNet();
+            EDIFNet logicalNet = parentNet.getNet();
             List<EDIFPortInst> eprList = logicalNet.getSourcePortInsts(false);
             if (eprList.size() > 1) throw new RuntimeException("ERROR: Bad assumption on net, has two sources.");
             if (eprList.size() == 1) {
@@ -1176,8 +1176,13 @@ public class EDIFNetlist extends EDIFName {
             }
             // If size is 0, assume top level port in an OOC design
 
-            n = d.createNet(parentNetName.getHierarchicalNetName());
-            n.setLogicalHierNet(parentNetName);
+            n = d.createNet(parentNet.getHierarchicalNetName());
+            n.setLogicalHierNet(parentNet);
+        } else {
+            NetType staticType = p.getNet().getPhysStaticSourceType();
+            if (staticType != NetType.UNKNOWN) {
+                d.getStaticNet(staticType);
+            }
         }
         return n;
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -234,6 +234,32 @@ public class EDIFPort extends EDIFPropertyObject {
     }
 
     /**
+     * Gets the internal port instance connected to this port at the specified
+     * index.
+     * 
+     * @param index Index of the bussed port instance to get.
+     * @return The EDIFPortInst connected to this port at the specified index, or
+     *         null if none exists.
+     */
+    public EDIFPortInst getInternalPortInstFromIndex(int index) {
+        String name = getPortInstNameFromPort(index);
+        EDIFNet net = getInternalNet(index);
+        return net.getPortInst(null, name);
+    }
+
+    /**
+     * Gets the internal port instance connect to this port. Assumes this is a
+     * single bit port.
+     * 
+     * @return The EDIFPortInst connected to this port, or null if none exists.
+     */
+    public EDIFPortInst getInternalPortInst() {
+        assert (!isBus());
+        EDIFNet net = getInternalNet();
+        return net.getPortInst(null, getBusName());
+    }
+
+    /**
      * Gets the internal port instance index from the named index for this port.
      * Given a bussed port 'bus[4:0]', the bus has an ordered list of named indices
      * [4, 3, 2, 1, 0]. If the named index is 'bus[1]', the port index is 3. When

--- a/src/com/xilinx/rapidwright/util/StringTools.java
+++ b/src/com/xilinx/rapidwright/util/StringTools.java
@@ -301,6 +301,25 @@ public class StringTools {
         }
     }
 
+    /**
+     * Light-weight helper method to get the value of an option in an array of
+     * arguments. For example, if option is '--option' and args is {"in.dcp",
+     * "out.dcp", "--option=value"}, this method will return 'value'.
+     * 
+     * @param option The name of the option to search for
+     * @param args   The list or arguments (usually from main())
+     * @return The value of the option or null if it was not found
+     */
+    public static String getOptionValue(String option, String[] args) {
+        for (String arg : args) {
+            if (arg.startsWith(option)) {
+                int idx = arg.indexOf('=');
+                return arg.substring(idx + 1).trim();
+            }
+        }
+        return null;
+    }
+
     public static void main(String[] args) {
         String[] tests = new String[] {
             "ARCHITECTURE",

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -389,6 +389,45 @@ public class VivadoTools {
     }
 
     /**
+     * Run Vivado's `place_design` and `route_design` command on the design provided
+     * and get the `report_route_status` results. Note: this method does not
+     * preserve the routed output from Vivado.
+     * 
+     * @param design  The design to route and report on.
+     * @param workdir Directory to work within.
+     * @return The results of `report_route_status`.
+     */
+    public static ReportRouteStatusResult placeAndRouteDesignAndGetStatus(Design design, Path workdir) {
+        boolean encrypted = !design.getNetlist().getEncryptedCells().isEmpty();
+        Path dcp = workdir.resolve("placeAndRouteDesignAndGetStatus.dcp");
+        design.writeCheckpoint(dcp);
+        return placeAndRouteDesignAndGetStatus(dcp, workdir, encrypted);
+    }
+
+    /**
+     * Run Vivado's `place_design` and `route_design` command on the provided DCP
+     * path and return the `report_route_status` results. Note: this method does not
+     * preserve the routed output from Vivado.
+     *
+     * @param dcp       Path to DCP to route and report on.
+     * @param workdir   Directory to work within.
+     * @param encrypted Indicates whether DCP contains encrypted EDIF cells.
+     * @return The results of `report_route_status`.
+     */
+    public static ReportRouteStatusResult placeAndRouteDesignAndGetStatus(Path dcp, Path workdir, boolean encrypted) {
+        final Path outputLog = workdir.resolve("outputLog.log");
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(createTclDCPLoadCommand(dcp, encrypted));
+        sb.append(PLACE_DESIGN + "; ");
+        sb.append(ROUTE_DESIGN + "; ");
+        sb.append(REPORT_ROUTE_STATUS + "; ");
+
+        List<String> log = VivadoTools.runTcl(outputLog, sb.toString(), true);
+        return new ReportRouteStatusResult(log);
+    }
+
+    /**
      * Run Vivado's `route_design` command on the provided DCP path and return the
      * `report_route_status` results. Note: this method does not preserve the routed
      * output from Vivado.

--- a/test/shared/com/xilinx/rapidwright/util/VivadoToolsHelper.java
+++ b/test/shared/com/xilinx/rapidwright/util/VivadoToolsHelper.java
@@ -60,4 +60,12 @@ public class VivadoToolsHelper {
         ReportRouteStatusResult rrs = VivadoTools.routeDesignAndGetStatus(design, dir);
         Assertions.assertTrue(rrs.isFullyRouted());
     }
+
+    public static void assertCanBeFullyPlacedAndRoutedByVivado(Design design, Path dir) {
+        if (!FileTools.isVivadoOnPath()) {
+            return;
+        }
+        ReportRouteStatusResult rrs = VivadoTools.placeAndRouteDesignAndGetStatus(design, dir);
+        Assertions.assertTrue(rrs.isFullyRouted());
+    }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestCell.java
+++ b/test/src/com/xilinx/rapidwright/design/TestCell.java
@@ -63,9 +63,27 @@ public class TestCell {
         List<String> sitePinNames = cell.getAllCorrespondingSitePinNames(logicalPinName, considerLutRoutethru);
         Assertions.assertEquals(expectedSitePins, sitePinNames.toString());
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            // Versal input pins
+            "xcvp1502,SLICE_X148Y0,BFF,D,D,BX",
+    })
+    public void testGetCorrespondingSitePinName(String deviceName,
+                                                String siteName,
+                                                String belName,
+                                                String logicalPinName,
+                                                String physicalPinName,
+                                                String expectedSitePin) {
+        Device device = Device.getDevice(deviceName);
+        Cell cell = new Cell("cell", device.getSite(siteName).getBEL(belName));
+        cell.addPinMapping(physicalPinName, logicalPinName);
+        String sitePinName = cell.getCorrespondingSitePinName(logicalPinName);
+        Assertions.assertEquals(expectedSitePin, sitePinName);
+    }
     
     @Test
-    public void testGetCorrespondingSitePinName() {
+    public void testGetCorrespondingSitePinNameDualLut() {
         Device device = Device.getDevice("xcvu3p");
         Design design = new Design("testDesign", device.getName());
         Cell cell = design.createAndPlaceCell("testFF", Unisim.FDRE, "SLICE_X10Y10/GFF");


### PR DESCRIPTION
A tool designed to attached (and remove in a separate invocation) inline flip-flops to ports of an out-of-context DCP.  This is to help routability for kernels once put in-context that will be replicated later.