### PR TITLE
[DesignTools] createCeClkOfRoutethruFFToVCC() to handle AND2B1L/OR2L

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3363,7 +3363,7 @@ public class DesignTools {
     }
 
     /**
-     * Examines a design for FFs configured as routethrus or as AND/OR functions, ensuring that the CE pins of
+     * Examines a design for FFs configured as routethrus or as AND2B1L/OR2L functions, ensuring that the CE pins of
      * the used BELs are connected via the correct intra-site routing to VCC and their CLK pins are connected to
      * GND (which is supplied via inversion from VCC).
      * @param design Design to be processed.

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3363,7 +3363,7 @@ public class DesignTools {
     }
 
     /**
-     * Examines a design for FFs configured as routethrus or as AND2B1L/OR2L functions, ensuring that the CE pins of
+     * Examines a design for FFs configured as routethrus or as AND2B1L/OR2L functionality, ensuring that the CE pins of
      * the used BELs are connected via the correct intra-site routing to VCC and their CLK pins are connected to
      * GND (which is supplied via inversion from VCC).
      * @param design Design to be processed.

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3362,6 +3362,12 @@ public class DesignTools {
         createCeSrRstPinsToVCC(design);
     }
 
+    /**
+     * Examines a design for FFs configured as routethrus or as AND/OR functions, ensuring that the CE pins of
+     * the used BELs are connected via the correct intra-site routing to VCC and their CLK pins are connected to
+     * GND (which is supplied via inversion from VCC).
+     * @param design Design to be processed.
+     */
     public static void createCeClkOfRoutethruFFToVCC(Design design) {
         boolean isVersal = (design.getSeries() == Series.Versal);
         Net vcc = design.getVccNet();

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3363,10 +3363,7 @@ public class DesignTools {
     }
 
     public static void createCeClkOfRoutethruFFToVCC(Design design) {
-        if (design.getSeries() == Series.Versal) {
-            // Versal have OUTMUX[A-H][12]-es for bypassing FFs
-            return;
-        }
+        boolean isVersal = (design.getSeries() == Series.Versal);
         Net vcc = design.getVccNet();
         Net gnd = design.getGndNet();
         for (SiteInst si : design.getSiteInsts()) {
@@ -3374,12 +3371,19 @@ public class DesignTools {
                 continue;
             }
             for (Cell cell : si.getCells()) {
-                if (!cell.isFFRoutethruCell()) {
+                BEL bel = cell.getBEL();
+                if (bel == null || !bel.isFF() || bel.isAnyIMR()) {
                     continue;
                 }
 
-                BEL bel = cell.getBEL();
-                if (bel == null) {
+                String cellType = cell.getType();
+                if (cellType.equals("AND2B1L") || cellType.equals("OR2L")) {
+                    // pass
+                } else if (cell.isFFRoutethruCell()) {
+                    // Versal have OUTMUX[A-H][12]-es for bypassing FFs
+                    assert(!isVersal);
+                    // pass
+                } else {
                     continue;
                 }
 
@@ -3394,6 +3398,13 @@ public class DesignTools {
                 // ...and GND at CLK
                 BELPin clkInput = bel.getPin("CLK");
                 BELPin clkInvOut = clkInput.getSourcePin();
+                if (isVersal) {
+                    // On Versal only, punch through the FF_CLK_MOD
+                    assert(clkInvOut.getBEL().isSliceFFClkMod());
+                    assert(clkInvOut.getName().equals("CLK_OUT"));
+                    clkInvOut = clkInvOut.getBEL().getPin("CLK").getSourcePin();
+                }
+                assert(clkInvOut.getBELName().matches("CLK[12]?INV"));
                 si.routeIntraSiteNet(gnd, clkInvOut, clkInput);
                 BELPin clkInvIn = clkInvOut.getBEL().getPin(0);
                 String clkInputSitePinName = clkInvIn.getConnectedSitePinName();

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -1679,6 +1679,35 @@ public class TestDesignTools {
         for (SitePinInst p : unrouted) {
             Assertions.assertTrue(p.getName().equals("CLKAU_X") || p.getName().equals("CLKAL_X"));
         }
+    }
 
+    @ParameterizedTest
+    @CsvSource({
+            // Versal
+            "xcvp1202,SLICE_X64Y105,AND2B1L",
+            "xcvp1202,SLICE_X64Y105,OR2L",
+
+            // US+
+            "xcvu3p,SLICE_X0Y0,AND2B1L",
+            "xcvu3p,SLICE_X0Y0,OR2L"
+    })
+    public void testCreateCeClkOfRoutethruFFToVCC(String deviceName, String siteName, String unisimName) {
+        Design design = new Design("testCreateCeClkOfRoutethruFFToVCC", deviceName);
+        Cell cell = design.createAndPlaceCell("ff", Unisim.valueOf(unisimName), siteName + "/AFF");
+
+        Assertions.assertTrue(design.getNets().isEmpty());
+
+        DesignTools.createCeClkOfRoutethruFFToVCC(design);
+
+        SiteInst si = cell.getSiteInst();
+        SitePinInst ceSpi = si.getSitePinInst("CKEN1");
+        Assertions.assertTrue(ceSpi.getNet().isVCCNet());
+
+        boolean isVersal = design.getSeries() == Series.Versal;
+        SitePinInst clkSpi = si.getSitePinInst(isVersal ? "CLK" : "CLK1");
+        Assertions.assertTrue(clkSpi.getNet().isVCCNet());
+        if (isVersal) {
+            Assertions.assertTrue(si.getNetFromSiteWire("FF_CLK_MOD_CLK_OUT").isGNDNet());
+        }
     }
 }


### PR DESCRIPTION
`DesignTools.createCeClkOfRoutethruFFToVCC()` is responsible for examining the physical netlist to discover the presence of FFs configured as routethrus and ensuring that their `CE` pins are connected to VCC, and their `CLK` pins are connected to GND (which is supplied via inversion from VCC). This operation only applied to US/US+ but not to Versal, since Versal now has a mux to bypass the flop without needing routethru.

It turns out this same operation is also necessary for the `AND2B1L` and `OR2L` unisims (and perhaps more; these seem to be the only two officially supported ones according to [UG974 for US/US+](https://docs.amd.com/r/en-US/ug974-vivado-ultrascale-libraries) and [UG1344 for Versal](https://docs.amd.com/r/en-US/ug1344-versal-architecture-libraries))

Do we want to change the name of this method (with an alias to the old name)? (Answered: No)

Depends on https://github.com/Xilinx/RapidWright/pull/1285 passing first.