### PR TITLE
[DesignTools] Handles VCC/GND connections properly in populateBlackBox()

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -945,6 +945,8 @@ public class DesignTools {
         // We need to prefix all cell and net names with the hierarchicalCellName as a prefix
         Net vcc = design.getVccNet();
         Net gnd = design.getGndNet();
+        Net vccCell = cell.getVccNet();
+        Net gndCell = cell.getGndNet();
         for (SiteInst si : cell.getSiteInsts()) {
             for (Cell c : new ArrayList<Cell>(si.getCells())) {
                 c.updateName(hierarchicalCellName + "/" + c.getName());
@@ -958,11 +960,11 @@ public class DesignTools {
             }
             design.addSiteInst(si);
             // Update GND/VCC site routing to point to destination design's GND/VCC nets
-            for (String siteWire : si.getSiteWiresFromNet(vcc)) {
+            for (String siteWire : si.getSiteWiresFromNet(vccCell)) {
                 BELPin pin = si.getSiteWirePins(siteWire)[0];
                 si.routeIntraSiteNet(vcc, pin, pin);
             }
-            for (String siteWire : si.getSiteWiresFromNet(gnd)) {
+            for (String siteWire : si.getSiteWiresFromNet(gndCell)) {
                 BELPin pin = si.getSiteWirePins(siteWire)[0];
                 si.routeIntraSiteNet(gnd, pin, pin);
             }

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1008,7 +1008,13 @@ public class DesignTools {
             EDIFHierNet parentNetName = netlist.getParentNet(netName);
             Net parentNet = design.getNet(parentNetName.getHierarchicalNetName());
             if (parentNet == null) {
-                parentNet = new Net(parentNetName);
+                if (net.isVCC()) {
+                    parentNet = design.getVccNet();
+                } else if (net.isGND()) {
+                    parentNet = design.getGndNet();
+                } else {
+                    parentNet = new Net(parentNetName);
+                }
             }
             for (EDIFHierNet netAlias : netlist.getNetAliases(netName)) {
                 if (parentNet.getName().equals(netAlias.getHierarchicalNetName())) continue;

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -943,6 +943,8 @@ public class DesignTools {
 
         // Add placement information
         // We need to prefix all cell and net names with the hierarchicalCellName as a prefix
+        Net vcc = design.getVccNet();
+        Net gnd = design.getGndNet();
         for (SiteInst si : cell.getSiteInsts()) {
             for (Cell c : new ArrayList<Cell>(si.getCells())) {
                 c.updateName(hierarchicalCellName + "/" + c.getName());
@@ -955,6 +957,15 @@ public class DesignTools {
                 }
             }
             design.addSiteInst(si);
+            // Update GND/VCC site routing to point to destination design's GND/VCC nets
+            for (String siteWire : si.getSiteWiresFromNet(vcc)) {
+                BELPin pin = si.getSiteWirePins(siteWire)[0];
+                si.routeIntraSiteNet(vcc, pin, pin);
+            }
+            for (String siteWire : si.getSiteWiresFromNet(gnd)) {
+                BELPin pin = si.getSiteWirePins(siteWire)[0];
+                si.routeIntraSiteNet(gnd, pin, pin);
+            }
         }
 
         // Add routing information


### PR DESCRIPTION
If the top level design is driving one of the ports of the black box with GND or VCC, this should recognize that it should switch the parent net to their physical net equivalents (`GLOBAL_LOGIC[1|0]`).  