### PR TITLE
Unisim Primitive Mappings Updates for Versal 

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2025.1.1-rc6.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2025.1.1-rc7.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2025.1.1-rc6-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2025.1.1-rc7-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2025.1.1-rc6-beta
+  RAPIDWRIGHT_VERSION: v2025.1.1-rc7-beta
 
 jobs:
   build:

--- a/src/com/xilinx/rapidwright/device/PartNameTools.java
+++ b/src/com/xilinx/rapidwright/device/PartNameTools.java
@@ -159,6 +159,7 @@ public class PartNameTools {
             case QZYNQUPLUSRFSOC: return FamilyType.ZYNQUPLUSRFSOC;
             case SPARTAN7: return FamilyType.SPARTAN7;
             case SPARTANUPLUS: return FamilyType.SPARTANUPLUS;
+            case VERSAL: return FamilyType.VERSAL;
             case VERSALAICORE: return FamilyType.VERSAL;
             case VERSALAIEDGE: return FamilyType.VERSAL;
             case VERSALAIEDGE2: return FamilyType.VERSAL;

--- a/src/com/xilinx/rapidwright/eco/ECOTools.java
+++ b/src/com/xilinx/rapidwright/eco/ECOTools.java
@@ -528,7 +528,11 @@ public class ECOTools {
                     // Otherwise create and attach a new site-pin
                     String logicalPinName = ehpi.getPortInst().getName();
                     if (cell.getAllPhysicalPinMappings(logicalPinName) != null) {
-                        createExitSitePinInst(design, ehpi, newPhysNet);
+                        boolean isTopLevelPort = cell.getType().equals("IBUF") && logicalPinName.equals("I") ||
+                                                 cell.getType().equals("OBUF") && logicalPinName.equals("O"); 
+                        if (!isTopLevelPort) {
+                            createExitSitePinInst(design, ehpi, newPhysNet);
+                        }
                     } else {
                         if (LUTTools.isCellALUT(cell)) {
                             // TODO: Find a new physical pin mapping

--- a/src/com/xilinx/rapidwright/util/DataVersions.java
+++ b/src/com/xilinx/rapidwright/util/DataVersions.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Generated on: Tue Jul 29 14:25:42 MDT 2025
+ * Generated on: Mon Aug 11 18:08:13 MDT 2025
  * by: com.xilinx.rapidwright.release.UploadFilesToAzure
  *
  * Versioned list of data files to use in current RapidWright environment
@@ -393,6 +393,6 @@ public class DataVersions {
         dataVersionMap.put("data/devices/zynquplusrfsoc/xqzu67dr_db.dat", new Pair<>("xqzu67dr-db-dat", "54198c52563ba965424fb20fc4eccee2"));
         dataVersionMap.put("data/partdump.csv", new Pair<>("partdump-csv", "4cb26d6ffe32c6a1e2afad64daf2fbfc"));
         dataVersionMap.put("data/parts.db", new Pair<>("parts-db", "36b61be8570aaea97756590a430b4618"));
-        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "24cfc4015db471aa1593a52bdaa75ad3"));
+        dataVersionMap.put("data/unisim_data.dat", new Pair<>("unisim-data-dat", "b22797c846512a5a18aeb95c012f8948"));
     }
 }

--- a/src/com/xilinx/rapidwright/util/FileTools.java
+++ b/src/com/xilinx/rapidwright/util/FileTools.java
@@ -143,7 +143,7 @@ public class FileTools {
     /** Part Database File Version */
     public static final int PART_DB_FILE_VERSION = 1;
     /** Unisim Data File Version */
-    public static final int UNISIM_DATA_FILE_VERSION = 1;
+    public static final int UNISIM_DATA_FILE_VERSION = 2;
     /** Base URL for download data files */
     public static final String RAPIDWRIGHT_DATA_URL = "http://data.rapidwright.io/";
     /** Suffix added to data file names to capture md5 status */

--- a/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
+++ b/test/src/com/xilinx/rapidwright/eco/TestECOTools.java
@@ -1134,17 +1134,16 @@ public class TestECOTools {
         Net gate = design.createNet("gate");
         gate.getLogicalNet().createPortInst(top.createPort("gate", EDIFDirection.INPUT, 1));
 
-        // TODO - Instantiate IBUFs after primitives fix
-//        Cell clkIBUF = design.createAndPlaceCell(top, "clkIBUF", Unisim.IBUF, "IOB_X29Y0/IOB_M");
-//        ECOTools.connectNet(design, clkIBUF, "I", clk);
-//        
-//        Cell gateIBUF = design.createAndPlaceCell(top, "gateIBUF", Unisim.IBUF, "IOB_X29Y1/IOB_M");
-//        ECOTools.connectNet(design, gateIBUF, "I", gate);
-//
-//        Net clkBUF = design.createNet("clkBUF");
-//        ECOTools.connectNet(design, clkIBUF, "O", clkBUF);
-//        Net gateBUF = design.createNet("gateBUF");
-//        ECOTools.connectNet(design, gateIBUF, "O", gateBUF);
+        Cell clkIBUF = design.createAndPlaceCell(top, "clkIBUF", Unisim.IBUF, "IOB_X29Y0/IOB_M");
+        ECOTools.connectNet(design, clkIBUF, "I", clk);
+
+        Cell gateIBUF = design.createAndPlaceCell(top, "gateIBUF", Unisim.IBUF, "IOB_X29Y1/IOB_M");
+        ECOTools.connectNet(design, gateIBUF, "I", gate);
+
+        Net clkBUF = design.createNet("clkBUF");
+        ECOTools.connectNet(design, clkIBUF, "O", clkBUF);
+        Net gateBUF = design.createNet("gateBUF");
+        ECOTools.connectNet(design, gateIBUF, "O", gateBUF);
 
         Cell lut = design.createAndPlaceCell("lut", Unisim.LUT2, "SLICE_X86Y67/C6LUT");
         LUTTools.configureLUT(lut, "O=I1 & I0");
@@ -1159,8 +1158,8 @@ public class TestECOTools {
         Net gatedClk = design.createNet("gated_clk");
 
         ECOTools.connectNet(design, lut, "O", gatedClk);
-        ECOTools.connectNet(design, lut, "I0", clk);
-        ECOTools.connectNet(design, lut, "I1", gate);
+        ECOTools.connectNet(design, lut, "I0", clkBUF);
+        ECOTools.connectNet(design, lut, "I1", gateBUF);
         ECOTools.connectNet(design, ff1, "C", gatedClk);
         ECOTools.connectNet(design, ff2, "C", gatedClk);
 
@@ -1179,6 +1178,8 @@ public class TestECOTools {
         ECOTools.connectNet(design, ff2, "R", gnd);
 
         RWRoute.routeDesignFullNonTimingDriven(design);
+
+        VivadoToolsHelper.assertFullyRouted(design);
     }
 
 }


### PR DESCRIPTION
Versal devices can have different unisim mappings/placements based on the underlying device.  This is unlike previous architectures which are consistent across the entire series.  This update makes unisim placement and mapping rules accurate per the Versal device (other devices should be unaffected).  