### PR TITLE
[RWRoute] Add support for SLL tile types

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -799,6 +799,7 @@ public class RWRoute {
             for (Connection connection : indirectConnections) {
                 RouteNode sinkRnode = connection.getSinkRnode();
                 if (sinkRnode.getType() == RouteNodeType.EXCLUSIVE_SINK_BOTH) {
+                    IntentCode sinkIntent = sinkRnode.getIntentCode();
                     for (Node uphill : sinkRnode.getAllUphillNodes()) {
                         if (uphill.isTiedToVcc()) {
                             continue;
@@ -807,10 +808,17 @@ public class RWRoute {
                         if (preservedNet != null && preservedNet != connection.getNet()) {
                             continue;
                         }
-                        assert((sinkRnode.getIntentCode() == IntentCode.NODE_CLE_CTRL &&
-                                (uphill.getIntentCode() == IntentCode.NODE_CLE_CNODE || uphill.getIntentCode() == IntentCode.NODE_CLE_BNODE)) ||
-                                (sinkRnode.getIntentCode() == IntentCode.NODE_INTF_CTRL &&
-                                        (uphill.getIntentCode() == IntentCode.NODE_INTF_CNODE || uphill.getIntentCode() == IntentCode.NODE_INTF_BNODE)));
+                        if (sinkIntent == IntentCode.NODE_SLL_INPUT && uphill.getIntentCode() == IntentCode.NODE_SLL_OUTPUT) {
+                            // No need to reserve NODE_SLL_OUTPUT nodes of a NODE_SLL_INPUT
+                            continue;
+                        }
+                        assert((sinkIntent == IntentCode.NODE_CLE_CTRL &&
+                                        (uphill.getIntentCode() == IntentCode.NODE_CLE_CNODE || uphill.getIntentCode() == IntentCode.NODE_CLE_BNODE)) ||
+                                (sinkIntent == IntentCode.NODE_INTF_CTRL &&
+                                        (uphill.getIntentCode() == IntentCode.NODE_INTF_CNODE || uphill.getIntentCode() == IntentCode.NODE_INTF_BNODE)) ||
+                                (sinkIntent == IntentCode.NODE_SLL_INPUT &&
+                                        uphill.getIntentCode() == IntentCode.NODE_CLE_BNODE)
+                        );
                         RouteNode rnode = routingGraph.getOrCreate(uphill, RouteNodeType.LOCAL_RESERVED);
                         rnode.setType(RouteNodeType.LOCAL_RESERVED);
                     }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -170,6 +170,7 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
                     case NODE_CLE_OUTPUT:    // CLE outputs (US+ and Versal)
                     case NODE_LAGUNA_OUTPUT: // LAG_LAG.{LAG_MUX_ATOM_*_TXOUT,RXD*} (US+)
                     case NODE_LAGUNA_DATA:   // LAG_LAG.UBUMP* super long lines for u-turns at the boundary of the device (US+)
+                    case NODE_SLL_INPUT:     // Versal only
                     case INTENT_DEFAULT:     // INT.VCC_WIRE
                         assert(length == 0);
                         break;

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -1090,6 +1090,10 @@ public class RouteNodeGraph {
                 case NODE_INTF_CTRL:
                     // CTRL pins that are not our target EXCLUSIVE_SINK will have been isExcluded() from the graph
                     break;
+                case NODE_SLL_INPUT:
+                    // Temporarily only allow NODE_SLL_INPUT to be explored if they are the sink
+                    // TODO: Revisit when SLR crossings are supported
+                    return childRnode == sinkRnode;
             }
             throw new RuntimeException("ERROR: Unhandled IntentCode: " + childIntentCode);
         }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -202,8 +202,8 @@ public class RouteNodeGraph {
             intTilesToExamine.add(tile);
 
             Tile sllTile = device.getArbitraryTileOfType(TileTypeEnum.SLL);
-            tile = sllTile.getTileNeighbor(2, 0);
-            if (tile != null) {
+            if (sllTile != null) {
+                tile = sllTile.getTileNeighbor(2, 0);
                 assert(tile.getTileTypeEnum() == TileTypeEnum.INT);
                 intTilesToExamine.add(tile);
             }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -23,6 +23,7 @@
 
 package com.xilinx.rapidwright.rwroute;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
@@ -170,23 +171,23 @@ public class RouteNodeGraph {
         boolean isUltraScale = series == Series.UltraScale;
         boolean isUltraScalePlus = series == Series.UltraScalePlus;
         isVersal = series == Series.Versal;
-        Tile intTile;
         final Set<IntentCode> intTileIntentCodeCareSet;
         Pattern eastWestPattern;
         eastWestWires = new EnumMap<>(TileTypeEnum.class);
         BitSet localWires = new BitSet();
+        List<Tile> intTilesToExamine = null;
         if (isUltraScale || isUltraScalePlus) {
-            intTile = device.getArbitraryTileOfType(TileTypeEnum.INT);
+            Tile tile = device.getArbitraryTileOfType(TileTypeEnum.INT);
             // Device.getArbitraryTileOfType() typically gives you the North-Western-most
             // tile (with minimum X, maximum Y). Analyze the tile just below that.
-            intTile = intTile.getTileXYNeighbor(0, -1);
+            intTilesToExamine = Collections.singletonList(tile.getTileXYNeighbor(0, -1));
             intTileIntentCodeCareSet = EnumSet.of(
                     IntentCode.NODE_PINFEED,
                     IntentCode.NODE_PINBOUNCE,
                     IntentCode.NODE_LOCAL);
 
             ultraScalesLocalWires = new EnumMap<>(TileTypeEnum.class);
-            ultraScalesLocalWires.put(intTile.getTileTypeEnum(), localWires);
+            ultraScalesLocalWires.put(tile.getTileTypeEnum(), localWires);
 
             eastWestPattern = Pattern.compile("(((BOUNCE|BYPASS|IMUX|INODE(_[12])?)_(?<eastwest>[EW]))|INT_NODE_IMUX_(?<inode>\\d+)_).*");
         } else {
@@ -194,10 +195,19 @@ public class RouteNodeGraph {
 
             // Find an INT tile adjacent to a CLE_BC_CORE tile since Versal devices may contain AIEs on their northern edge
             Tile bcCoreTile = device.getArbitraryTileOfType(TileTypeEnum.CLE_BC_CORE);
-            // Device.getArbitraryTileOfType() typically gives you the North-Western-most
-            // tile (with minimum X, maximum Y). Analyze the tile just below that.
-            intTile = bcCoreTile.getTileNeighbor(2, 0);
-            assert(intTile.getTileTypeEnum() == TileTypeEnum.INT);
+            Tile tile = bcCoreTile.getTileNeighbor(2, 0);
+            assert(tile.getTileTypeEnum() == TileTypeEnum.INT);
+
+            intTilesToExamine = new ArrayList<>(2);
+            intTilesToExamine.add(tile);
+
+            Tile sllTile = device.getArbitraryTileOfType(TileTypeEnum.SLL);
+            tile = sllTile.getTileNeighbor(2, 0);
+            if (tile != null) {
+                assert(tile.getTileTypeEnum() == TileTypeEnum.INT);
+                intTilesToExamine.add(tile);
+            }
+
             intTileIntentCodeCareSet = EnumSet.of(
                     IntentCode.NODE_IMUX,
                     IntentCode.NODE_PINBOUNCE,
@@ -210,89 +220,91 @@ public class RouteNodeGraph {
             eastWestPattern = Pattern.compile("(((BOUNCE|IMUX_B|[BC]NODE_OUTS)_(?<eastwest>[EW]))|INT_NODE_IMUX_ATOM_(?<inode>\\d+)_).*");
         }
 
-        for (int wireIndex = 0; wireIndex < intTile.getWireCount(); wireIndex++) {
-            Node baseNode = Node.getNode(intTile, wireIndex);
-            if (baseNode == null) {
-                continue;
-            }
-
-            IntentCode baseIntentCode = baseNode.getIntentCode();
-            if (!intTileIntentCodeCareSet.contains(baseIntentCode)) {
-                continue;
-            }
-
-            String baseWireName = baseNode.getWireName();
-            if (isUltraScale || isUltraScalePlus) {
-                if (baseIntentCode == IntentCode.NODE_LOCAL) {
-                    Tile baseTile = baseNode.getTile();
-                    assert(baseTile.getTileTypeEnum() == intTile.getTileTypeEnum());
-                    if (isUltraScalePlus) {
-                        if (baseWireName.startsWith("INT_NODE_SDQ_") || baseWireName.startsWith("SDQNODE_")) {
-                            if (baseTile != intTile) {
-                                if (baseWireName.endsWith("_FT0")) {
-                                    assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() - 1);
-                                } else {
-                                    assert(baseWireName.endsWith("_FT1"));
-                                    assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() + 1);
-                                }
-                            }
-                            continue;
-                        }
-                    } else {
-                        assert(isUltraScale);
-                        if (baseWireName.startsWith("INT_NODE_SINGLE_DOUBLE_") || baseWireName.startsWith("SDND") ||
-                                baseWireName.startsWith("INT_NODE_QUAD_LONG") || baseWireName.startsWith("QLND")) {
-                            if (baseTile != intTile) {
-                                if (baseWireName.endsWith("_FTN")) {
-                                    assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() - 1);
-                                } else {
-                                    assert(baseWireName.endsWith("_FTS"));
-                                    assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() + 1);
-                                }
-                            }
-                            continue;
-                        }
-                    }
-                } else {
-                    assert(baseIntentCode == IntentCode.NODE_PINFEED || baseIntentCode == IntentCode.NODE_PINBOUNCE);
+        for (Tile intTile : intTilesToExamine) {
+            for (int wireIndex = 0; wireIndex < intTile.getWireCount(); wireIndex++) {
+                Node baseNode = Node.getNode(intTile, wireIndex);
+                if (baseNode == null) {
+                    continue;
                 }
-                localWires.set(baseNode.getWireIndex());
-            } else {
-                assert(isVersal);
-            }
 
-            Matcher m = eastWestPattern.matcher(baseWireName);
-            if (m.matches()) {
-                BitSet[] eastWestWires = this.eastWestWires.computeIfAbsent(baseNode.getTile().getTileTypeEnum(),
-                        k -> new BitSet[]{new BitSet(), new BitSet()});
-                BitSet eastWires = eastWestWires[0];
-                BitSet westWires = eastWestWires[1];
-                String ew = m.group("eastwest");
-                String inode;
-                if (ew != null) {
-                    // [BC]NODEs connect to INODEs opposite to their wire name
-                    if (baseIntentCode == IntentCode.NODE_CLE_BNODE || baseIntentCode == IntentCode.NODE_CLE_CNODE) {
-                        ew = ew.equals("E") ? "W" : "E";
-                    }
-                    if (ew.equals("E")) {
-                        eastWires.set(baseNode.getWireIndex());
+                IntentCode baseIntentCode = baseNode.getIntentCode();
+                if (!intTileIntentCodeCareSet.contains(baseIntentCode)) {
+                    continue;
+                }
+
+                String baseWireName = baseNode.getWireName();
+                if (isUltraScale || isUltraScalePlus) {
+                    if (baseIntentCode == IntentCode.NODE_LOCAL) {
+                        Tile baseTile = baseNode.getTile();
+                        assert(baseTile.getTileTypeEnum() == intTile.getTileTypeEnum());
+                        if (isUltraScalePlus) {
+                            if (baseWireName.startsWith("INT_NODE_SDQ_") || baseWireName.startsWith("SDQNODE_")) {
+                                if (baseTile != intTile) {
+                                    if (baseWireName.endsWith("_FT0")) {
+                                        assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() - 1);
+                                    } else {
+                                        assert(baseWireName.endsWith("_FT1"));
+                                        assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() + 1);
+                                    }
+                                }
+                                continue;
+                            }
+                        } else {
+                            assert(isUltraScale);
+                            if (baseWireName.startsWith("INT_NODE_SINGLE_DOUBLE_") || baseWireName.startsWith("SDND") ||
+                                    baseWireName.startsWith("INT_NODE_QUAD_LONG") || baseWireName.startsWith("QLND")) {
+                                if (baseTile != intTile) {
+                                    if (baseWireName.endsWith("_FTN")) {
+                                        assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() - 1);
+                                    } else {
+                                        assert(baseWireName.endsWith("_FTS"));
+                                        assert(baseTile.getTileYCoordinate() == intTile.getTileYCoordinate() + 1);
+                                    }
+                                }
+                                continue;
+                            }
+                        }
                     } else {
-                        assert(ew.equals("W"));
-                        westWires.set(baseNode.getWireIndex());
+                        assert(baseIntentCode == IntentCode.NODE_PINFEED || baseIntentCode == IntentCode.NODE_PINBOUNCE);
                     }
+                    localWires.set(baseNode.getWireIndex());
                 } else {
-                    if ((inode = m.group("inode")) != null) {
-                        int i = Integer.parseInt(inode);
-                        if (i < 32 || ((isUltraScale || isVersal) && i >= 64 && i < 96)) {
+                    assert(isVersal);
+                }
+
+                Matcher m = eastWestPattern.matcher(baseWireName);
+                if (m.matches()) {
+                    BitSet[] eastWestWires = this.eastWestWires.computeIfAbsent(baseNode.getTile().getTileTypeEnum(),
+                            k -> new BitSet[]{new BitSet(), new BitSet()});
+                    BitSet eastWires = eastWestWires[0];
+                    BitSet westWires = eastWestWires[1];
+                    String ew = m.group("eastwest");
+                    String inode;
+                    if (ew != null) {
+                        // [BC]NODEs connect to INODEs opposite to their wire name
+                        if (baseIntentCode == IntentCode.NODE_CLE_BNODE || baseIntentCode == IntentCode.NODE_CLE_CNODE) {
+                            ew = ew.equals("E") ? "W" : "E";
+                        }
+                        if (ew.equals("E")) {
                             eastWires.set(baseNode.getWireIndex());
                         } else {
-                            assert(i < 64 || (isUltraScale || isVersal && i >= 96 && i < 128));
+                            assert(ew.equals("W"));
                             westWires.set(baseNode.getWireIndex());
                         }
+                    } else {
+                        if ((inode = m.group("inode")) != null) {
+                            int i = Integer.parseInt(inode);
+                            if (i < 32 || ((isUltraScale || isVersal) && i >= 64 && i < 96)) {
+                                eastWires.set(baseNode.getWireIndex());
+                            } else {
+                                assert(i < 64 || (isUltraScale || isVersal && i >= 96 && i < 128));
+                                westWires.set(baseNode.getWireIndex());
+                            }
+                        }
                     }
+                } else {
+                    assert((isUltraScale || isUltraScalePlus) && baseWireName.matches("CTRL_[EW](_B)?\\d+|INT_NODE_GLOBAL_\\d+(_INT)?_OUT[01]?"));
                 }
-            } else {
-                assert((isUltraScale || isUltraScalePlus) && baseWireName.matches("CTRL_[EW](_B)?\\d+|INT_NODE_GLOBAL_\\d+(_INT)?_OUT[01]?"));
             }
         }
 
@@ -678,6 +690,7 @@ public class RouteNodeGraph {
 
         // Versal only: include tiles hosting BNODE/CNODEs
         allowedTileEnums.add(TileTypeEnum.CLE_BC_CORE);
+        allowedTileEnums.add(TileTypeEnum.SLL);
         allowedTileEnums.add(TileTypeEnum.INTF_LOCF_TL_TILE);
         allowedTileEnums.add(TileTypeEnum.INTF_LOCF_TR_TILE);
         allowedTileEnums.add(TileTypeEnum.INTF_LOCF_BL_TILE);
@@ -942,7 +955,7 @@ public class RouteNodeGraph {
         assert(childTileType == TileTypeEnum.INT ||
                isVersal && EnumSet.of(TileTypeEnum.INTF_LOCF_TR_TILE, TileTypeEnum.INTF_LOCF_BR_TILE, TileTypeEnum.INTF_ROCF_TR_TILE, TileTypeEnum.INTF_ROCF_BR_TILE,
                                       TileTypeEnum.INTF_LOCF_TL_TILE, TileTypeEnum.INTF_LOCF_BL_TILE, TileTypeEnum.INTF_ROCF_TL_TILE, TileTypeEnum.INTF_ROCF_BL_TILE,
-                                      TileTypeEnum.CLE_BC_CORE)
+                                      TileTypeEnum.CLE_BC_CORE, TileTypeEnum.SLL)
                        .contains(childTileType));
 
         if (lutRoutethru && !type.leadsToLaguna()) {
@@ -992,7 +1005,9 @@ public class RouteNodeGraph {
                 // This must be a CTRL sink that can be accessed from both east/west sides
 
                 if (isVersal) {
-                    assert(sinkRnode.getIntentCode() == IntentCode.NODE_CLE_CTRL || sinkRnode.getIntentCode() == IntentCode.NODE_INTF_CTRL);
+                    assert(sinkRnode.getIntentCode() == IntentCode.NODE_CLE_CTRL ||
+                            sinkRnode.getIntentCode() == IntentCode.NODE_INTF_CTRL ||
+                            sinkRnode.getIntentCode() == IntentCode.NODE_SLL_INPUT);
 
                     if (childTile == sinkTile) {
                         // CTRL sinks can be only accessed directly from LOCAL_RESERVED nodes in the sink CLE_BC_CORE/INTF_* tile ...

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -182,6 +182,9 @@ public class RouteNodeInfo {
                 return RouteNodeType.LOCAL_BOTH;
             }
 
+            case NODE_SLL_INPUT: // Versal only
+                return RouteNodeType.LOCAL_BOTH;
+
             case NODE_PINFEED:
                 if (routingGraph.isVersal) {
                     return RouteNodeType.LOCAL_BOTH;

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -233,7 +233,7 @@ public class RouterHelper {
                 TileTypeEnum uphillTileType = uphill.getTile().getTileTypeEnum();
                 if (uphillTileType == TileTypeEnum.INT ||
                         // Versal only: Terminate at non INT (e.g. CLE_BC_CORE) tile type for CTRL pin inputs
-                        EnumSet.of(IntentCode.NODE_CLE_CTRL, IntentCode.NODE_INTF_CTRL).contains(uphill.getIntentCode())) {
+                        EnumSet.of(IntentCode.NODE_CLE_CTRL, IntentCode.NODE_INTF_CTRL, IntentCode.NODE_SLL_INPUT).contains(uphill.getIntentCode())) {
                     return uphill;
                 }
                 if (isLagunaRXD && uphill.getTile() == sink.getTile() && node.getWireName().startsWith("UBUMP")) {

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -604,7 +604,7 @@ public class TestRWRoute {
             SiteInst si = ff.getSiteInst();
             SitePinInst spi = si.getSitePinInst("AX");
             Assertions.assertTrue(si.unrouteIntraSiteNet(spi.getBELPin(), ff.getBEL().getPin("D")));
-            spi.movePin("LAG_E2");
+            Assertions.assertTrue(spi.movePin("LAG_E2"));
             Assertions.assertTrue(si.routeIntraSiteNet(spi.getNet(), spi.getBELPin(), ff.getBEL().getPin("D")));
         }
 

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -540,7 +540,7 @@ public class TestRWRoute {
     }
 
     @Test
-    public void testDiscussion1245() {
+    public void testDiscussion1245_20250805() {
         // Adapted from https://github.com/Xilinx/RapidWright/discussions/1245#discussioncomment-14003055
         Design test_place = new Design("test_design", "vp1202");
 
@@ -562,4 +562,46 @@ public class TestRWRoute {
 
         RWRoute.routeDesignFullNonTimingDriven(test_route);
     }
+
+    @Test
+    public void testDiscussion1245_20250807() {
+        // Adapted from https://github.com/Xilinx/RapidWright/discussions/1245#discussioncomment-14035707
+
+        Design test_place = new Design("test_design", "vp1202");
+
+        Cell cell_1 = test_place.createAndPlaceCell("my_test_cell_1", Unisim.LUT6, "SLICE_X100Y0/A6LUT");
+        LUTTools.configureLUT(cell_1, "O=I1");
+        cell_1.fixCell(true);
+
+        Cell cell_2 = test_place.createAndPlaceCell("my_test_cell_2", Unisim.LUT6, "SLICE_X100Y0/H6LUT");
+        LUTTools.configureLUT(cell_2, "O=I1");
+        cell_2.fixCell(true);
+
+        Cell ff = test_place.createAndPlaceCell("flipflop", Unisim.FDCE, "SLICE_X100Y0/AFF");
+        ff.fixCell(true);
+
+        Net net = test_place.createNet("my_test_net_0");
+        ECOTools.connectNet(test_place, cell_1, "O", net);
+        ECOTools.connectNet(test_place, cell_2, "I1", net);
+
+        Net outer_net_1 = test_place.createNet("my_test_net_1");
+        ECOTools.connectNet(test_place, cell_2, "O", outer_net_1);
+        ECOTools.connectNet(test_place, ff, "D", outer_net_1);
+
+        Net outer_net_2 = test_place.createNet("my_test_net_2");
+        ECOTools.connectNet(test_place, ff, "Q", outer_net_2);
+        ECOTools.connectNet(test_place, cell_1, "I1", outer_net_2);
+
+        Design test_route = test_place;
+
+        test_route.routeSites();
+
+        // Test for intra-SLR connections to the LAG input
+        Assertions.assertEquals("SLICE_X100Y0.LAG_E2", ff.getSitePinFromLogicalPin("D", null).getSitePinName());
+
+        RWRoute.routeDesignFullNonTimingDriven(test_route);
+
+        VivadoToolsHelper.assertFullyRouted(test_route);
+    }
+
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -602,8 +602,8 @@ public class TestRWRoute {
         // Test for intra-SLR connections to the LAG input
         if (forceLagPin) {
             SiteInst si = ff.getSiteInst();
-            Assertions.assertTrue(si.unrouteIntraSiteNet(si.getBELPin("AX", "AX"), ff.getBEL().getPin("D")));
             SitePinInst spi = si.getSitePinInst("AX");
+            Assertions.assertTrue(si.unrouteIntraSiteNet(spi.getBELPin(), ff.getBEL().getPin("D")));
             spi.movePin("LAG_E2");
             Assertions.assertTrue(si.routeIntraSiteNet(spi.getNet(), spi.getBELPin(), ff.getBEL().getPin("D")));
         }


### PR DESCRIPTION
Certain devices (e.g. vp1202) use a `SLL` tile type instead of a `CLE_BC_CORE`. Add support for that here. 

Turns out that tile type is at the very least necessary to reach the `LAG_?` site pin, let alone using `BNODE`/`CNODE`s that don't live in `CLE_BC_CORE` tiles.