### PR TITLE
[TimingGraph] Improving Report Timing Example; add some APIs 

### DIFF
--- a/src/com/xilinx/rapidwright/examples/ReportTimingExample.java
+++ b/src/com/xilinx/rapidwright/examples/ReportTimingExample.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019-2022, Xilinx, Inc.
- * Copyright (c) 2022, Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2025, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, Xilinx Research Labs.
@@ -26,6 +26,7 @@ package com.xilinx.rapidwright.examples;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.timing.TimingEdge;
+import com.xilinx.rapidwright.timing.TimingGraph;
 import com.xilinx.rapidwright.timing.TimingManager;
 import com.xilinx.rapidwright.timing.TimingVertex;
 import org.jgrapht.GraphPath;
@@ -51,15 +52,19 @@ public class ReportTimingExample {
         // Instantiate and populate the timing manager for the design
         t.stop().start("Create TimingManager");
         TimingManager tim = new TimingManager(design);
+        TimingGraph tg = tim.getTimingGraph();
 
         // Get and print out worst data path delay in design
         t.stop().start("Get Max Delay");
-        GraphPath<TimingVertex, TimingEdge> criticalPath = tim.getTimingGraph().getMaxDelayPath();
+        GraphPath<TimingVertex, TimingEdge> criticalPath = tg.getMaxDelayPath();
 
         // Print runtime summary
         t.stop().printSummary();
-        System.out.println("\nCritical path: "+ ((int)criticalPath.getWeight())+ " ps");
-        System.out.println("\nPath details:");
-        System.out.println(criticalPath.toString().replace(",", ",\n")+"\n");
+
+        tg.prettyPrintPathDelays(criticalPath);
+        // Previous simple example
+        // System.out.println("\nCritical path: "+ ((int)criticalPath.getWeight())+ " ps");
+        // System.out.println("\nPath details:");
+        // System.out.println(criticalPath.toString().replace(",", ",\n")+"\n");
     }
 }

--- a/src/com/xilinx/rapidwright/timing/TimingGraph.java
+++ b/src/com/xilinx/rapidwright/timing/TimingGraph.java
@@ -50,6 +50,7 @@ import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFHierCellInst;
 import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import com.xilinx.rapidwright.edif.EDIFNet;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFPropertyValue;
 import com.xilinx.rapidwright.edif.EDIFTools;
@@ -355,6 +356,24 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
         return new Pair<>(superSink.getArrivalTime(), superSink);
     }
     
+    /**
+     * Gets the total timing delay of the provided path.
+     * 
+     * @param path The path of interest.
+     * @return The timing delay of the entire path.
+     */
+    public Float getPathDelay(GraphPath<TimingVertex, TimingEdge> path) {
+        if (path == null) {
+            System.err.println("ERROR: Cannot get path delay, path is null.");
+            return null;
+        }
+        float delay = 0.0f;
+        for (TimingEdge e : path.getEdgeList()) {
+            delay += e.getDelay();
+        }
+        return delay;
+    }
+
     private List<TimingVertex> getReversedOrder() {
         List<TimingVertex> reversedOrderedTimingVertices = new ArrayList<>();
         reversedOrderedTimingVertices.addAll(orderedTimingVertices);
@@ -583,6 +602,46 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
             }
         }
         return result;
