### PR TITLE
Cannot close the zip file (refactor?)

### DIFF
--- a/src/com/xilinx/rapidwright/util/FileTools.java
+++ b/src/com/xilinx/rapidwright/util/FileTools.java
@@ -1500,7 +1500,9 @@ public class FileTools {
     }
 
     public static Pair<InputStream,Long> getInputStreamFromZipFile(String zipFileName, String fileEndsWith) {
-        try (ZipFile zip = new ZipFile(zipFileName)) {
+        try {
+            @SuppressWarnings("resource")
+            final ZipFile zip = new ZipFile(zipFileName);
             Enumeration<? extends ZipEntry> entries = zip.entries();
             ZipEntry match = null;
             while (entries.hasMoreElements()) {


### PR DESCRIPTION
This is to undo a previous change in https://github.com/Xilinx/RapidWright/commit/3ad137f6ae8d99f78c58979ab7acd7d0245d80b6#diff-383ed60df1114ad2a85cd1978f13b57b3b5d29f7adc22dee6c3423137ed6010d. This is causing an internal test failure, by setting the `ZipFile zip` to close where the previous behavior was to leave it open.  This change returns the code to is previous behavior.

Ideally, we would refactor to change the way this method is used,