### PR TITLE
Full TCL parser for XDC

### DIFF
--- a/src/com/xilinx/rapidwright/ipi/BlockStitcher.java
+++ b/src/com/xilinx/rapidwright/ipi/BlockStitcher.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
@@ -137,7 +138,7 @@ public class BlockStitcher {
      * @param design
      * @param constraints
      */
-    public void stitchDesign(Design design, HashMap<String,PackagePinConstraint> constraints) {
+    public void stitchDesign(Design design, Map<String,PackagePinConstraint> constraints) {
         boolean debug = false;
         EDIFNetlist n = design.getNetlist();
         // Create a reverse parent net map (Parent Net -> Children Nets: all logical nets that are physically equivalent)
@@ -271,7 +272,7 @@ public class BlockStitcher {
                 Net portNet = null;
                 portNet = e.getValue();
 
-                Site site = design.getDevice().getSiteFromPackagePin(constraints.get(portName).getName());
+                Site site = design.getDevice().getSiteFromPackagePin(constraints.get(portName).getPackagePin());
                 if (site == null) {
                     MessageGenerator.briefMessage("WARNING: It appears that the I/O called " + portName + " is not assigned to a package pin!");
                     continue nextPort;
@@ -294,7 +295,7 @@ public class BlockStitcher {
                 }
 
                 String ioStandard = constraints.get(portName).getIoStandard();
-                String pkgPin = constraints.get(portName).getName();
+                String pkgPin = constraints.get(portName).getPackagePin();
                 EDIFNet logNet = e.getKey().getPortInst().getNet();
                 design.createAndPlaceIOB(portName, isPortOutput ? PinType.OUT : PinType.IN, pkgPin, ioStandard, portNet, logNet);
             }
@@ -562,7 +563,7 @@ public class BlockStitcher {
         runtimes[2] = System.currentTimeMillis();
         System.out.println("Total Blocks : " + totalBlocks);
         String xdcFileName = args[1].replace(".edf", ".xdc");
-        HashMap<String,PackagePinConstraint> constraints = null;
+        Map<String,PackagePinConstraint> constraints = null;
         if (new File(xdcFileName).exists()) {
             constraints = XDCParser.parseXDC(xdcFileName,stitched.getDevice());
         } else {

--- a/src/com/xilinx/rapidwright/ipi/ClockConstraint.java
+++ b/src/com/xilinx/rapidwright/ipi/ClockConstraint.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+
+import java.util.Locale;
+
+public class ClockConstraint implements Constraint<ClockConstraint>{
+    private String clockName;
+    private double period;
+
+    private String portName;
+
+    public ClockConstraint(String clockName, double period, String portName) {
+        this.clockName = clockName;
+        this.period = period;
+        this.portName = portName;
+    }
+
+    @Override
+    public ClockConstraint clone() {
+        return new ClockConstraint(clockName, period, portName);
+    }
+
+    public String getClockName() {
+        return clockName;
+    }
+
+    public void setClockName(String clockName) {
+        this.clockName = clockName;
+    }
+
+    public double getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(double period) {
+        this.period = period;
+    }
+
+    public String asXdc() {
+        String periodString = String.format(Locale.US, "%.3f", period);
+        return "create_clock -period "+periodString+" -name "+clockName+" [get_ports "+portName+"]";
+    }
+
+    public String getPortName() {
+        return portName;
+    }
+
+    public void setPortName(String portName) {
+        this.portName = portName;
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/Constraint.java
+++ b/src/com/xilinx/rapidwright/ipi/Constraint.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+public interface Constraint<T extends Constraint<T>> {
+    T clone();
+}

--- a/src/com/xilinx/rapidwright/ipi/DebugDumpCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/DebugDumpCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.ReflectObject;
+import tcl.lang.TclException;
+import tcl.lang.TclList;
+import tcl.lang.TclObject;
+
+public class DebugDumpCommand implements Command {
+    @Override
+    public void cmdProc(Interp interp, TclObject[] tclObjects) throws TclException {
+        debugDump(interp, tclObjects);
+    }
+
+    public static void debugDump(Interp interp, TclObject[] tclObjects) {
+        for (int i = 0; i < tclObjects.length; i++) {
+            System.out.print("index "+i+": ");
+            debugDump(tclObjects[i], interp, "    ");
+        }
+    }
+
+    public static void debugDump(TclObject tclObject, Interp interp, String indent) {
+        if (tclObject.getInternalRep() instanceof TclList) {
+            System.out.println("list");
+            try {
+                TclObject[] items = TclList.getElements(interp, tclObject);
+                for (int i = 0; i < items.length; i++) {
+                    System.out.print(indent+" index "+i+": ");
+                    debugDump(items[i], interp,indent+"    ");
+                }
+            } catch (TclException e) {
+                throw new RuntimeException(e);
+            }
+        } else if (tclObject.getInternalRep() instanceof ReflectObject) {
+            try {
+                Object refl = ReflectObject.get(interp, tclObject);
+                System.out.println("reflect object "+tclObject+" "+refl);
+            } catch (TclException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            System.out.println(tclObject.getInternalRep().getClass().getName()+": "+tclObject);
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/EdifCellLookup.java
+++ b/src/com/xilinx/rapidwright/ipi/EdifCellLookup.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import org.apache.commons.io.FilenameUtils;
+import org.jetbrains.annotations.NotNull;
+import tcl.lang.Interp;
+import tcl.lang.TclException;
+import tcl.lang.TclObject;
+
+/**
+ * Lookup Cells for use in the XDC Parser
+ * @param <T>
+ */
+public abstract class EdifCellLookup<T> {
+
+
+    @NotNull
+    public TclObject toReflectObj(Interp interp, T cell) throws TclException {
+        return TclHashIdentifiedObject.createReflectObject(interp, getCellClass(), cell);
+    }
+
+    public Stream<T> allCellInsts(T ci) {
+        Stream<T> self = Stream.of(ci);
+        Stream<? extends T> directChildren = getChildrenOf(ci);;
+        Stream<? extends T> allChildren = directChildren.flatMap(this::allCellInsts);
+        return Stream.concat(self, allChildren);
+    }
+
+    public Stream<T> getHierCellInstsFromWildcardName(String cellName) {
+        return getChildBySomeAbsoluteName(cellName, (s, item) -> FilenameUtils.wildcardMatch(getRelativeOriginalName(item), s));
+    }
+    public abstract T getInstFromOriginalName(String cellName);
+
+    public abstract Stream<? extends T> getChildrenOf(T f);
+
+    public abstract T getChild(T cell, String name);
+
+    private Stream<T> getChildBySomeAbsoluteNameWorker(String[] parts, int level, T current, BiPredicate<String, T> filter) {
+        if (level==parts.length) {
+            return Stream.of(current);
+        }
+        return IntStream.range(level, parts.length)
+                .boxed().flatMap(end-> {
+                    String nameAtCurrentLevel = Arrays.stream(parts, level, end+1).collect(Collectors.joining(EDIFTools.EDIF_HIER_SEP));
+                    return getChildrenOf(current)
+                            .filter(item->filter.test(nameAtCurrentLevel, item))
+                            .flatMap(c->getChildBySomeAbsoluteNameWorker(parts, end+1, c, filter));
+                });
+    }
+
+
+    public Stream<T> getChildBySomeAbsoluteName(String name, BiPredicate<String, T> filter) {
+
+        if (name.isEmpty()) return Stream.of(getRoot());
+
+        String[] parts = name.split(EDIFTools.EDIF_HIER_SEP);
+
+        // Sadly, cells can be named 'fred/' instead of 'fred', this code handles this situation
+        if (name.charAt(name.length()-1) == '/') {
+            parts[parts.length-1] = parts[parts.length-1] + EDIFTools.EDIF_HIER_SEP;
+        }
+
+        return getChildBySomeAbsoluteNameWorker(parts, 0, getRoot(), filter);
+    }
+
+
+
+
+    public Predicate<T> getAbsoluteRegexFilter(String cellNames) {
+        return eci -> getAbsoluteOriginalName(eci).matches(cellNames);
+    }
+
+    public Predicate<T> getAbsoluteWildcardFilter(String cellNames) {
+        return eci -> FilenameUtils.wildcardMatch(getAbsoluteOriginalName(eci), cellNames);
+    }
+
+    public Stream<T> getAllCellInsts() {
+        return allCellInsts(getRoot());
+    }
+
+    public abstract EDIFHierCellInst toEdifHierCellInst(T cell);
+
+    public Predicate<T> getCellTypeFilter(Set<String> values) {
+        return ci -> values.contains(getCellType(ci));
+    }
+
+    public abstract T getRoot();
+
+    public abstract String getAbsoluteFinalName(T current);
+    public abstract String getRelativeFinalName(T current);
+    public abstract String getAbsoluteOriginalName(T current);
+    public abstract String getRelativeOriginalName(T current);
+
+    public abstract String getCellType(T current);
+
+    public abstract Class<?> getCellClass();
+
+    public T castCellInst(Object obj) {
+        return (T)getCellClass().cast(obj);
+    }
+
+    public abstract T getInstFromFinalName(String s);
+
+    public String getOriginalName(String s) {
+        return getAbsoluteOriginalName(getInstFromFinalName(s));
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/NoNetlistLookup.java
+++ b/src/com/xilinx/rapidwright/ipi/NoNetlistLookup.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+
+public class NoNetlistLookup  extends EdifCellLookup<String>{
+
+    @Override
+    public Stream<String> getHierCellInstsFromWildcardName(String cellName) {
+        return Stream.of(cellName);
+    }
+
+    @Override
+    public String getInstFromOriginalName(String cellName) {
+        return cellName;
+    }
+
+    @Override
+    public Stream<? extends String> getChildrenOf(String f) {
+        throw new RuntimeException("not supported");
+    }
+
+    @Override
+    public String getChild(String cell, String name) {
+        if (cell.isEmpty()) {
+            return name;
+        }
+        return cell+"/"+name;
+    }
+
+    @Override
+    public EDIFHierCellInst toEdifHierCellInst(String cell) {
+        throw new RuntimeException("not supported");
+    }
+
+    @Override
+    public String getRoot() {
+        return "";
+    }
+
+    @Override
+    public String getAbsoluteFinalName(String current) {
+        return current;
+    }
+
+    @Override
+    public String getRelativeFinalName(String current) {
+        return getRelativeOriginalName(current);
+    }
+
+    @Override
+    public String getAbsoluteOriginalName(String current) {
+        return current;
+    }
+
+    @Override
+    public String getRelativeOriginalName(String current) {
+        String[] split = current.split("/");
+        return split[split.length-1];
+    }
+
+    @Override
+    public String getCellType(String current) {
+        throw new RuntimeException("not supported");
+    }
+
+    @Override
+    public Class<String> getCellClass() {
+        return String.class;
+    }
+
+    @Override
+    public String getInstFromFinalName(String s) {
+        return s;
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/PackagePinConstraint.java
+++ b/src/com/xilinx/rapidwright/ipi/PackagePinConstraint.java
@@ -26,28 +26,47 @@
  */
 package com.xilinx.rapidwright.ipi;
 
+import java.util.stream.Stream;
+
 /**
  * Annotates a package pin name with an IO standard
  * Created on: Jan 25, 2018
  */
-public class PackagePinConstraint {
+public class PackagePinConstraint implements Constraint<PackagePinConstraint> {
 
-    private String name;
+    private String portName;
+
+    private String packagePin;
 
     private String ioStandard;
+
+    public PackagePinConstraint() {
+    }
+
+    @Override
+    public PackagePinConstraint clone() {
+        PackagePinConstraint res = new PackagePinConstraint(portName);
+        res.setPackagePin(packagePin);
+        res.setIOStandard(ioStandard);
+        return res;
+    }
+
+    public PackagePinConstraint(String portName) {
+        setPortName(portName);
+    }
 
     /**
      * @return the name
      */
-    public String getName() {
-        return name;
+    public String getPackagePin() {
+        return packagePin;
     }
 
     /**
-     * @param name the name to set
+     * @param packagePin the name to set
      */
-    public void setName(String name) {
-        this.name = name;
+    public void setPackagePin(String packagePin) {
+        this.packagePin = packagePin;
     }
 
     /**
@@ -65,6 +84,21 @@ public class PackagePinConstraint {
     }
 
     public String toString() {
-        return name + ":" + ioStandard;
+        return packagePin + ":" + ioStandard;
+    }
+
+    public String getPortName() {
+        return portName;
+    }
+
+    public Stream<String> asXdc() {
+        return Stream.of(
+                "set_property PACKAGE_PIN "+packagePin+" [get_ports "+portName+"]",
+                "set_property IOSTANDARD "+ioStandard+" [get_ports "+portName+"]"
+        );
+    }
+
+    public void setPortName(String portName) {
+        this.portName = portName;
     }
 }

--- a/src/com/xilinx/rapidwright/ipi/RegularEdifCellLookup.java
+++ b/src/com/xilinx/rapidwright/ipi/RegularEdifCellLookup.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPropertyValue;
+
+public class RegularEdifCellLookup extends EdifCellLookup<EDIFHierCellInst> {
+
+    private final EDIFNetlist netlist;
+
+    public RegularEdifCellLookup(EDIFNetlist netlist) {
+        this.netlist = netlist;
+    }
+
+    @Override
+    public Stream<? extends EDIFHierCellInst> getChildrenOf(EDIFHierCellInst f) {
+        return f.getCellType().getCellInsts().stream().map(f::getChild);
+    }
+
+    @Override
+    public EDIFHierCellInst getChild(EDIFHierCellInst cell, String name) {
+        EDIFCellInst child = cell.getCellType().getCellInst(name);
+        if (child==null) {
+            return null;
+        }
+        return cell.getChild(child);
+    }
+
+    @Override
+    public EDIFHierCellInst toEdifHierCellInst(EDIFHierCellInst cell) {
+        return cell;
+    }
+
+
+    @Override
+    public EDIFHierCellInst getRoot() {
+        return netlist.getTopHierCellInst();
+    }
+
+    @Override
+    public String getAbsoluteFinalName(EDIFHierCellInst current) {
+        return current.getFullHierarchicalInstName();
+    }
+
+    @Override
+    public String getRelativeFinalName(EDIFHierCellInst current) {
+        return current.getInst().getName();
+    }
+
+    @Override
+    public String getAbsoluteOriginalName(EDIFHierCellInst current) {
+        return current.getFullHierarchicalInstName();
+    }
+
+    @Override
+    public String getRelativeOriginalName(EDIFHierCellInst current) {
+        return current.getInst().getName();
+    }
+
+    @Override
+    public String getCellType(EDIFHierCellInst current) {
+        EDIFPropertyValue prop = current.getCellType().getProperty("ORIG_REF_NAME");
+        if (prop != null) {
+            return prop.getValue();
+        }
+        return current.getCellType().getName();
+    }
+
+    @Override
+    public Class<EDIFHierCellInst> getCellClass() {
+        return EDIFHierCellInst.class;
+    }
+
+    @Override
+    public EDIFHierCellInst getInstFromOriginalName(String cellName) {
+        return netlist.getHierCellInstFromName(cellName);
+    }
+
+    @Override
+    public EDIFHierCellInst getInstFromFinalName(String s) {
+        return netlist.getHierCellInstFromName(s);
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/TclHashIdentifiedObject.java
+++ b/src/com/xilinx/rapidwright/ipi/TclHashIdentifiedObject.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+
+import java.util.function.Consumer;
+
+import tcl.lang.Interp;
+import tcl.lang.ReflectObject;
+import tcl.lang.TclException;
+import tcl.lang.TclObject;
+
+public class TclHashIdentifiedObject {
+    private static final String NAME_START = "-%%javahashstart%%-";
+    private static final String NAME_END = "-%%javahashend%%-";
+    public static <T> TclObject createReflectObject(Interp interp, Class<?> clazz, Object obj) throws TclException {
+        TclObject tclObject = ReflectObject.newInstance(interp, clazz, obj, NAME_START + ReflectObject.getHashString(clazz, obj) + NAME_END);
+        //Normally, TCL objects are removed from internal table once no variable refers to them.
+        //We want to keep them around till the end of life of the interpreter (since a stringified reference may still exist)
+        //Therefore, increase reference count by 1
+        tclObject.preserve();
+        return tclObject;
+    }
+
+    public static void unpack(Interp interp, String s, Consumer<String> outputString, Consumer<Object> outputObject) {
+        int offset = 0;
+        while (offset < s.length()) {
+            int objStart = s.indexOf(NAME_START, offset);
+            if (objStart==-1) {
+                outputString.accept(s.substring(offset, s.length()));
+                break;
+            }
+            if (objStart>offset) {
+                outputString.accept(s.substring(offset, objStart));
+            }
+            int objEnd = s.indexOf(NAME_END, objStart);
+
+            String objName = s.substring(objStart+NAME_START.length(), objEnd);
+            Object obj = ReflectObject.findObjectByHash(interp, objName);
+            if (obj==null) {
+                throw new RuntimeException("Did not find hash identified object "+objName+". Was this mistakenly freed?");
+            }
+            outputObject.accept(obj);
+
+            offset = objEnd+NAME_END.length();
+        }
+    }
+
+    public static boolean containsStringifiedObject(String s) {
+        return s.contains(NAME_START);
+    }
+
+    public static <T> String unpackAsString(Interp interp, String s, EdifCellLookup<T> lookup) {
+        StringBuilder sb = new StringBuilder();
+        unpack(interp, s, sb::append, obj -> {
+            T t = lookup.castCellInst(obj);
+            sb.append(lookup.getAbsoluteOriginalName(t));
+        });
+        return sb.toString();
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/UnsupportedConstraintElement.java
+++ b/src/com/xilinx/rapidwright/ipi/UnsupportedConstraintElement.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.ipi.xdcParserCommands.CellObject;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.DesignObject;
+import org.apache.commons.io.FilenameUtils;
+import tcl.lang.Interp;
+import tcl.lang.TclException;
+import tcl.lang.TclList;
+import tcl.lang.TclObject;
+
+public abstract class UnsupportedConstraintElement {
+    public static String toXdc(Stream<UnsupportedConstraintElement> unsupportedConstraintElements) {
+        return unsupportedConstraintElements.map(e->e.toXdc()).collect(Collectors.joining());
+    }
+
+    public static Stream<UnsupportedConstraintElement> wrapStream(Stream<UnsupportedConstraintElement> inner, Stream<UnsupportedConstraintElement> prefix, Stream<UnsupportedConstraintElement> suffix) {
+        if (prefix !=null) {
+            inner = Stream.concat(
+                    prefix,
+                    inner
+            );
+        }
+        if (suffix != null) {
+            inner = Stream.concat(
+                    inner,
+                    suffix
+            );
+        }
+        return inner;
+
+    }
+    public static Stream<UnsupportedConstraintElement> wrapStream(Stream<UnsupportedConstraintElement> inner, String prefix, String suffix) {
+        if (prefix !=null) {
+            inner = Stream.concat(
+                    Stream.of(new SyntaxConstraintElement(prefix)),
+                    inner
+            );
+        }
+        if (suffix != null) {
+            inner = Stream.concat(
+                    inner,
+                    Stream.of(new SyntaxConstraintElement(suffix))
+            );
+        }
+        return inner;
+    }
+
+
+    public static <T> Function<T, Stream<UnsupportedConstraintElement>> addSpacesBetween(Function<T, Stream<UnsupportedConstraintElement>> innerFunc) {
+        final boolean[] first = {true};
+        return e->{
+            if (first[0]) {
+                first[0] =false;
+                return innerFunc.apply(e);
+            }
+            return Stream.concat(Stream.of(new SyntaxConstraintElement(" ")), innerFunc.apply(e));
+        };
+    }
+
+    public static Function<UnsupportedConstraintElement, Stream<UnsupportedConstraintElement>> addSpacesBetween() {
+        final boolean[] first = {true};
+        return e->{
+            if (first[0]) {
+                first[0] =false;
+                return Stream.of(e);
+            }
+            return Stream.of(new SyntaxConstraintElement(" "), e);
+        };
+    }
+
+    public abstract String toXdc();
+
+    public abstract boolean referencesCell(String name);
+
+
+    public static class NameConstraintElement extends UnsupportedConstraintElement {
+        private final String text;
+
+        public NameConstraintElement(String text) {
+            this.text = text;
+        }
+
+        @Override
+        public String toXdc() {
+            return text;
+        }
+
+        @Override
+        public boolean referencesCell(String name) {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "N<"+toXdc()+">";
+        }
+    }
+    public static class SyntaxConstraintElement extends UnsupportedConstraintElement {
+        private final String text;
+
+        public SyntaxConstraintElement(String text) {
+            this.text = text;
+        }
+
+        @Override
+        public String toXdc() {
+            return text;
+        }
+
+        @Override
+        public boolean referencesCell(String name) {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "S<"+toXdc()+">";
+        }
+    }
+    public static class CellConstraintElement extends UnsupportedConstraintElement{
+        private final String cellName;
+
+        public CellConstraintElement(String cellName) {
+            this.cellName = cellName;
+        }
+
+        @Override
+        public String toXdc() {
+            return cellName;
+        }
+
+        @Override
+        public boolean referencesCell(String name) {
+            return cellName.equals(name);
+        }
+
+        public String getCellName() {
+            return cellName;
+        }
+
+        @Override
+        public String toString() {
+            return "C<"+toXdc()+">";
+        }
+    }
+
+
+    public static <T> Stream<UnsupportedConstraintElement> objToUnsupportedConstraintElement(Interp interp, TclObject obj, EdifCellLookup<T> lookup, boolean replaceProbableCells, boolean applyWildcardsChooseAny) {
+        try {
+            Optional<DesignObject<?>> designObject = DesignObject.unwrapTclObject(interp, obj, lookup);
+            if (designObject.isPresent()) {
+                return designObject.get().toUnsupportedConstraintElement();
+            }
+            if (obj.getInternalRep() instanceof TclList) {
+                TclObject[] elements = TclList.getElements(interp, obj);
+
+                Stream<UnsupportedConstraintElement> inner = Arrays.stream(elements).flatMap(e -> objToUnsupportedConstraintElement(interp, e, lookup, false, applyWildcardsChooseAny));
+                return wrapStream(inner, "{","}");
+            }
+
+            final boolean[] startsWithCell = {false};
+            final T[] cell = (T[]) new Object[]{null};
+
+            String s = obj.toString();
+            List<UnsupportedConstraintElement> res = new ArrayList<>();
+            TclHashIdentifiedObject.unpack(interp, s, partS -> {
+                res.add(new UnsupportedConstraintElement.NameConstraintElement(partS));
+            }, partObj -> {
+                DesignObject<?> po = DesignObject.requireCastUnwrappedObject(partObj, lookup);
+                if (po instanceof CellObject && cell[0]==null) {
+                    List<T> cells = ((CellObject<T>) po).getCells();
+                    if (cells.size()!=1) {
+                        throw new RuntimeException("should have one cell??");
+                    }
+                    startsWithCell[0] = true;
+
+                    T c = cells.iterator().next();
+                    cell[0] = c;
+                } else {
+                    po.toUnsupportedConstraintElement().forEach(res::add);
+                }
+            });
+
+            if (replaceProbableCells) {
+                absorbIntoCells(lookup, res, (T) cell[0], applyWildcardsChooseAny);
+            } else if (cell[0]!=null) {
+                res.add(0, new UnsupportedConstraintElement.CellConstraintElement(lookup.getAbsoluteFinalName(cell[0])));
+            }
+
+            if (s.contains(" ")) {
+                return wrapStream(res.stream(), "{", "}");
+            }
+            return res.stream();
+
+        } catch (TclException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T> void absorbIntoCells(EdifCellLookup<T> lookup, List<UnsupportedConstraintElement> res, T cell, boolean applyWildcardsChooseAny) {
+        if (res.size()!=1) {
+            return;
+        }
+        String suffix = res.get(0).toXdc();
+        if (cell != null) {
+            if (!suffix.startsWith("/")) {
+                //Suffix should always start with slash, something unsupported is happening
+
+                //Currently unimplemented! The code is trying to access a sibling cell on the same hierarchy level.
+                //Need to strip last level off cell, prepend suffix with its name
+                throw new RuntimeException("Suffix should start with slash!");
+            }
+            suffix = suffix.substring(1);
+        } else {
+            cell = lookup.getRoot();
+        }
+
+        while (suffix!=null) {
+            System.out.println("try to expand " + cell + " and " + suffix);
+            int slashPos = suffix.indexOf("/");
+            String currLevel, remaining;
+            if (slashPos == -1) {
+                currLevel = suffix;
+                remaining = null;
+            } else {
+                currLevel = suffix.substring(0, slashPos);
+                remaining = suffix.substring(slashPos+1);
+            }
+            System.out.println("decomposed into "+currLevel+" and "+remaining);
+            T child = lookup.getChild(cell, currLevel);
+            if (child == null) {
+                if (applyWildcardsChooseAny) {
+                    List<T> matches = lookup.getChildrenOf(cell)
+                            .filter(x-> FilenameUtils.wildcardMatch(lookup.getRelativeOriginalName(x), currLevel))
+                            .collect(Collectors.toList());
+                    if (matches.isEmpty()) {
+                        break;
+                    }
+                    child = matches.get(0);
+                    if (matches.size() > 1) {
+                        System.out.println("chose arbitrary wildcard match for "+currLevel+": "+child);
+                    }
+                } else {
+                    break;
+                }
+            }
+            if (child == null) {
+                break;
+            }
+            cell = child;
+            suffix = remaining;
+        }
+
+        if (cell==lookup.getRoot()) {
+            return;
+        }
+        System.out.println("applying absorption: "+cell+" and "+suffix);
+
+        res.clear();
+        res.add(new UnsupportedConstraintElement.CellConstraintElement(lookup.getAbsoluteFinalName(cell)));
+        if (suffix!=null) {
+            res.add(new NameConstraintElement("/"+suffix));
+        }
+
+        System.out.println(res);
+
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/XDCConstraints.java
+++ b/src/com/xilinx/rapidwright/ipi/XDCConstraints.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.util.Pair;
+
+public class XDCConstraints {
+    private Map<String, PackagePinConstraint> pinConstraints = new HashMap<>();
+    private Map<String, ClockConstraint> clockConstraints = new HashMap<>();
+    private Map<String, Map<String, String>> cellProperties = new HashMap<>();
+    private List<List<UnsupportedConstraintElement>> unsupportedConstraints = new ArrayList<>();
+
+
+    public XDCConstraints(Map<String, PackagePinConstraint> pinConstraints,
+                          Map<String, ClockConstraint> clockConstraints,
+                          Map<String, Map<String, String>> cellProperties,
+                          List<List<UnsupportedConstraintElement>> unsupportedConstraints) {
+        this.pinConstraints = pinConstraints;
+        this.clockConstraints = clockConstraints;
+        this.cellProperties = cellProperties;
+        this.unsupportedConstraints = unsupportedConstraints;
+    }
+
+    private static <T extends Constraint<T>> Map<String,T> cloneMap(Map<String,T> map) {
+        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e->e.getValue().clone()));
+    }
+    private static Map<String,Map<String, String>> cloneStringMap(Map<String,Map<String, String>> map) {
+        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e->new HashMap<>(e.getValue())));
+    }
+
+    private static List<List<UnsupportedConstraintElement>> cloneList(List<List<UnsupportedConstraintElement>> list) {
+        return list.stream().map(ArrayList::new).collect(Collectors.toList());
+    }
+    public XDCConstraints clone() {
+        return new XDCConstraints(
+                cloneMap(pinConstraints),
+                cloneMap(clockConstraints),
+                cloneStringMap(cellProperties),
+                cloneList(unsupportedConstraints)
+        );
+    }
+
+    public XDCConstraints() {
+    }
+
+    public Map<String, PackagePinConstraint> getPinConstraints() {
+        return pinConstraints;
+    }
+
+    public Map<String, ClockConstraint> getClockConstraints() {
+        return clockConstraints;
+    }
+
+    public Map<String, Map<String, String>> getCellProperties() {
+        return cellProperties;
+    }
+
+    public List<List<UnsupportedConstraintElement>> getUnsupportedConstraints() {
+        return unsupportedConstraints;
+    }
+
+    private static Stream<String> cellPropsToXdc(int counter, String cell, Map<String, String> properties) {
+        String varName = "rw_getcell_"+counter;
+        String initVarLine = "set "+varName+  " [get_cells {" + cell + "}]";
+        return Stream.concat(
+                Stream.of(initVarLine),
+                properties.entrySet().stream().map(propToValue->
+                                "set_property " + propToValue.getKey() + " " + propToValue.getValue() + " $"+varName
+                        )
+        );
+    }
+
+    public Stream<String> getAllAsXdc() {
+        Stream<String> clocks = clockConstraints.values().stream().map(ClockConstraint::asXdc);
+        Stream<String> unsupported = unsupportedConstraints.stream().map(e->UnsupportedConstraintElement.toXdc(e.stream()));
+
+        AtomicInteger varCounter = new AtomicInteger();
+        Stream<String> cellProps = cellProperties.entrySet().stream().flatMap(
+                cellToProps -> cellPropsToXdc(varCounter.getAndIncrement(), cellToProps.getKey(), cellToProps.getValue()));
+        Stream<String> pinConstrs = pinConstraints.values().stream().flatMap(PackagePinConstraint::asXdc);
+
+
+        return Stream.of(clocks, unsupported, cellProps, pinConstrs).flatMap(e->e);
+    }
+
+    /**
+     * Create a copy of
+     * @param netlist
+     * @return
+     */
+    public XDCConstraints newNetlistCopy(EDIFNetlist netlist) {
+        return null;
+    }
+
+    public void writeToFile(Path file) {
+        try (PrintWriter pw = new PrintWriter(Files.newBufferedWriter(file))) {
+            getAllAsXdc().forEach(pw::println);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private List<UnsupportedConstraintElement> rewriteUnsupported(List<UnsupportedConstraintElement> list, UnaryOperator<String> cellNameMapper) {
+        System.out.println("rewriting unsupported: "+list);
+        return list.stream().map(elem -> {
+            if (!(elem instanceof UnsupportedConstraintElement.CellConstraintElement)) {
+                return elem;
+            }
+            UnsupportedConstraintElement.CellConstraintElement cellElem = (UnsupportedConstraintElement.CellConstraintElement) elem;
+            return new UnsupportedConstraintElement.CellConstraintElement(cellNameMapper.apply(cellElem.getCellName()));
+        }).collect(Collectors.toList());
+    }
+
+    public XDCConstraints duplicateWithReplacedCellNames(UnaryOperator<String> cellNameMapper) {
+        Map<String, Map<String, String>> rewrittenProperties = cellProperties.entrySet().stream()
+                .flatMap(e -> e.getValue().entrySet().stream().map(e2 -> new Pair<>(e.getKey(), e2)))
+                .collect(Collectors.groupingBy(
+                        e -> cellNameMapper.apply(e.getFirst()), Collectors.toMap(
+                                e->e.getSecond().getKey(),
+                                e->e.getSecond().getValue(),
+                                (a,b) -> {
+                                    if (!a.equals(b)) {
+                                        throw new IllegalStateException("Cannot merge values "+a+" and "+b);
+                                    }
+                                    return a;
+                                }
+                        )
+                ));
+        List<List<UnsupportedConstraintElement>> rewrittenUnsupported = unsupportedConstraints.stream()
+                .map(l->rewriteUnsupported(l, cellNameMapper)).collect(Collectors.toList());
+        return new XDCConstraints(
+                pinConstraints,
+                clockConstraints,
+                rewrittenProperties,
+                rewrittenUnsupported
+        );
+    }
+
+    public boolean isCellReferencedInConstraints(String name) {
+        return unsupportedConstraints.stream().anyMatch(elements -> elements.stream().anyMatch(elem -> elem.referencesCell(name)));
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/XDCParser.java
+++ b/src/com/xilinx/rapidwright/ipi/XDCParser.java
@@ -27,11 +27,34 @@ package com.xilinx.rapidwright.ipi;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
+import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.CreateClockCommand;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.DesignObject;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.DumpObjsCommand;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.GetCellsCommand;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.ObjType;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.ObjectGetterCommand;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.SetPropertyCommand;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.UnsupportedCmdResult;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.UnsupportedCommand;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.UnsupportedGetterCommand;
+import com.xilinx.rapidwright.ipi.xdcParserCommands.UnsupportedIfCommand;
 import com.xilinx.rapidwright.util.FileTools;
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.Namespace;
+import tcl.lang.Resolver;
+import tcl.lang.TCL;
+import tcl.lang.TclException;
+import tcl.lang.TclObject;
+import tcl.lang.Var;
+import tcl.lang.WrappedCommand;
 
 
 /**
@@ -42,72 +65,185 @@ import com.xilinx.rapidwright.util.FileTools;
  */
 public class XDCParser {
 
-    private static boolean expect(String expected, String found, int lineNum, String line) {
-        if (!expected.equals(found)) {
-            throw new RuntimeException("\nERROR: While parsing line:\n   '" +
-                line + "' (line number " + lineNum + ")\n" + "   Expected: '" +
-                    expected + "'\n      Found: '" + found + "'\nStack Trace:");
+    private static <T> void replaceCommand(Interp interp, EdifCellLookup<T> cellLookup, String commandName) {
+        Command replacedCommand = Objects.requireNonNull(interp.getCommand(commandName));
+        if (commandName.equals("if")) {
+            interp.createCommand(commandName, new UnsupportedIfCommand(cellLookup, replacedCommand));
+        } else {
+            interp.createCommand(commandName, new UnsupportedGetterCommand(cellLookup, replacedCommand));
         }
-        return true;
+    }
+
+
+    public static <T> Interp makeTclInterp(XDCConstraints constraints, Device dev, EdifCellLookup<T> cellLookup) {
+        Interp interp = new Interp();
+        interp.createCommand("set_property", new SetPropertyCommand<>(constraints, dev, cellLookup));
+        interp.createCommand("current_design", new ObjectGetterCommand(false,ObjType.Design));
+
+        if (cellLookup!=null) {
+            interp.createCommand("get_cells", new GetCellsCommand<>(cellLookup));
+        } else {
+            interp.createCommand("get_cells", new ObjectGetterCommand(true, ObjType.Cell));
+        }
+        interp.createCommand("get_ports", new ObjectGetterCommand(true, ObjType.Port));
+        interp.createCommand("create_clock", new CreateClockCommand(constraints, cellLookup));
+
+        interp.createCommand("dump_objs", new DumpObjsCommand(cellLookup));
+
+        UnsupportedCommand unsupportedCommand = new UnsupportedCommand(constraints, cellLookup);
+        interp.createCommand("set_false_path", unsupportedCommand);
+        interp.createCommand("set_input_delay", unsupportedCommand);
+        interp.createCommand("set_output_delay", unsupportedCommand);
+        interp.createCommand("set_max_delay", unsupportedCommand);
+        interp.createCommand("set_bus_skew", unsupportedCommand);
+
+        UnsupportedGetterCommand unsupportedGetterCommand = new UnsupportedGetterCommand(cellLookup);
+        interp.createCommand("get_pins", unsupportedGetterCommand);
+        interp.createCommand("get_clocks", unsupportedGetterCommand);
+        interp.createCommand("get_property", unsupportedGetterCommand);
+        interp.createCommand("get_nets", unsupportedGetterCommand);
+        replaceCommand(interp, cellLookup, "if");
+        replaceCommand(interp, cellLookup, "llength");
+        replaceCommand(interp, cellLookup, "expr");
+
+        interp.createCommand("debugDump", new DebugDumpCommand());
+
+
+        interp.setCommandDoneCallback(()-> {
+            try {
+                DesignObject.unwrapTclObject(interp, interp.getResult(), cellLookup).ifPresent(obj -> {
+                    if (obj instanceof UnsupportedCmdResult<?>) {
+                        constraints.getUnsupportedConstraints().add(((UnsupportedCmdResult<?>) obj).withoutOutsideBrackets().getCmd());
+                    }
+                });
+            } catch (TclException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+
+        //We need to allow [*] and bracketed numbers (e.h. [1] ) as suffix on quoted strings, so we need to hook into the command lookup
+        //This actually mirrors Vivado's behaviour very closely! Just enter * on Vivado's tcl prompt to see
+        interp.createCommand("wrapInput", new Command() {
+            @Override
+            public void cmdProc(Interp interp, TclObject[] objv) throws TclException {
+                interp.setResult("["+objv[0]+"]");
+            }
+        });
+        try {
+            WrappedCommand wrapInputCmd = Objects.requireNonNull(Namespace.findCommand(interp, "wrapInput", null, 0));
+            interp.addInterpResolver("", new Resolver() {
+                @Override
+                public WrappedCommand resolveCmd(Interp interp, String name, Namespace context, int flags) throws TclException {
+                    if (name.matches("\\d+") || name.equals("*")) {
+                        return wrapInputCmd;
+                    }
+                    return null;
+                }
+
+                @Override
+                public Var resolveVar(Interp interp, String name, Namespace context, int flags) throws TclException {
+                    return null;
+                }
+            });
+        } catch (TclException e) {
+            throw new RuntimeException(e);
+        }
+
+        return interp;
     }
 
     /**
-     * Very rudimentary parsing to extract IO placements and IO standards.  This
-     * does not support many Tcl constructs.
-     * @param fileName Name of the XDC file to parse
-     * @param dev The device associated with the design.
-     * @return A map of port names to package pin information.
+     * Parse XDC
+     * @param dev the device
+     * @param lines XDC content
+     * @param cellLookup optional cell lookup, if given allows for more complex get_cells calls
+     * @return parsed constraints
      */
-    public static HashMap<String,PackagePinConstraint> parseXDC(String fileName, Device dev) {
-        HashMap<String,PackagePinConstraint> constraints = new HashMap<>();
-        int lineNum = 1;
-        for (String line : FileTools.getLinesFromTextFile(fileName)) {
-            if (line.trim().startsWith("#")) continue;
-            if (line.contains("set_property") && line.contains("PACKAGE_PIN")) {
-                String[] parts = line.split("\\s+");
-                expect("set_property", parts[0], lineNum, line);
-                expect("PACKAGE_PIN", parts[1], lineNum, line);
-                String pinLoc = parts[2];
-                if (!dev.getActivePackage().getPackagePinMap().containsKey(pinLoc)) {
-                    expect("<VALID_PKG_PIN>", pinLoc,lineNum,line);
-                }
-                expect("[get_ports", parts[3], lineNum, line);
-                String key = parts[4].substring(0, parts[4].lastIndexOf(']'));
-                key = key.replace("}", "");
-                key = key.replace("{", "");
-                PackagePinConstraint pkgPin = constraints.get(key);
-                if (pkgPin == null) {
-                    pkgPin = new PackagePinConstraint();
-                    constraints.put(key, pkgPin);
-                }
-                pkgPin.setName(pinLoc);
-            } else if (line.contains("set_property") && line.contains("IOSTANDARD")) {
-                String[] parts = line.split("\\s+");
-                expect("set_property", parts[0], lineNum, line);
-                expect("IOSTANDARD", parts[1], lineNum, line);
-                String ioStandard = parts[2];
-                expect("[get_ports", parts[3], lineNum, line);
-                String key = parts[4].substring(0, parts[4].lastIndexOf(']'));
-                key = key.replace("}", "");
-                key = key.replace("{", "");
-                PackagePinConstraint pkgPin = constraints.get(key);
-                if (pkgPin == null) {
-                    pkgPin = new PackagePinConstraint();
-                    constraints.put(key, pkgPin);
-                }
-                pkgPin.setIOStandard(ioStandard);
-            }
-            lineNum++;
-        }
+    public static XDCConstraints parseXDC(Device dev, List<String> lines, EdifCellLookup<?> cellLookup) {
+        XDCConstraints constraints = new XDCConstraints();
 
+
+        Interp interp = makeTclInterp(constraints, dev, cellLookup);
+        try {
+            String data = String.join("\n", lines);
+            try {
+                interp.eval(data);
+            } catch (TclException ex) {
+                int code = ex.getCompletionCode();
+                switch (code) {
+                    case TCL.ERROR:
+                        throw new RuntimeException(interp.getResult().toString()+" in line "+interp.getErrorLine(), ex);
+                    case TCL.BREAK:
+                        throw new RuntimeException(
+                                "invoked \"break\" outside of a loop", ex);
+                    case TCL.CONTINUE:
+                        throw new RuntimeException(
+                                "invoked \"continue\" outside of a loop", ex);
+                    default:
+                        throw new RuntimeException(
+                                "command returned bad error code: " + code, ex);
+                }
+            }
+        }  finally {
+            interp.dispose();
+        }
 
         return constraints;
     }
 
-    public static void writeXDC(List<String> constraints, OutputStream out) {
-        if (constraints == null) return;
+
+
+    /**
+     * @param fileName Name of the XDC file to parse
+     * @param dev the design
+     * @param cellLookup optional cell lookup, if given allows for more complex get_cells calls
+     * @return A map of port names to package pin information.
+     */
+    public static XDCConstraints parseXDCNew(String fileName, Device dev, EdifCellLookup<?> cellLookup){
+        return parseXDC(dev, FileTools.getLinesFromTextFile(fileName), cellLookup);
+    }
+
+    /**
+     * @param fileName Name of the XDC file to parse
+     * @param dev the design
+     * @param netlist optional netlist to enable more advanced get_cells calls
+     * @return A map of port names to package pin information.
+     */
+    public static XDCConstraints parseXDCNew(String fileName, Device dev, EDIFNetlist netlist){
+        return parseXDC(dev, FileTools.getLinesFromTextFile(fileName), new RegularEdifCellLookup(netlist));
+    }
+
+    /**
+     * @param fileName Name of the XDC file to parse
+     * @param design The design
+     * @return A map of port names to package pin information.
+     */
+    public static XDCConstraints parseXDCNew(String fileName, Design design){
+        return parseXDC(design.getDevice(), FileTools.getLinesFromTextFile(fileName), new RegularEdifCellLookup(design.getNetlist()));
+    }
+
+    public static Map<String,PackagePinConstraint> parseXDC(String fileName, Design design) {
+        return parseXDCNew(fileName, design).getPinConstraints();
+    }
+
+    /**
+     * @param fileName Name of the XDC file to parse
+     * @param dev the device
+     * @return A map of port names to package pin information.
+     */
+    public static XDCConstraints parseXDCNew(String fileName, Device dev){
+        return parseXDC(dev, FileTools.getLinesFromTextFile(fileName), null);
+    }
+
+    public static Map<String,PackagePinConstraint> parseXDC(String fileName, Device dev) {
+        return parseXDCNew(fileName, dev).getPinConstraints();
+    }
+
+    public static void writeXDC(List<String> constraints, OutputStream out){
+        if(constraints == null) return;
         try {
-            for (String s : constraints) {
+            for(String s : constraints){
                 out.write(s.getBytes());
                 out.write('\n');
             }

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/CellObject.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/CellObject.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import com.xilinx.rapidwright.ipi.UnsupportedConstraintElement;
+
+public class CellObject<T> extends DesignObject {
+    private final List<T> cells;
+    private final EdifCellLookup<? super T> cellLookup;
+
+    public CellObject(List<T> cells, EdifCellLookup<? super T> cellLookup) {
+        this.cells = cells;
+        this.cellLookup = cellLookup;
+    }
+
+    public String toXdc() {
+        if (cells.size()==1) {
+            String onlyCell = cellLookup.getAbsoluteFinalName(cells.get(0));
+            if (cells.size() == 1 && !onlyCell.contains("[")) {
+                return "[get_cells " + onlyCell + "]";
+            }
+        }
+
+        return "[get_cells {" + cells.stream().map(cellLookup::getAbsoluteFinalName).collect(Collectors.joining(" ")) + "}]";
+    }
+
+    @Override
+    public Stream<UnsupportedConstraintElement> toUnsupportedConstraintElement() {
+        if (cells.size()==1) {
+            String onlyCell = cellLookup.getAbsoluteFinalName(cells.get(0));
+            if (!onlyCell.contains("[")) {
+                return Stream.of(
+                        new UnsupportedConstraintElement.SyntaxConstraintElement("["),
+                        new UnsupportedConstraintElement.NameConstraintElement("get_cells"),
+                        new UnsupportedConstraintElement.SyntaxConstraintElement(" "),
+                        new UnsupportedConstraintElement.CellConstraintElement(onlyCell),
+                        new UnsupportedConstraintElement.SyntaxConstraintElement("]")
+                );
+            }
+        }
+
+        Stream<UnsupportedConstraintElement> cellStream = cells.stream()
+                .map(cellLookup::getAbsoluteFinalName)
+                .map(UnsupportedConstraintElement.CellConstraintElement::new)
+                .flatMap(UnsupportedConstraintElement.addSpacesBetween());
+        return UnsupportedConstraintElement.wrapStream(cellStream, Stream.of(
+                new UnsupportedConstraintElement.SyntaxConstraintElement("["),
+                new UnsupportedConstraintElement.NameConstraintElement("get_cells"),
+                new UnsupportedConstraintElement.SyntaxConstraintElement(" "),
+                new UnsupportedConstraintElement.SyntaxConstraintElement("{")
+                ), Stream.of(
+
+                new UnsupportedConstraintElement.SyntaxConstraintElement("}"),
+                new UnsupportedConstraintElement.SyntaxConstraintElement("]")
+        ));
+    }
+
+    public List<T> getCells() {
+        return cells;
+    }
+
+    @Override
+    public String toString() {
+        return cells.toString();
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/CreateClockCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/CreateClockCommand.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.List;
+
+import com.xilinx.rapidwright.ipi.ClockConstraint;
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import com.xilinx.rapidwright.ipi.XDCConstraints;
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.TclException;
+import tcl.lang.TclObject;
+
+public class CreateClockCommand implements Command {
+
+    private final XDCConstraints constraints;
+    private final EdifCellLookup<?> cellLookup;
+
+    public CreateClockCommand(XDCConstraints constraints, EdifCellLookup<?> cellLookup) {
+
+        this.constraints = constraints;
+        this.cellLookup = cellLookup;
+    }
+
+    @Override
+    public void cmdProc(Interp interp, TclObject[] objv) throws TclException {
+        List<String> ports = null;
+        String period = null;
+        String clockName = null;
+        for (int i = 1; i < objv.length; i++) {
+            if (objv[i].toString().startsWith("-")) {
+                switch (objv[i].toString()) {
+                    case "-period":
+                        period = objv[++i].toString();
+                        break;
+                    case "-name":
+                        clockName = objv[++i].toString();
+
+                        break;
+                    case "-waveform":
+                        //Just skip the waveform specification
+                        ++i;
+                        break;
+                    default:
+                        throw new RuntimeException("expected -name | -period | -waveform but got " + objv[i]);
+                }
+            } else {
+
+                DesignObject obj = DesignObject.requireUnwrapTclObject(interp, objv[i], cellLookup);
+                if (!(obj instanceof NameDesignObject) || ((NameDesignObject) obj).getType() != ObjType.Port) {
+                    throw new RuntimeException("expected port but got " + obj.toXdc());
+                }
+                ports = ((NameDesignObject) obj).getObjects();
+
+                if (i + 1 != objv.length) {
+                    throw new RuntimeException("Extra elements after port name");
+                }
+            }
+        }
+        if (ports == null) {
+            throw new RuntimeException("did not have ports!");
+        }
+        for (String port : ports) {
+            constraints.getClockConstraints().put(port, new ClockConstraint(clockName, Double.parseDouble(period), port));
+        }
+
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/DesignObject.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/DesignObject.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import com.xilinx.rapidwright.ipi.UnsupportedConstraintElement;
+import tcl.lang.Interp;
+import tcl.lang.ReflectObject;
+import tcl.lang.TclException;
+import tcl.lang.TclList;
+import tcl.lang.TclObject;
+
+public abstract class DesignObject<T> {
+    public static <T> DesignObject<?> requireCastUnwrappedObject(Object obj, EdifCellLookup<T> lookup) {
+        if (lookup != null && lookup.getCellClass().isInstance(obj)) {
+            return new CellObject<T>(Collections.singletonList(lookup.castCellInst(obj)), lookup);
+        }
+        return (DesignObject<?>) obj;
+    }
+    public static <T> Optional<DesignObject<?>> unwrapTclObject(Interp interp, TclObject obj, EdifCellLookup<T> lookup) throws TclException {
+        if (obj.getInternalRep() instanceof TclList) {
+            TclObject[] elements = TclList.getElements(interp, obj);
+            if (!Arrays.stream(elements).allMatch(e-> {
+                try {
+                    return e.getInternalRep() instanceof ReflectObject &&lookup.getCellClass().isInstance(ReflectObject.get(interp,e));
+                } catch (TclException ex) {
+                    throw new RuntimeException(ex);
+                }
+            })) {
+                return Optional.empty();
+            }
+            List<T> cells = Arrays.stream(elements).map(x -> {
+                try {
+                    return lookup.castCellInst(ReflectObject.get(interp, x));
+                } catch (TclException e) {
+                    throw new RuntimeException(e);
+                }
+            }).collect(Collectors.toList());
+            return Optional.<DesignObject<?>>of(new CellObject<>(cells, lookup));
+        }
+        if (obj.getInternalRep() instanceof ReflectObject) {
+            return Optional.of(requireCastUnwrappedObject(ReflectObject.get(interp, obj), lookup));
+        }
+        return Optional.empty();
+    }
+
+    private static String objDebugInfo(Interp interp, TclObject obj) {
+        try {
+            if (obj.getInternalRep() instanceof ReflectObject) {
+                Object ref = ReflectObject.get(interp, obj);
+                return " is reflect object type " + ref.getClass() + ": " + ref;
+            } else if (obj.getInternalRep() instanceof TclList) {
+                return " is list: ["+ Arrays.stream(TclList.getElements(interp, obj)).map(o->objDebugInfo(interp,o)).collect(Collectors.joining(", "))+"]";
+            } else {
+                return " internal rep: "+obj.getInternalRep().getClass();
+            }
+        } catch (TclException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    public static <T> DesignObject<?> requireUnwrapTclObject(Interp interp, TclObject obj, EdifCellLookup<T> lookup) throws TclException {
+        return unwrapTclObject(interp, obj, lookup)
+                .orElseThrow(()-> {
+                    String moreInfo = objDebugInfo(interp, obj);
+                    return new IllegalArgumentException("expected DesignObject but got " + obj + moreInfo);
+                });
+
+    }
+
+
+    protected static Collector<DesignObject<?>, ?, Optional<DesignObject<?>>> tryMerge() {
+
+        return Collectors.reducing((a, b) -> {
+            if (a == null) {
+                return null;
+            }
+            if (b == null) {
+                return null;
+            }
+            if (a instanceof NameDesignObject && b instanceof NameDesignObject) {
+                if (!((NameDesignObject<?>) a).getType().equals(((NameDesignObject<?>) b).getType())) {
+                    return null;
+                }
+                boolean aHasObjs = ((NameDesignObject<?>) a).getObjects() == null;
+                boolean bHasObjs = ((NameDesignObject<?>) b).getObjects() == null;
+                if (aHasObjs != bHasObjs) {
+                    return null;
+                }
+                if (!aHasObjs) {
+                    return a;
+                }
+
+                List<String> res = new ArrayList<>();
+                res.addAll(((NameDesignObject<?>) a).getObjects());
+                res.addAll(((NameDesignObject<?>) b).getObjects());
+                return new NameDesignObject<>(((NameDesignObject<?>) a).getType(), res);
+            }
+            return null;
+        });
+    }
+
+    public abstract String toXdc();
+
+    public abstract Stream<UnsupportedConstraintElement> toUnsupportedConstraintElement();
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/DumpObjsCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/DumpObjsCommand.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.Optional;
+
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.TclException;
+import tcl.lang.TclObject;
+
+public class DumpObjsCommand implements Command {
+    private final EdifCellLookup<?> cellLookup;
+    public DumpObjsCommand(EdifCellLookup<?> cellLookup) {
+        this.cellLookup = cellLookup;
+    }
+
+
+
+    @Override
+    public void cmdProc(Interp interp, TclObject[] objv) throws TclException {
+        TclObject tclObject = objv[1];
+        Optional<DesignObject<?>> obj = DesignObject.unwrapTclObject(interp, tclObject, cellLookup);
+        if (obj.isPresent()) {
+            System.out.println(obj.get());
+        } else {
+            System.out.println("no java obj: "+tclObject);
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/GetCellsCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/GetCellsCommand.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import com.xilinx.rapidwright.ipi.TclHashIdentifiedObject;
+import com.xilinx.rapidwright.util.Pair;
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.TclException;
+import tcl.lang.TclList;
+import tcl.lang.TclObject;
+
+public class GetCellsCommand<T> implements Command {
+
+    private final EdifCellLookup<T> cellLookup;
+
+    public GetCellsCommand(EdifCellLookup<T> cellLookup) {
+        this.cellLookup = cellLookup;
+    }
+
+    @Override
+    public void cmdProc(Interp interp, TclObject[] argv) throws TclException {
+        boolean hierFlag = false;
+        boolean regexpFlag = false;
+        TclObject filter = null;
+        String cellNameStr = null;
+
+        for (int i = 1; i < argv.length; i++) {
+            String item = argv[i].toString();
+            switch (item) {
+                case "-hier":
+                    hierFlag = true;
+                    break;
+                case "-filter":
+                    filter = argv[++i];
+                    break;
+                case "-regexp":
+                    regexpFlag = true;
+                    break;
+                case "-quiet":
+                    //Ignore
+                    break;
+                case "-of_objects":
+                    interp.setResult(UnsupportedCmdResult.makeTclObj(interp, argv, cellLookup, false, false));
+                    return;
+                default:
+                    if (cellNameStr != null) {
+                        throw new RuntimeException("Duplicate cell-name string");
+                    }
+                    cellNameStr = TclHashIdentifiedObject.unpackAsString(interp, argv[i].toString(), cellLookup);
+                    break;
+            }
+
+        }
+
+        if (cellNameStr != null && !regexpFlag && filter == null && !hierFlag) {
+
+            simpleGetCells(interp, cellNameStr);
+        } else {
+            complexGetCells(interp, hierFlag, regexpFlag, cellNameStr, filter, argv);
+        }
+    }
+
+    /**
+     * This only supports OR-in together different == clauses.
+     *
+     * @param expr
+     * @return
+     */
+    private static Map<String, Set<String>> parseFilterExpression(String expr) {
+        //Remove unneeded parens
+        if (expr.matches("\\([^)]*\\)")) {
+            expr = expr.substring(1, expr.length() - 1);
+        }
+        if (expr.contains("&&") || expr.contains("(")) {
+            throw new RuntimeException("expression too complex: " + expr);
+        }
+        String[] split = expr.split("\\s*\\|\\|\\s*");
+
+        Map<String, Set<String>> oredClauses = new HashMap<>();
+        for (String s : split) {
+            String[] clause = s.split("\\s*==\\s*");
+            if (clause.length != 2) {
+                throw new RuntimeException("unexpected clause " + s + " in " + expr);
+            }
+            oredClauses.computeIfAbsent(clause[0], x -> new HashSet<>()).add(clause[1]);
+        }
+
+        Set<String> refname = oredClauses.get("REF_NAME");
+        Set<String> origrefname = oredClauses.get("ORIG_REF_NAME");
+        if (!Objects.equals(refname, origrefname)) {
+            throw new RuntimeException("expression too complex2: " + expr);
+        }
+        oredClauses.remove("ORIG_REF_NAME");
+
+        return oredClauses;
+    }
+
+    private static int cellDebugCallCout = 0;
+
+    private void complexGetCells(Interp interp, boolean hierFlag, boolean regexFlag, String cellNames, TclObject filterArg, TclObject[] argv) throws TclException {
+        Stream<T> candidateSupplier = null;
+        List<Pair<Predicate<T>, Function<T, String>>> filter = new ArrayList<>();
+
+        if (!hierFlag) {
+            throw new RuntimeException("no hier flag? not implemented");
+        }
+
+
+        if (filterArg != null) {
+            Map<String, Set<String>> s = parseFilterExpression(filterArg.toString());
+
+            if (s.size() > 1) {
+                throw new RuntimeException("Filter too complex");
+            }
+            String entryType = s.keySet().iterator().next();
+            Set<String> values = s.get(entryType);
+            if (Objects.equals(entryType, "REF_NAME")) {
+                filter.add(new Pair<>(cellLookup.getCellTypeFilter(values), e -> {
+                    return "checked if " + cellLookup.getCellType(e) + " is in " + values;
+                }));
+            } else if (Objects.equals(entryType, "PARENT")) {
+                List<T> roots = values.stream()
+                        .map(r-> TclHashIdentifiedObject.unpackAsString(interp, r, cellLookup))
+                        .flatMap(cellLookup::getHierCellInstsFromWildcardName)
+                        .collect(Collectors.toList());
+                candidateSupplier = roots.stream().flatMap(cellLookup::getChildrenOf);
+                System.out.println("Supplying candidates from direct children of " + roots + ". raw roots: " + values);
+            }
+        }
+
+        if (cellNames != null) {
+            if (regexFlag) {
+                filter.add(new Pair<>(cellLookup.getAbsoluteRegexFilter(cellNames), eci -> "Checking if " + eci + " matches regex " + cellNames));
+            } else {
+                filter.add(new Pair<>(cellLookup.getAbsoluteWildcardFilter(cellNames), eci -> "Checking if " + eci + " matches wildcard " + cellNames));
+            }
+        }
+
+        if (candidateSupplier == null) {
+            System.out.println("Supplying candidates from all cells");
+            candidateSupplier = cellLookup.getAllCellInsts();
+        }
+        boolean debugFiltering = false;
+        List<T> cells;
+        if (!debugFiltering) {
+            Stream<T> resultStream = candidateSupplier;
+            for (Pair<Predicate<T>,?> filterStage : filter) {
+                resultStream = resultStream.filter(filterStage.getFirst());
+            }
+            cells = resultStream.collect(Collectors.toList());
+        } else{
+            Path debugFile = Paths.get("./debugCellFiltering/"+(cellDebugCallCout++)+".txt");
+            try {
+                Files.createDirectories(debugFile.getParent());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            System.out.println("Writing debug info to "+debugFile);
+            try (PrintStream ps = new PrintStream(Files.newOutputStream(debugFile))) {
+                ps.println("Debugging for "+ Arrays.toString(argv));
+
+                ps.println("hierFlag = " + hierFlag);
+                ps.println("regexFlag = " + regexFlag);
+                ps.println("cellNames = " + cellNames);
+                ps.println("filterArg = " + filterArg);
+
+                cells = new ArrayList<>();
+                Iterable<T> iterable = candidateSupplier::iterator;
+                for (T eci : iterable) {
+                    ps.println("checking eci: " + eci);
+                    boolean in = true;
+                    for (int i = 0; i < filter.size(); i++) {
+                        Predicate<T> f = filter.get(i).getFirst();
+                        boolean test = f.test(eci);
+                        if (!test) {
+                            ps.println("\tFiltered out by filter " + i + ": " + filter.get(i).getSecond().apply(eci));
+                            in = false;
+                            break;
+                        } else {
+                            ps.println("\taccepted by filter " + i + ": " + filter.get(i).getSecond().apply(eci));
+                        }
+                    }
+                    if (in) {
+                        ps.println("\tadding!");
+                        cells.add(eci);
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        TclObject list = TclList.newInstance();
+        if (cells.isEmpty()) {
+            System.out.println("did not find cell for call "+Arrays.toString(argv));
+        } else {
+            cells.stream().sorted(Comparator.comparing(cellLookup::getAbsoluteOriginalName))
+                    .forEach(cell-> {
+                        try {
+                            TclList.append(interp, list, cellLookup.toReflectObj(interp, cell));
+                        } catch (TclException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+        interp.setResult(list);
+    }
+
+
+    private void simpleGetCells(Interp interp, String cellNameStr) throws TclException {
+        String[] cellNames = cellNameStr.split(" ");
+        TclObject list = TclList.newInstance();
+        for (String cellName : cellNames) {
+            List<T> cells = cellLookup.getHierCellInstsFromWildcardName(cellName).collect(Collectors.toList());
+            if (cells.isEmpty()) {
+                System.out.println("did not find cell for " + cellName);
+            } else {
+                cells.sort(Comparator.comparing(cellLookup::getAbsoluteOriginalName));
+                for (T cell : cells) {
+                    TclList.append(interp, list, cellLookup.toReflectObj(interp, cell));
+                }
+            }
+        }
+        interp.setResult(list);
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/NameDesignObject.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/NameDesignObject.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.ipi.UnsupportedConstraintElement;
+
+public class NameDesignObject<T> extends DesignObject<T> {
+    private final ObjType type;
+    private final List<String> objects;
+
+    public NameDesignObject(ObjType type, List<String> objects) {
+        this.type = type;
+        this.objects = objects;
+    }
+
+    @Override
+    public String toString() {
+        return "DesignObjects{" +
+                "type='" + type + '\'' +
+                ", objects=" + objects +
+                '}';
+    }
+
+    public String toXdc() {
+        return UnsupportedConstraintElement.toXdc(toUnsupportedConstraintElement());
+    }
+
+    @Override
+    public Stream<UnsupportedConstraintElement> toUnsupportedConstraintElement() {
+        if (objects == null) {
+            return Stream.of(
+                    new UnsupportedConstraintElement.SyntaxConstraintElement("["),
+                    new UnsupportedConstraintElement.NameConstraintElement(type.getXdcCommand()),
+                    new UnsupportedConstraintElement.SyntaxConstraintElement("]")
+                    );
+        }
+        boolean braces = objects.size()!=1 || objects.stream().anyMatch(o->o.contains("*") || o.contains("$"));
+
+
+
+        List<UnsupportedConstraintElement> before = new ArrayList<>(Arrays.asList(
+                new UnsupportedConstraintElement.SyntaxConstraintElement("["),
+                new UnsupportedConstraintElement.NameConstraintElement(type.getXdcCommand()),
+                new UnsupportedConstraintElement.SyntaxConstraintElement(" ")
+        ));
+        List<UnsupportedConstraintElement> after = new ArrayList<>(Collections.singleton(
+
+                new UnsupportedConstraintElement.SyntaxConstraintElement("]")
+        ));
+        if (braces) {
+            before.add(new UnsupportedConstraintElement.SyntaxConstraintElement("{"));
+            after.add(0, new UnsupportedConstraintElement.SyntaxConstraintElement("}"));
+        }
+
+        Function<? super String, ? extends UnsupportedConstraintElement> uceConstructor = type == ObjType.Cell ? UnsupportedConstraintElement.CellConstraintElement::new : UnsupportedConstraintElement.NameConstraintElement::new;
+        Stream<UnsupportedConstraintElement> objs = objects.stream().map(uceConstructor).flatMap(UnsupportedConstraintElement.addSpacesBetween());
+        return UnsupportedConstraintElement.wrapStream(objs, before.stream(), after.stream());
+    }
+
+    public ObjType getType() {
+        return type;
+    }
+
+    public List<String> getObjects() {
+        return objects;
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/ObjType.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/ObjType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+public enum ObjType {
+    Design("current_design"),
+    Cell("get_cells"),
+    Port("get_ports");
+
+    private final String xdcCommand;
+
+    ObjType(String xdcCommand) {
+        this.xdcCommand = xdcCommand;
+    }
+
+    public String getXdcCommand() {
+        return xdcCommand;
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/ObjectGetterCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/ObjectGetterCommand.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.Arrays;
+
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.ReflectObject;
+import tcl.lang.TclException;
+import tcl.lang.TclNumArgsException;
+import tcl.lang.TclObject;
+
+public class ObjectGetterCommand implements Command {
+
+    private final boolean takesObjects;
+    private final ObjType objType;
+
+    public ObjectGetterCommand(boolean takesObjects, ObjType objType) {
+        this.takesObjects = takesObjects;
+
+        this.objType = objType;
+    }
+
+    @Override
+    public void cmdProc(Interp interp, TclObject[] argv) throws TclException {
+        DesignObject res;
+        if (!takesObjects) {
+            if (argv.length != 1) {
+                throw new TclNumArgsException(interp, 1, argv, "");
+            }
+            res = new NameDesignObject(objType, null);
+        } else {
+            if (argv.length != 2) {
+                throw new TclNumArgsException(interp, 2, argv, "");
+            }
+
+            res = new NameDesignObject(objType, Arrays.asList(argv[1].toString().split(" ")));
+        }
+        interp.setResult(ReflectObject.newInstance(interp, res.getClass(), res));
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/SetPropertyCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/SetPropertyCommand.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import com.xilinx.rapidwright.ipi.PackagePinConstraint;
+import com.xilinx.rapidwright.ipi.UnsupportedConstraintElement;
+import com.xilinx.rapidwright.ipi.XDCConstraints;
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.TclException;
+import tcl.lang.TclObject;
+
+public class SetPropertyCommand<T> implements Command {
+    private final XDCConstraints constraints;
+    private final Device dev;
+    private final  EdifCellLookup<T> cellLookup;
+
+    public SetPropertyCommand(XDCConstraints constraints, Device dev, EdifCellLookup<T> cellLookup) {
+        this.constraints = constraints;
+        this.dev = dev;
+        this.cellLookup = cellLookup;
+    }
+
+    public void cmdProc(Interp interp, TclObject[] argv)
+            throws TclException {
+        String k = argv[1].toString();
+        String v = argv[2].toString();
+        DesignObject<?> obj = DesignObject.requireUnwrapTclObject(interp, argv[argv.length - 1], cellLookup);
+
+        if (k.equals("-dict")) {
+            String[] items = v.split(" ");
+            if (items.length % 2 != 0) {
+                throw new TclException(interp, "found odd number of arguments in kv-dict");
+            }
+            for (int i = 0; i < items.length; i += 2) {
+                storeKV(items[i], items[i + 1], obj);
+            }
+        } else {
+            storeKV(k, v, obj);
+        }
+
+        interp.setResult(0);
+    }
+
+    private void eachPin(NameDesignObject<?> pins, BiConsumer<PackagePinConstraint, String> setter, String value) {
+        for (String object : pins.getObjects()) {
+            PackagePinConstraint ppc = constraints.getPinConstraints().computeIfAbsent(object, PackagePinConstraint::new);
+            setter.accept(ppc, value);
+        }
+    }
+
+    private void addUnsupportedKV(String k, String v, DesignObject<?> someObj) {
+        Stream<UnsupportedConstraintElement> line = Stream.concat(
+                Stream.of(
+                        new UnsupportedConstraintElement.NameConstraintElement("set_property"),
+                        new UnsupportedConstraintElement.SyntaxConstraintElement(" "),
+                        new UnsupportedConstraintElement.NameConstraintElement(k),
+                        new UnsupportedConstraintElement.SyntaxConstraintElement(" "),
+                        new UnsupportedConstraintElement.NameConstraintElement(v),
+                        new UnsupportedConstraintElement.SyntaxConstraintElement(" ")
+                ),
+                someObj.toUnsupportedConstraintElement()
+        );
+        List<UnsupportedConstraintElement> l = line.collect(Collectors.toList());
+        constraints.getUnsupportedConstraints().add(l);
+    }
+
+    private void storeKV(String k, String v, DesignObject<?> someObj) {
+        if (someObj instanceof CellObject) {
+            for (T cell : ((CellObject<T>) someObj).getCells()) {
+                constraints.getCellProperties().computeIfAbsent(cellLookup.getAbsoluteFinalName(cell), x -> new HashMap<>()).put(k, v);
+            }
+            return;
+        }
+        if (someObj instanceof UnsupportedCmdResult<?>) {
+            addUnsupportedKV(k, v, someObj);
+            return;
+        }
+        if (!(someObj instanceof NameDesignObject<?>)) {
+            throw new RuntimeException("expected NameDesignObject but got "+someObj.getClass()+": "+someObj);
+        }
+        NameDesignObject<?> obj = (NameDesignObject<?>) someObj;
+        switch (obj.getType()) {
+            case Design:
+                addUnsupportedKV(k, v, obj);
+                break;
+            case Cell:
+                if (k.equals("ASYNC_REG")) {
+                    addUnsupportedKV(k,v,obj);
+                } else {
+                    for (String object : obj.getObjects()) {
+                        constraints.getCellProperties().computeIfAbsent(object, x -> new HashMap<>()).put(k, v);
+                    }
+                }
+                break;
+            case Port:
+                switch (k) {
+                    case "IOSTANDARD":
+                        eachPin(obj, PackagePinConstraint::setIOStandard, v);
+                        break;
+                    case "PACKAGE_PIN":
+                    case "LOC":
+                        if (dev !=null && !dev.getActivePackage().getPackagePinMap().containsKey(v)) {
+                            throw new RuntimeException("Invalid pin for " + obj + ": " + v);
+                        }
+                        eachPin(obj, PackagePinConstraint::setPackagePin, v);
+                        break;
+                    default:
+                        addUnsupportedKV(k, v, obj);
+
+                }
+                break;
+            default:
+                throw new RuntimeException("Unexpected obj type");
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/UnsupportedCmdResult.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/UnsupportedCmdResult.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import com.xilinx.rapidwright.ipi.TclHashIdentifiedObject;
+import com.xilinx.rapidwright.ipi.UnsupportedConstraintElement;
+import tcl.lang.Interp;
+import tcl.lang.TclException;
+import tcl.lang.TclObject;
+
+/**
+ * This wraps an unsupported command's call to support passing it on
+ */
+public class UnsupportedCmdResult<T> extends DesignObject{
+    private final List<UnsupportedConstraintElement> cmd;
+
+    private final EdifCellLookup<T> lookup;
+
+    public UnsupportedCmdResult(List<UnsupportedConstraintElement> cmd, EdifCellLookup<T> lookup) {
+        this.cmd = cmd;
+        this.lookup = lookup;
+    }
+
+    private static Function<UnsupportedConstraintElement, Stream<UnsupportedConstraintElement>> wrapDollarSigns() {
+        final boolean[] inBraces = {false};
+        return uce -> {
+            if (uce instanceof UnsupportedConstraintElement.CellConstraintElement || uce instanceof UnsupportedConstraintElement.NameConstraintElement) {
+                if (!inBraces[0] && uce.toXdc().contains("$")) {
+                    inBraces[0] = true;
+                    return Stream.of(new UnsupportedConstraintElement.SyntaxConstraintElement("{"), uce);
+                }
+                return Stream.of(uce);
+            } else {
+                String s = uce.toXdc();
+                StringBuilder sb = new StringBuilder();
+                for (char c : s.toCharArray()) {
+                    switch (c) {
+                        case '{':
+                            inBraces[0] = true;
+                            sb.append(c);
+                            break;
+                        case '}':
+                            inBraces[0] = false;
+                            sb.append(c);
+                            break;
+                        case ']':
+                            if (inBraces[0]) {
+                                sb.append('}');
+                                inBraces[0] = false;
+                            }
+                            sb.append(c);
+                            break;
+                        default:
+                            sb.append(c);
+                            break;
+                    }
+                }
+                return Stream.of(new UnsupportedConstraintElement.SyntaxConstraintElement(sb.toString()));
+            }
+        };
+    }
+
+    public UnsupportedCmdResult(Interp interp, TclObject[] argv, EdifCellLookup<T> lookup, boolean replaceProbableCells, boolean applyWildcardsChooseAny) {
+        this.lookup = lookup;
+        Stream<UnsupportedConstraintElement> objs = Arrays.stream(argv)
+                .flatMap(UnsupportedConstraintElement.addSpacesBetween(
+                        obj->UnsupportedConstraintElement.objToUnsupportedConstraintElement(interp, obj, lookup, replaceProbableCells, applyWildcardsChooseAny)
+                ));
+        this.cmd = UnsupportedConstraintElement.wrapStream(objs, "[", "]")
+                .flatMap(wrapDollarSigns())
+                .collect(Collectors.toList());
+    }
+
+    public static <T> TclObject makeTclObj(Interp interp, TclObject[] objv, EdifCellLookup<T> lookup, boolean replaceProbableCells, boolean applyWildcardsChooseAny) throws TclException {
+        return new UnsupportedCmdResult<>(interp, objv, lookup, replaceProbableCells, applyWildcardsChooseAny).toReflectObj(interp);
+    }
+
+    @Override
+    public String toString() {
+        return toXdc();
+    }
+
+    @Override
+    public String toXdc() {
+        return UnsupportedConstraintElement.toXdc(cmd.stream());
+    }
+
+    @Override
+    public Stream<UnsupportedConstraintElement> toUnsupportedConstraintElement() {
+        return cmd.stream();
+    }
+
+    public TclObject toReflectObj(Interp interp) throws TclException {
+        return TclHashIdentifiedObject.createReflectObject(interp, DesignObject.class, this);
+    }
+
+    public List<UnsupportedConstraintElement> getCmd() {
+        return cmd;
+    }
+
+    private static boolean isSyntaxStr(UnsupportedConstraintElement elem, String s) {
+        if (!(elem instanceof UnsupportedConstraintElement.SyntaxConstraintElement)) {
+            return false;
+        }
+        return elem.toXdc().equals(s);
+    }
+
+    public UnsupportedCmdResult<T> withoutOutsideBrackets() {
+        if (isSyntaxStr(cmd.get(0), "[") && isSyntaxStr(cmd.get(cmd.size()-1), "]")) {
+            List<UnsupportedConstraintElement> newList = cmd.stream().skip(1).limit(cmd.size() - 2).collect(Collectors.toList());
+            return new UnsupportedCmdResult<>(newList, lookup);
+        }
+        return new UnsupportedCmdResult<>(new ArrayList<>(cmd), lookup);
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/UnsupportedCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/UnsupportedCommand.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import com.xilinx.rapidwright.ipi.UnsupportedConstraintElement;
+import com.xilinx.rapidwright.ipi.XDCConstraints;
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.TclException;
+import tcl.lang.TclObject;
+import tcl.lang.TclString;
+
+public class UnsupportedCommand implements Command {
+
+    private final XDCConstraints constraints;
+    private final EdifCellLookup<?> cellLookup;
+
+    public UnsupportedCommand(XDCConstraints constraints, EdifCellLookup<?> cellLookup) {
+
+        this.constraints = constraints;
+        this.cellLookup = cellLookup;
+    }
+
+    @Override
+    public void cmdProc(Interp interp, TclObject[] objv) throws TclException {
+        List<UnsupportedConstraintElement> constraint = Arrays.stream(objv)
+                .flatMap(UnsupportedConstraintElement.addSpacesBetween(obj -> UnsupportedConstraintElement.objToUnsupportedConstraintElement(interp, obj, cellLookup, false, false)))
+                .collect(Collectors.toList());
+        constraints.getUnsupportedConstraints().add(constraint);
+    }
+
+    private String toSource(Interp interp, TclObject o) {
+        if (o.getInternalRep() instanceof TclString) {
+            String s = o.toString();
+            if (s.contains(" ")) {
+                return '{' + s + '}';
+            }
+            return s;
+        }
+        try {
+            DesignObject designObject = DesignObject.requireUnwrapTclObject(interp, o, cellLookup);
+            return designObject.toXdc();
+        } catch (TclException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/UnsupportedGetterCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/UnsupportedGetterCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import com.xilinx.rapidwright.ipi.DebugDumpCommand;
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import com.xilinx.rapidwright.ipi.TclHashIdentifiedObject;
+import tcl.lang.Command;
+import tcl.lang.Interp;
+import tcl.lang.ReflectObject;
+import tcl.lang.TclException;
+import tcl.lang.TclList;
+import tcl.lang.TclObject;
+import tcl.lang.TclString;
+
+public class UnsupportedGetterCommand implements Command {
+    protected final EdifCellLookup<?> lookup;
+    protected final Command replacedCommand;
+
+    public UnsupportedGetterCommand(EdifCellLookup<?> lookup, Command replacedCommand) {
+        this.lookup = lookup;
+        this.replacedCommand = replacedCommand;
+    }
+    public UnsupportedGetterCommand(EdifCellLookup<?> lookup) {
+        this.lookup = lookup;
+        this.replacedCommand = null;
+    }
+
+    @Override
+    public void cmdProc(Interp interp, TclObject[] objv) throws TclException {
+        if (replacedCommand!=null && Arrays.stream(objv).noneMatch(obj -> containsUnsupportedCmdResults(interp, obj, false))) {
+            replacedCommand.cmdProc(interp, objv);
+        } else {
+            interp.setResult(UnsupportedCmdResult.makeTclObj(interp, objv, lookup, true, true));
+        }
+    }
+
+    protected boolean containsUnsupportedCmdResults(Interp interp, TclObject obj, boolean isInList) {
+        try {
+            if (obj.getInternalRep() instanceof TclList) {
+                TclObject[] elements = TclList.getElements(interp, obj);
+                return Arrays.stream(elements).anyMatch(elem -> containsUnsupportedCmdResults(interp, elem, true));
+            } else if (obj.getInternalRep() instanceof ReflectObject) {
+                Optional<DesignObject<?>> designObject = DesignObject.unwrapTclObject(interp, obj, lookup);
+                if (!designObject.isPresent()) {
+                    return true;
+                }
+                return !isInList || !(designObject.get() instanceof CellObject<?>);
+            } else if (obj.getInternalRep() instanceof TclString) {
+                return TclHashIdentifiedObject.containsStringifiedObject(obj.toString());
+            } else {
+                return false;
+            }
+        } catch (TclException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/ipi/xdcParserCommands/UnsupportedIfCommand.java
+++ b/src/com/xilinx/rapidwright/ipi/xdcParserCommands/UnsupportedIfCommand.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Jakob Wenzel
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.ipi.xdcParserCommands;
+
+import com.xilinx.rapidwright.ipi.EdifCellLookup;
+import tcl.lang.CharPointer;
+import tcl.lang.Command;
+import tcl.lang.ExprValue;
+import tcl.lang.Interp;
+import tcl.lang.Parser;
+import tcl.lang.TCL;
+import tcl.lang.TclDouble;
+import tcl.lang.TclException;
+import tcl.lang.TclInteger;
+import tcl.lang.TclObject;
+import tcl.lang.TclParse;
+import tcl.lang.TclRuntimeError;
+import tcl.lang.TclString;
+import tcl.lang.TclToken;
+
+public class UnsupportedIfCommand extends UnsupportedGetterCommand {
+    public UnsupportedIfCommand(EdifCellLookup<?> lookup, Command replacedCommand) {
+        super(lookup, replacedCommand);
+    }
+
+    private TclObject exprValueToObj(ExprValue exprValue) {
+        switch (exprValue.getType()) {
+            case 0:
+                return TclInteger.newInstance(exprValue.getIntValue());
+            case 1:
+                return TclDouble.newInstance(exprValue.getDoubleValue());
+            case 2:
+                return TclString.newInstance("{"+exprValue.getStringValue()+"}");
+            default:
+                throw new RuntimeException("invalid expr type");
+        }
+    }
+
+    //Copied from Parser.java
+    static final int TCL_TOKEN_WORD = 1;
+    static final int TCL_TOKEN_SIMPLE_WORD = 2;
+    static final int TCL_TOKEN_TEXT = 4;
+    static final int TCL_TOKEN_BS = 8;
+    static final int TCL_TOKEN_COMMAND = 16;
+    static final int TCL_TOKEN_VARIABLE = 32;
+    static final int TCL_TOKEN_SUB_EXPR = 64;
+    static final int TCL_TOKEN_OPERATOR = 128;
+
+    String tokensToStr(TclParse tclParse, Interp interp) {
+        try {
+            StringBuilder res = new StringBuilder();
+            boolean needsSpace = false;
+            for (int i = 0; i < tclParse.numTokens; i++) {
+                TclToken token = tclParse.tokenList[i];
+                switch (token.type) {
+                    case TCL_TOKEN_VARIABLE:
+
+                        String varName = tclParse.tokenList[++i].getTokenString();
+                        if (token.numComponents != 1) {
+                            throw new RuntimeException("we don't currently support arrays here");
+                        }
+                        TclObject value = interp.getVar(varName, null, 0);
+                        if (needsSpace) {
+                            res.append(' ');
+                        }
+                        res.append(value.toString());
+                        needsSpace = true;
+                        break;
+                    case TCL_TOKEN_SIMPLE_WORD:
+                    case TCL_TOKEN_COMMAND:
+                        if (needsSpace) {
+                            res.append(' ');
+                        }
+                        res.append(token.getTokenString());
+                        needsSpace = true;
+                        break;
+                    case TCL_TOKEN_TEXT:
+                    case TCL_TOKEN_WORD:
+                        //Ignore
+                        break;
+                    default:
+                        throw new RuntimeException("unsupported token type: "+token.type);
+                }
+            }
+            return res.toString();
+        } catch (TclException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    void makeUnsupportedResult(Interp interp, TclObject[] objv, int i) throws TclException {
+
+        for (++i;i<objv.length;++i) {
+            String obj = objv[i].toString();
+            CharPointer script = new CharPointer(obj);
+            TclParse tclParse = Parser.parseCommand(interp, script.array, script.index, script.length(), (String) null, 0, true);
+
+            String s = tokensToStr(tclParse, interp);
+            System.out.println("from "+obj+" to "+s);
+            objv[i] = TclString.newInstance(s);
+        }
+        interp.setResult(UnsupportedCmdResult.makeTclObj(interp, objv, lookup, true, true));
+    }
+
+    @Override
+    public void cmdProc(Interp interp, TclObject[] objv) throws TclException {
+        //Code copied from IfCmd.java
+        int i;
+        boolean value;
+
+        i = 1;
+        while (true) {
+            // At this point in the loop, objv and argc refer to an
+            // expression to test, either for the main expression or
+            // an expression following an "elseif".  The arguments
+            // after the expression must be "then" (optional) and a
+            // script to execute if the expression is true.
+
+            if (i >= objv.length) {
+                throw new TclException(interp,
+                        "wrong # args: no expression after \"" +
+                                objv[i - 1] + "\" argument");
+            }
+            try {
+                ExprValue exprValue = interp.evalExpression(objv[i].toString());
+                try {
+                    value = exprValue.getBooleanValue(interp);
+                } catch (TclException | TclRuntimeError e) {
+                    //Not evaluatable, forward if to Vivado
+                    objv[i] = exprValueToObj(exprValue);
+
+                    makeUnsupportedResult(interp, objv, i);
+                    return;
+                } finally {
+                    interp.releaseExprValue(exprValue);
+                }
+            } catch (TclException e) {
+                switch (e.getCompletionCode()) {
+                    case TCL.ERROR:
+                        interp.addErrorInfo("\n    (\"if\" test expression)");
+                        break;
+                }
+                throw e;
+            }
+
+            i++;
+            if ((i < objv.length) && (objv[i].toString().equals("then"))) {
+                i++;
+            }
+            if (i >= objv.length) {
+                throw new TclException(interp,
+                        "wrong # args: no script following \"" +
+                                objv[i - 1] + "\" argument");
+            }
+            if (value) {
+                try {
+                    interp.eval(objv[i], 0);
+                } catch (TclException e) {
+                    switch (e.getCompletionCode()) {
+                        case TCL.ERROR:
+                            interp.addErrorInfo("\n    (\"if\" then script line " +
+                                    interp.getErrorLine() + ")");
+                            break;
+                    }
+                    throw e;
+                }
+                return;
+            }
+
+            // The expression evaluated to false.  Skip the command, then
+            // see if there is an "else" or "elseif" clause.
+
+            i++;
+            if (i >= objv.length) {
+                interp.resetResult();
+                return;
+            }
+            if (objv[i].toString().equals("elseif")) {
+                i++;
+                continue;
+            }
+            break;
+        }
+
+        // Couldn't find a "then" or "elseif" clause to execute.
+        // Check now for an "else" clause.  We know that there's at
+        // least one more argument when we get here.
+
+        if (objv[i].toString().equals("else")) {
+            i++;
+            if (i >= objv.length) {
+                throw new TclException(interp,
+                        "wrong # args: no script following \"else\" argument");
+            } else if (i != (objv.length - 1)) {
+                throw new TclException(interp,
+                        "wrong # args: extra words after \"else\" clause in " +
+                                "\"if\" command");
+            }
+        } else {
+            // Not else, if there is more than 1 more argument
+            // then generate an error.
+
+            if (i != (objv.length - 1)) {
+                throw new TclException(interp,
+                        "wrong # args: extra words after \"else\" clause in \"if\" command");
+            }
+        }
+        try {
+            interp.eval(objv[i], 0);
+        } catch (TclException e) {
+            switch (e.getCompletionCode()) {
+                case TCL.ERROR:
+                    interp.addErrorInfo("\n    (\"if\" else script line " +
+                            interp.getErrorLine() + ")");
+                    break;
+            }
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
Hi there!

This PR implements a full TCL parser for XDC. The parser handles package pin, `create_clock` and `set_property` constraints. If the Parser encounters unsupported commands or command options, the parsed TCL code is converted back to strings and returned as `UnsupportedConstraintElement`s. Support for more constraint types can be easily added by implementing more TCL commands.

The parser can be called with a netlist and then supports cell lookup via `get_cells` with a number of filtering flags. If called without a netlist, `get_cells` support is more limited.

As discussed previously, this introduces a dependency on a modified version of JACL ([upstream](https://tcljava.sourceforge.net/docs/website/index.html), [modified version](https://github.com/jakobwenzel/jacl)). This is not yet on Maven Central, so I have not added the actual dependency in the Gradle build. CI will fail for now. For testing, I have added the jars in a directory inside RapidWright ([see this branch](https://github.com/jakobwenzel/RapidWright/tree/full-tcl-parser-dependencies)).

In my use case, the source Verilog is restructured before creating an EDIF. Therefore, XDC needed to be rewritten as well. This led to a few design decisions in the XDC parser:
* The EDIF cell lookup is customizable via the interface `EDIFCellLookup` (with default implementations for lookup with and without a netlist). My rewriting implementation is not part of this PR.
* `EDIFCellLookup` has a notion of original (pre-rewrite) and final (post-rewrite) design names.
* In XDC code, cells returned by `get_cells` calls can be stringified (and appended to get a sub-cell) and be passed to `get_cells` again. For my use case, the exact Java Instance needed to be found again. Stringifying cells therefore returns a hash code, which can be converted back to Java instances in further XDC calls. This is handled by `TclHashIdentifiedObject`.

## Open Questions
* I have a testcase which uses https://github.com/alexforencich/verilog-ethernet, which has quite complex XDC. This code is under MIT license. Currently, my testcase just points to an EDIF file on my disk... I assume it is ok to put an EDIF of that under https://github.com/eddieh-xlnx/RapidWrightDCP if a license notice is included? (Will open a PR if I get a go ahead) Should we fetch the XDC from upstream or copy it into our Git somewhere?
* As there now are quite a few classes for XDC, it might make sense to move everything out of `ipi` into its own package. I was hesistant because of backwards compatibility.
* In `XDCParser`, the `parseXDC` methods used to return `Map<String,PackagePinConstraint>`. The new parser returns instances of `XDCConstraints`. We can either break backwards compatibility and have change the existing methods' return type, or we keep the old return type and choose a new method name for returning `XDCConstraints` (currently implemented, as `parseXDCNew`).
* I assume you would want to handle publishing JACL onto Maven Central to have everything under your control?

I am planning to add some more Javadoc in the coming days.

Jakob