+    }
+
+    /**
+     * Gets the longest timing path between two hierarchical pins in the netlist.
+     * 
+     * @param src Hierarchical port instance of the source of the path of interest.
+     * @param snk Hierarchical port instance of the sink of the path of interest.
+     * @return The longest timing path between src and snk or null if none could be
+     *         found.
+     */
+    public GraphPath<TimingVertex, TimingEdge> getTimingPath(EDIFHierPortInst src, EDIFHierPortInst snk) {
+        return getTimingPath(src.toString(), snk.toString());
+    }
+    
+    /**
+     * Gets the longest timing path between two hierarchical pins in the netlist.
+     * 
+     * @param src Full hierarchical name of the source of the path of interest.
+     * @param snk Full hierarchical name of the sink of the path of interest.
+     * @return The longest timing path between src and snk or null if none could be
+     *         found.
+     */
+    public GraphPath<TimingVertex, TimingEdge> getTimingPath(String src, String snk) {
+        TimingVertex srcVertex = safeVertexCheck.get(src);
+        TimingVertex snkVertex = safeVertexCheck.get(snk);
+
+        if (srcVertex == null) {
+            System.err.println("ERROR: Couldn't find src pin '" + src + "' in getTimingPath()");
+            return null;
+        }
+        if (snkVertex == null) {
+            System.err.println("ERROR: Couldn't find snk pin '" + snk + "' in getTimingPath()");
+            return null;
+        }
+
+        // Invert the edge weights to find the longest path
+        for (TimingEdge e : edgeSet()) {
+            setEdgeWeight(e, -1 * e.getDelay());
+        }
+        return new BellmanFordShortestPath<>(this).getPath(srcVertex, snkVertex);
     }
 
     /**
@@ -1880,5 +1939,88 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                 timingEdgeConnectionMap.put(edge, connection); // for getting critical path delay breakdown in the timing report
             }
         }
+    }
+
+    private static String getBELPinName(EDIFHierPortInst i, Cell c) {
+        StringBuilder sb = new StringBuilder(c.getSiteName());
+        sb.append("/");
+        sb.append(c.getBELName());
+        sb.append(".");
+        sb.append(c.getPhysicalPinMapping(i.getPortInst().getName()));
+        return sb.toString();
+    }
+
+    private static String getSitePinName(SitePinInst spi) {
+        return spi == null ? "null" : spi.getSite().getName() + "." + spi.getName();
+    }
+
+    public void prettyPrintPathDelays(GraphPath<TimingVertex, TimingEdge> path) {
+        if (path == null) {
+            System.err.println("Cannot print path delay, path is null.");
+            return;
+        }
+        EDIFNetlist n = design.getNetlist();
+        float logicDelayTotal = 0.0f;
+        float netDelayTotal = 0.0f;
+        String indent = "                                                                ";
+        System.out.println("\n All Delays in picoseconds (ps):\n");
+        System.out.println(
+                " Net | Logic | Physical Site/BEL Pins                          | Logical Pins");
+        System.out.println(
+                "------------------------------------------------------------------------------");
+        for (TimingEdge te : path.getEdgeList()) {
+            TimingVertex src = te.getSrc();
+            TimingVertex snk = te.getDst();
+            // Don't report JGraphT endpoints
+            if (src.getName().equals("superSource") || snk.getName().equals("superSink")) {
+                continue;
+            }
+            EDIFNet logicalNet = te.getEdifNet();
+            Net physicalNet = te.getNet();
+            String netName = physicalNet == null
+                    ? (logicalNet == null ? "null" : logicalNet.getName())
+                    : physicalNet.getName();
+            float netDelay = 0.0f;
+            float logicDelay = 0.0f;
+            String physEdge = null;
+            String logEdge = null;
+            EDIFHierPortInst logicalSrc = n.getHierPortInstFromName(src.getName());
+            EDIFHierPortInst logicalSnk = n.getHierPortInstFromName(snk.getName());
+            Cell physicalSrcCell = logicalSrc.getPhysicalCell(design);
+            Cell physicalSnkCell = logicalSnk.getPhysicalCell(design);
+
+            logEdge = physicalSrcCell.getType() + " " + te.getSrc().getName() + "->\n" + indent
+                    + physicalSnkCell.getType() + " " + te.getDst().getName();
+
+            // Check if this is an logic or net delay
+            if (logicalNet == null) {
+                // This is a logic delay (cell pin -> cell pin)
+                logicDelay = te.getDelay();
+                physEdge = getBELPinName(logicalSrc, physicalSrcCell) + "->"
+                        + getBELPinName(logicalSnk, physicalSnkCell);
+            } else {
+                // This is a net delay
+                netDelay = te.getDelay();
+                if (te.getFirstPin() == null) {
+                    // Intra-site delay
+                    physEdge = getBELPinName(logicalSrc, physicalSrcCell) + "->"
+                            + getBELPinName(logicalSnk, physicalSnkCell);
+                } else {
+                    // Inter-site delay
+                    physEdge = getSitePinName(te.getFirstPin()) + "->"
+                            + getSitePinName(te.getSecondPin());
+                }
+            }
+
+            logicDelayTotal += logicDelay;
+            netDelayTotal += netDelay;
+            System.out.printf("%6.1f %6.1f %-49s %s\n", netDelay, logicDelay, physEdge, logEdge);
+            if (netName != null) {
+                System.out.println("              (Net: " + netName + ")");
+            }
+        }
+        System.out.println("---------------------------------------------------------------------");
+        System.out.printf("%6.1f %6.1f | Total: %6.1f\n", netDelayTotal, logicDelayTotal,
+                netDelayTotal + logicDelayTotal);
     }
 }

--- a/test/src/com/xilinx/rapidwright/timing/TestTimingGraph.java
+++ b/test/src/com/xilinx/rapidwright/timing/TestTimingGraph.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.edif.EDIFHierNet;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 
 public class TestTimingGraph {
@@ -40,6 +41,9 @@ public class TestTimingGraph {
 
         GraphPath<TimingVertex, TimingEdge> criticalPath = tg.getMaxDelayPath();
 
+        EDIFHierNet clk = tg.getClockNet(criticalPath);
+        Assertions.assertEquals("clk", clk.toString());
+
         tg.prettyPrintPathDelays(criticalPath);
 
         Assertions.assertEquals(2437.7f, tg.getPathDelay(criticalPath));
@@ -47,6 +51,9 @@ public class TestTimingGraph {
         GraphPath<TimingVertex, TimingEdge> otherPath = tg.getTimingPath(
                 "processor/sx_addr4_flop/Q",
                 "output_port_w_reg[6]/D");
+
+        clk = tg.getClockNet(otherPath);
+        Assertions.assertEquals("clk", clk.toString());
 
         tg.prettyPrintPathDelays(otherPath);
         

--- a/test/src/com/xilinx/rapidwright/timing/TestTimingGraph.java
+++ b/test/src/com/xilinx/rapidwright/timing/TestTimingGraph.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.timing;
+
+import org.jgrapht.GraphPath;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+
+public class TestTimingGraph {
+
+    @Test
+    public void testGetTimingPaths() {
+        Design d = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235_2022_1.dcp");
+
+        TimingManager tm = new TimingManager(d);
+        TimingGraph tg = tm.getTimingGraph();
+
+        GraphPath<TimingVertex, TimingEdge> criticalPath = tg.getMaxDelayPath();
+
+        tg.prettyPrintPathDelays(criticalPath);
+
+        Assertions.assertEquals(2437.7f, tg.getPathDelay(criticalPath));
+
+        GraphPath<TimingVertex, TimingEdge> otherPath = tg.getTimingPath(
+                "processor/sx_addr4_flop/Q",
+                "output_port_w_reg[6]/D");
+
+        tg.prettyPrintPathDelays(otherPath);
+        
+        Assertions.assertEquals(1611.1f, tg.getPathDelay(otherPath));
+    }
+}


### PR DESCRIPTION
This PR improves the [Report Timing Example](https://www.rapidwright.io/docs/ReportTimingExample.html) so that the path print out is more informative.  It also adds a view convenience methods for getting timing paths and calculating the total delay of the path.  Here are the main APIs added to `TimingGraph`:

- `public void prettyPrintPathDelays(GraphPath<TimingVertex, TimingEdge> path)`
- `public GraphPath<TimingVertex, TimingEdge> getTimingPath(String src, String snk)`
- `public GraphPath<TimingVertex, TimingEdge> getTimingPath(EDIFHierPortInst src, EDIFHierPortInst snk)`
- `public Float getPathDelay(GraphPath<TimingVertex, TimingEdge> path)`

**AFTER**
```
All Delays in picoseconds (ps):

 Net | Logic | Physical Site/BEL Pins                          | Logical Pins
------------------------------------------------------------------------------
 309.3    0.0 SLICE_X73Y104.BQ->SLICE_X71Y105.B1                FDRE microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Op2_reg[31]/Q->
                                                                LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/LUT6/I0
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Op2_reg[0]_0[0])
   0.0  150.0 SLICE_X71Y105/B6LUT.A1->SLICE_X71Y105/B6LUT.O6    LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/LUT6/I0->
                                                                LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/LUT6/O
  15.0    0.0 SLICE_X71Y105/B6LUT.O6->SLICE_X71Y105/CARRY8.S1   LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/LUT6/O->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/Using_FPGA.Native_CARRY4_CARRY8/S[1]
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/O6)
   0.0  197.0 SLICE_X71Y105/CARRY8.S1->SLICE_X71Y105/CARRY8.CO7 CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/Using_FPGA.Native_CARRY4_CARRY8/S[1]->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/Using_FPGA.Native_CARRY4_CARRY8/CO[7]
   0.0    0.0 SLICE_X71Y105.COUT->null                          CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/Using_FPGA.Native_CARRY4_CARRY8/CO[7]->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/Using_FPGA.Native_I1_CARRY4_CARRY8/CI
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/lopt_13)
   0.0   67.0 SLICE_X71Y106/CARRY8.CIN->SLICE_X71Y106/CARRY8.O2 CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/Using_FPGA.Native_I1_CARRY4_CARRY8/CI->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/Using_FPGA.Native_I1_CARRY4_CARRY8/O[2]
 211.0    0.0 SLICE_X71Y106.CMUX->SLICE_X74Y107.G1              CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/Using_FPGA.Native_I1_CARRY4_CARRY8/O[2]->
                                                                LUT5 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Using_FPGA.Native_i_1__73/I0
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/lopt_11)
   0.0  150.0 SLICE_X74Y107/G6LUT.A1->SLICE_X74Y107/G6LUT.O6    LUT5 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Using_FPGA.Native_i_1__73/I0->
                                                                LUT5 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Using_FPGA.Native_i_1__73/O
 242.1    0.0 SLICE_X74Y107.G_O->SLICE_X72Y102.D1               LUT5 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Using_FPGA.Native_i_1__73/O->
                                                                LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/Using_FPGA.Native_i_1__33/I0
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/EX_Fwd[22])
   0.0  150.0 SLICE_X72Y102/D6LUT.A1->SLICE_X72Y102/D6LUT.O6    LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/Using_FPGA.Native_i_1__33/I0->
                                                                LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/Using_FPGA.Native_i_1__33/O
 429.9    0.0 SLICE_X72Y102.D_O->SLICE_X75Y109.HX               LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/Using_FPGA.Native_i_1__33/O->
                                                                FDRE microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Branch_CMP_Op1_reg[22]/D
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/ex_sel_alu_i_reg[9])
---------------------------------------------------------------------
1207.3  714.0 | Total: 1921.3

```
**BEFORE**
```
    Critical path: 1921 ps

    Path details:
    [superSource -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Op2_reg[31]/Q,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Op2_reg[31]/Q -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/LUT6/I0,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/LUT6/I0 -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/LUT6/O,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[31].ALU_Bit_I1/Not_Last_Bit.I_ALU_LUT_V5/Using_FPGA.Native/LUT6/O -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/Using_FPGA.Native_CARRY4_CARRY8/S[1],
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/Using_FPGA.Native_CARRY4_CARRY8/S[1] -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/Using_FPGA.Native_CARRY4_CARRY8/CO[7],
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Use_Carry_Decoding.CarryIn_MUXCY/Using_FPGA.Native_CARRY4_CARRY8/CO[7] -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/Using_FPGA.Native_I1_CARRY4_CARRY8/CI,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/Using_FPGA.Native_I1_CARRY4_CARRY8/CI -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/Using_FPGA.Native_I1_CARRY4_CARRY8/O[2],
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/ALU_I/Using_FPGA.ALL_Bits[24].ALU_Bit_I1/Not_Last_Bit.MUXCY_XOR_I/Using_FPGA.Native_I1_CARRY4_CARRY8/O[2] -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Using_FPGA.Native_i_1__73/I0,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Using_FPGA.Native_i_1__73/I0 -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Using_FPGA.Native_i_1__73/O,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Using_FPGA.Native_i_1__73/O -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/Using_FPGA.Native_i_1__33/I0,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/Using_FPGA.Native_i_1__33/I0 -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/Using_FPGA.Native_i_1__33/O,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/PreFetch_Buffer_I1/Instruction_Prefetch_Mux[33].Gen_Instr_DFF/Using_FPGA.Native_i_1__33/O -> microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Branch_CMP_Op1_reg[22]/D,
     microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Branch_CMP_Op1_reg[22]/D -> superSink]
```

One can also now get a specific timing path given to cell pin endpoints, for example, using the same `microblaze4.dcp` used in the Report Timing Example:
```java 
        // Example of how to get an explicit path between two cell pins
        GraphPath<TimingVertex, TimingEdge> otherPath = tg.getTimingPath(
                "microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Branch_CMP_Op1_reg[8]/Q",
                "microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Use_Debug_Logic.Master_Core.Debug_Perf/single_step_count_reg[0]/CE");
        tg.prettyPrintPathDelays(otherPath);
```
Which outputs:
```
 All Delays in picoseconds (ps):

 Net | Logic | Physical Site/BEL Pins                          | Logical Pins
------------------------------------------------------------------------------
 397.2    0.0 SLICE_X75Y108.DQ2->SLICE_X75Y108.C4               FDRE microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Branch_CMP_Op1_reg[8]/Q->
                                                                LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/S0_inferred__3/i_/I2
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Operand_Select_I/EX_Branch_CMP_Op1_reg[0]_0[21])
   0.0   90.0 SLICE_X75Y108/C6LUT.A4->SLICE_X75Y108/C6LUT.O6    LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/S0_inferred__3/i_/I2->
                                                                LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/S0_inferred__3/i_/O
  15.0    0.0 SLICE_X75Y108/C6LUT.O6->SLICE_X75Y108/CARRY8.S2   LUT6 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/S0_inferred__3/i_/O->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/Part_Of_Zero_Carry_Start/Using_FPGA.Native_CARRY4_CARRY8/S[2]
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/S0_inferred__3/i__n_0)
   0.0  168.0 SLICE_X75Y108/CARRY8.S2->SLICE_X75Y108/CARRY8.CO7 CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/Part_Of_Zero_Carry_Start/Using_FPGA.Native_CARRY4_CARRY8/S[2]->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/Part_Of_Zero_Carry_Start/Using_FPGA.Native_CARRY4_CARRY8/CO[7]
   0.0    0.0 SLICE_X75Y108.COUT->null                          CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/Part_Of_Zero_Carry_Start/Using_FPGA.Native_CARRY4_CARRY8/CO[7]->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY2/Using_FPGA.Native_CARRY4_CARRY8/CI
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Data_Flow_I/Zero_Detect_I/Part_Of_Zero_Carry_Start/lopt_8)
   0.0   42.0 SLICE_X75Y109/CARRY8.CIN->SLICE_X75Y109/CARRY8.CO1 CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY2/Using_FPGA.Native_CARRY4_CARRY8/CI->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY2/Using_FPGA.Native_CARRY4_CARRY8/CO[1]
  87.0    0.0 SLICE_X75Y109.BMUX->SLICE_X74Y109.D5              CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY2/Using_FPGA.Native_CARRY4_CARRY8/CO[1]->
                                                                LUT4 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY3/Using_FPGA.Native_i_1__100/I0
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY2/lopt_1)
   0.0   50.0 SLICE_X74Y109/D6LUT.A5->SLICE_X74Y109/D6LUT.O6    LUT4 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY3/Using_FPGA.Native_i_1__100/I0->
                                                                LUT4 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY3/Using_FPGA.Native_i_1__100/O
  15.0    0.0 SLICE_X74Y109/D6LUT.O6->SLICE_X74Y109/CARRY8.S3   LUT4 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY3/Using_FPGA.Native_i_1__100/O->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/mem_wait_on_ready_N_carry_or/MUXCY_I/Using_FPGA.Native_CARRY4_CARRY8/S[3]
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/jump_logic_I1/MUXCY_JUMP_CARRY3/Using_FPGA.Native_0)
   0.0  170.0 SLICE_X74Y109/CARRY8.S3->SLICE_X74Y109/CARRY8.CO7 CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/mem_wait_on_ready_N_carry_or/MUXCY_I/Using_FPGA.Native_CARRY4_CARRY8/S[3]->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/mem_wait_on_ready_N_carry_or/MUXCY_I/Using_FPGA.Native_CARRY4_CARRY8/CO[7]
   0.0    0.0 SLICE_X74Y109.COUT->null                          CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/mem_wait_on_ready_N_carry_or/MUXCY_I/Using_FPGA.Native_CARRY4_CARRY8/CO[7]->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Use_MuxCy[7].OF_Piperun_Stage/MUXCY_I/Using_FPGA.Native_CARRY4_CARRY8/CI
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/mem_wait_on_ready_N_carry_or/MUXCY_I/lopt_10)
   0.0   92.0 SLICE_X74Y110/CARRY8.CIN->SLICE_X74Y110/CARRY8.CO4 CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Use_MuxCy[7].OF_Piperun_Stage/MUXCY_I/Using_FPGA.Native_CARRY4_CARRY8/CI->
                                                                CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Use_MuxCy[7].OF_Piperun_Stage/MUXCY_I/Using_FPGA.Native_CARRY4_CARRY8/CO[4]
 344.3    0.0 SLICE_X74Y110.EMUX->SLICE_X80Y99.F5               CARRY8 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Use_MuxCy[7].OF_Piperun_Stage/MUXCY_I/Using_FPGA.Native_CARRY4_CARRY8/CO[4]->
                                                                LUT2 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Use_Debug_Logic.Master_Core.Debug_Perf/single_step_count[0]_i_1/I1
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Decode_I/Use_MuxCy[7].OF_Piperun_Stage/MUXCY_I/lopt_10)
   0.0   50.0 SLICE_X80Y99/F6LUT.A5->SLICE_X80Y99/F6LUT.O6      LUT2 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Use_Debug_Logic.Master_Core.Debug_Perf/single_step_count[0]_i_1/I1->
                                                                LUT2 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Use_Debug_Logic.Master_Core.Debug_Perf/single_step_count[0]_i_1/O
 236.5    0.0 SLICE_X80Y99.F_O->SLICE_X80Y99.CKEN4              LUT2 microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Use_Debug_Logic.Master_Core.Debug_Perf/single_step_count[0]_i_1/O->
                                                                FDRE microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Use_Debug_Logic.Master_Core.Debug_Perf/single_step_count_reg[0]/CE
              (Net: microblaze_0/U0/MicroBlaze_Core_I/Performance.Core/Use_Debug_Logic.Master_Core.Debug_Perf/single_step_count[0]_i_1_n_0)
---------------------------------------------------------------------
1095.0  662.0 | Total: 1757.0
```
