### PR TITLE
EDIF compareNetlists() fails on null cell

### DIFF
--- a/src/com/xilinx/rapidwright/edif/compare/EDIFNetlistComparator.java
+++ b/src/com/xilinx/rapidwright/edif/compare/EDIFNetlistComparator.java
@@ -339,6 +339,7 @@ public class EDIFNetlistComparator {
                 EDIFCell testCell = testCells.remove(e2.getKey());
                 if (testCell == null) {
                     addDiff(EDIFDiffType.CELL_MISSING, e2.getValue(), testCell, null, goldLib, "");
+                    continue;
                 }
                 EDIFCell goldCell = e2.getValue();
                 checkCell(goldCell, testCell);


### PR DESCRIPTION
It looks like we are just missing a continue for the loop if the testCell is null.