### PR TITLE
Add features to PerformanceExplorer, ArrayBuilder, and InlineFlopTools

### DIFF
--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -219,4 +219,33 @@ public class NetTools {
         }
         return unroutedNets;
     }
+
+    /**
+     * Returns a list of nets with overlapping nodes without unrouting them.
+     *
+     * @param design The design to evaluate for conflicting nodes.
+     * @return The list of nets that overlap.
+     */
+    public static List<Net> netsWithOverlappingNodes(Design design) {
+        List<Net> overlappingNets = new ArrayList<>();
+        Map<Node, Net> used = new HashMap<>();
+        for (Net net : design.getNets()) {
+            for (PIP pip : net.getPIPs()) {
+                for (Node node : new Node[] { pip.getStartNode(), pip.getEndNode() }) {
+                    if (node == null)
+                        continue;
+                    Net existing = used.putIfAbsent(node, net);
+                    if (existing != null && existing != net) {
+                        for (PIP oldPip : new ArrayList<>(existing.getPIPs())) {
+                            for (Node oldNode : new Node[] { oldPip.getStartNode(), oldPip.getEndNode() }) {
+                                used.remove(oldNode);
+                            }
+                        }
+                        overlappingNets.add(existing);
+                    }
+                }
+            }
+        }
+        return overlappingNets;
+    }
 }

--- a/src/com/xilinx/rapidwright/design/tools/InlineFlopTools.java
+++ b/src/com/xilinx/rapidwright/design/tools/InlineFlopTools.java
@@ -38,11 +38,10 @@ import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
 import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.design.blocks.PBlock;
-import com.xilinx.rapidwright.device.BEL;
-import com.xilinx.rapidwright.device.Series;
-import com.xilinx.rapidwright.device.Site;
+import com.xilinx.rapidwright.device.*;
 import com.xilinx.rapidwright.eco.ECOPlacementHelper;
 import com.xilinx.rapidwright.edif.*;
+import com.xilinx.rapidwright.placer.blockplacer.Point;
 import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.StringTools;
 
@@ -51,7 +50,7 @@ import com.xilinx.rapidwright.util.StringTools;
  * This is targeted at kernel replication preparation prior to routing to ensure
  * that connections are routed outside of the pblock of the out-of-context
  * kernel.
- * 
+ *
  */
 public class InlineFlopTools {
 
@@ -62,21 +61,57 @@ public class InlineFlopTools {
     public static final String INLINE_SUFFIX = "_rw_inline_flop";
 
     /**
-     * Add flip flops inline on all the top-level ports of an out-of-context design.
+     * Add flip-flops inline on all the top-level ports of an out-of-context design.
      * This is useful for out-of-context kernels prior to placement and routing so that
      * after the flops have been placed, the router is forced to route connections
      * of each of the ports to each of the flops. This can help alleviate congestion
      * when the kernels are placed/relocated in context. Note this assumes the
      * design is not implemented as in most contexts it will be placed and routed
      * immediately following this modification.
-     * 
+     *
      * @param design  The design to modify
      * @param clkNet  Name of the clock net to use on which to add the flops
      * @param keepOut The pblock used to contain the kernel and the added flops will
      *                not be placed inside this area.
      */
-    public static void createAndPlaceFlopsInlineOnTopPorts(Design design, String clkNet, PBlock keepOut) {
-        assert (design.getSiteInsts().size() == 0);
+    public static void createAndPlaceFlopsInlineOnTopPortsArbitrarily(Design design, String clkNet, PBlock keepOut) {
+        createAndPlaceFlopsInlineOnTopPorts(design, clkNet, keepOut, false);
+    }
+
+    /**
+     * Add flip-flops inline on all the top-level ports of an out-of-context design.
+     * Flip-flop placements are chosen based on the centroid of net pins for each top-level
+     * I/O. This is useful for out-of-context kernels prior to final routing so that
+     * after the flops have been placed, the router is forced to route connections
+     * of each of the ports to each of the flops. Note this assumes the design is
+     * placed and potentially partially routed.
+     *
+     * @param design  The design to modify
+     * @param clkNet  Name of the clock net to use on which to add the flops
+     * @param keepOut The pblock used to contain the kernel and the added flops will
+     *                not be placed inside this area.
+     */
+    public static void createAndPlaceFlopsInlineOnTopPortsNearPins(Design design, String clkNet, PBlock keepOut) {
+        createAndPlaceFlopsInlineOnTopPorts(design, clkNet, keepOut, true);
+    }
+
+    /**
+     * Add flip-flops inline on all the top-level ports of an out-of-context design.
+     * This is useful for out-of-context kernels so that after the flops have been
+     * placed, the router is forced to route connections of each of the ports to
+     * each of the flops. This can help alleviate congestion when the kernels are
+     * placed/relocated in context.
+     *
+     * @param design         The design to modify
+     * @param clkNet         Name of the clock net to use on which to add the flops
+     * @param keepOut        The pblock used to contain the kernel and the added flops will
+     *                       not be placed inside this area.
+     * @param smartPlacement Places flip-flops based on the centroid of the top-level net pins. Should only be
+     *                       used if a placement already exists.
+     */
+    private static void createAndPlaceFlopsInlineOnTopPorts(Design design, String clkNet, PBlock keepOut,
+                                                            boolean smartPlacement) {
+        assert (design.getSiteInsts().isEmpty());
         EDIFCell top = design.getTopEDIFCell();
         Site start = keepOut.getAllSites("SLICE").iterator().next(); // TODO this is a bit wasteful
         boolean exclude = true;
@@ -88,28 +123,78 @@ public class InlineFlopTools {
         Set<SiteInst> siteInstsToRoute = new HashSet<>();
 
         for (EDIFPort port : top.getPorts()) {
-            // Don't flop the clock net
-            if (port.getName().equals(clkNet)) {
-                continue;
-            }
             if (port.isBus()) {
                 for (int i : port.getBitBlastedIndicies()) {
                     EDIFPortInst inst = port.getInternalPortInstFromIndex(i);
-                    Pair<Site, BEL> loc = nextAvailPlacement(design, siteItr);
-                    Cell flop = createAndPlaceFlopInlineOnTopPortInst(design, inst, loc, clk);
-                    siteInstsToRoute.add(flop.getSiteInst());
+                    if (allLeavesAreIBUF(design, inst)) {
+                        continue;
+                    }
+
+                    if (smartPlacement) {
+                        smartFlipFlopPlacement(design, inst, keepOut, clk, siteInstsToRoute);
+                    } else {
+                        Pair<Site, BEL> loc = nextAvailPlacement(design, siteItr);
+                        Cell flop = createAndPlaceFlopInlineOnTopPortInst(design, inst, loc, clk);
+                        siteInstsToRoute.add(flop.getSiteInst());
+                    }
                 }
             } else {
                 EDIFPortInst inst = port.getInternalPortInst();
                 if (inst != null) {
-                    Pair<Site, BEL> loc = nextAvailPlacement(design, siteItr);
-                    Cell flop = createAndPlaceFlopInlineOnTopPortInst(design, inst, loc, clk);
-                    siteInstsToRoute.add(flop.getSiteInst());
+                    if (allLeavesAreIBUF(design, inst)) {
+                        continue;
+                    }
+
+                    if (smartPlacement) {
+                        smartFlipFlopPlacement(design, inst, keepOut, clk, siteInstsToRoute);
+                    } else {
+                        Pair<Site, BEL> loc = nextAvailPlacement(design, siteItr);
+                        Cell flop = createAndPlaceFlopInlineOnTopPortInst(design, inst, loc, clk);
+                        siteInstsToRoute.add(flop.getSiteInst());
+                    }
                 }
             }
         }
         for (SiteInst si : siteInstsToRoute) {
             si.routeSite();
+        }
+    }
+
+    private static boolean allLeavesAreIBUF(Design design, EDIFPortInst inst) {
+        EDIFHierCellInst topInst = design.getNetlist().getTopHierCellInst();
+        EDIFHierPortInst hierPortInst = new EDIFHierPortInst(topInst, inst);
+        List<EDIFHierPortInst> leafHierPortInsts = hierPortInst.getHierarchicalNet().getLeafHierPortInsts();
+
+        boolean allLeavesAreIBUF = !leafHierPortInsts.isEmpty();
+        for (EDIFHierPortInst leafHierPortInst : leafHierPortInsts) {
+            allLeavesAreIBUF &= leafHierPortInst.getCellType().getName().equals("IBUF");
+        }
+        return allLeavesAreIBUF;
+    }
+
+    private static void smartFlipFlopPlacement(Design design, EDIFPortInst inst, PBlock keepOut, EDIFHierNet clk,
+                                               Set<SiteInst> siteInstsToRoute) {
+        EDIFHierCellInst topInst = design.getNetlist().getTopHierCellInst();
+        EDIFHierPortInst hierPortInst = new EDIFHierPortInst(topInst, inst);
+        List<EDIFHierPortInst> leafHierPortInsts = hierPortInst.getHierarchicalNet().getLeafHierPortInsts();
+        List<Point> points = new ArrayList<>();
+        for (EDIFHierPortInst leafInst : leafHierPortInsts) {
+            Cell cell = design.getCell(leafInst.getFullHierarchicalInstName());
+            if (cell != null && cell.isPlaced()) {
+                Tile t = cell.getTile();
+                Point p = new Point(t.getColumn(), t.getRow());
+                points.add(p);
+            }
+        }
+
+        if (!points.isEmpty()) {
+            Set<SiteTypeEnum> validCentroidSiteTypes = Set.of(SiteTypeEnum.SLICEL, SiteTypeEnum.SLICEM);
+            Site centroid = ECOPlacementHelper.getCentroidOfPoints(design.getDevice(), points, validCentroidSiteTypes);
+            Iterator<Site> siteItr = ECOPlacementHelper.spiralOutFrom(centroid, keepOut, true).iterator();
+            siteItr.next();
+            Pair<Site, BEL> loc = nextAvailPlacement(design, siteItr);
+            Cell flop = createAndPlaceFlopInlineOnTopPortInst(design, inst, loc, clk);
+            siteInstsToRoute.add(flop.getSiteInst());
         }
     }
 
@@ -126,7 +211,7 @@ public class InlineFlopTools {
     }
 
     private static Cell createAndPlaceFlopInlineOnTopPortInst(Design design, EDIFPortInst portInst, Pair<Site, BEL> loc,
-            EDIFHierNet clk) {
+                                                              EDIFHierNet clk) {
         String name = portInst.getFullName() + INLINE_SUFFIX;
         Cell flop = design.createAndPlaceCell(design.getTopEDIFCell(), name, Unisim.FDRE, loc.getFirst(),
                 loc.getSecond());
@@ -154,8 +239,8 @@ public class InlineFlopTools {
 
     /**
      * Removes the inline flops added by
-     * {@link #createAndPlaceFlopsInlineOnTopPorts(Design, String, PBlock)}
-     * 
+     * {@link #createAndPlaceFlopsInlineOnTopPorts(Design, String, PBlock, boolean)}
+     *
      * @param design The current design from which to remove the flops
      */
     public static void removeInlineFlops(Design design) {
@@ -165,7 +250,7 @@ public class InlineFlopTools {
         Net vcc = design.getVccNet();
         Set<SitePinInst> vccPins = new HashSet<>();
         pinsToRemove.put(vcc, vccPins);
-        String[] staticPins = new String[] { "CKEN1", design.getSeries() == Series.Versal ? "RST" : "SRST1" };
+        String[] staticPins = new String[]{"CKEN1", design.getSeries() == Series.Versal ? "RST" : "SRST1"};
         for (EDIFCellInst inst : design.getTopEDIFCell().getCellInsts()) {
             if (inst.getName().endsWith(INLINE_SUFFIX)) {
                 Cell flop = design.getCell(inst.getName());
@@ -190,7 +275,7 @@ public class InlineFlopTools {
         }
         DesignTools.batchRemoveSitePins(pinsToRemove, true);
 
-        String[] ctrlPins = new String[] { "C", "R", "CE" };
+        String[] ctrlPins = new String[]{"C", "R", "CE"};
         EDIFCell top = design.getTopEDIFCell();
         for (EDIFCellInst c : cellsToRemove) {
             // Remove control set pins
@@ -233,11 +318,11 @@ public class InlineFlopTools {
 
     public static void main(String[] args) {
         if (args.length < 3 || args.length > 4) {
-            System.out.println("USAGE (to add flops)   : <input.dcp> <output.dcp> "+CLK_OPT+"=<clkName> "+PBLOCK_OPT+"=<pblock range(s)>");
+            System.out.println("USAGE (to add flops)   : <input.dcp> <output.dcp> " + CLK_OPT + "=<clkName> " + PBLOCK_OPT + "=<pblock range(s)>");
             System.out.println("USAGE (to remove flops): <input.dcp> <output.dcp> " + REMOVE_FLOPS_OPT);
             return;
         }
-        
+
         Design d = Design.readCheckpoint(args[0]);
 
         if (args[2].startsWith(CLK_OPT) || args[2].startsWith(PBLOCK_OPT)) {
@@ -245,18 +330,18 @@ public class InlineFlopTools {
             String clkName = StringTools.getOptionValue(CLK_OPT, args);
             String pblockRange = StringTools.getOptionValue(PBLOCK_OPT, args);
             if (clkName == null || pblockRange == null) {
-                throw new RuntimeException("ERROR: Missing value(s) for option(s): " 
+                throw new RuntimeException("ERROR: Missing value(s) for option(s): "
                         + CLK_OPT + "=" + clkName + ", " + PBLOCK_OPT + "=" + pblockRange);
             }
             PBlock pblock = new PBlock(d.getDevice(), pblockRange);
-            createAndPlaceFlopsInlineOnTopPorts(d, clkName, pblock);
+            createAndPlaceFlopsInlineOnTopPortsArbitrarily(d, clkName, pblock);
         } else if (args[2].equals(REMOVE_FLOPS_OPT)) {
             removeInlineFlops(d);
         } else {
-            System.err.println("ERROR: Unrecognized option '" + args[2] +"'");
+            System.err.println("ERROR: Unrecognized option '" + args[2] + "'");
         }
-        
-        
+
+
         d.writeCheckpoint(args[1]);
     }
 }

--- a/src/com/xilinx/rapidwright/eco/ECOPlacementHelper.java
+++ b/src/com/xilinx/rapidwright/eco/ECOPlacementHelper.java
@@ -272,7 +272,7 @@ public class ECOPlacementHelper {
         if (points.size() == 0) return null;
         Point centroid = KMeans.calculateCentroid(points);
         Tile centroidTile = device.getTile(centroid.y, centroid.x);
-    
+
         // We need to snap to the closest site with the site type of interest from the
         // centroid tile
         Site closest = null;
@@ -305,7 +305,7 @@ public class ECOPlacementHelper {
         for (SitePinInst i : net.getPins()) {
             points.add(new Point(i.getTile().getColumn(), i.getTile().getRow()));
         }
-        return ECOPlacementHelper.getCentroidOfPoints(net.getSource().getTile().getDevice(), points, targetSiteTypes);
+        return ECOPlacementHelper.getCentroidOfPoints(net.getDesign().getDevice(), points, targetSiteTypes);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -256,7 +256,7 @@ public class EDIFPort extends EDIFPropertyObject {
     public EDIFPortInst getInternalPortInst() {
         assert (!isBus());
         EDIFNet net = getInternalNet();
-        return net.getPortInst(null, getBusName());
+        return net == null ? null : net.getPortInst(null, getBusName());
     }
 
     /**

--- a/src/com/xilinx/rapidwright/util/PerformanceExplorer.java
+++ b/src/com/xilinx/rapidwright/util/PerformanceExplorer.java
@@ -395,7 +395,7 @@ public class PerformanceExplorer {
 
             String pblockDcpName = dcpName;
             if (ensureExternalRoutability()) {
-                InlineFlopTools.createAndPlaceFlopsInlineOnTopPorts(design, clkName, pblock);
+                InlineFlopTools.createAndPlaceFlopsInlineOnTopPortsArbitrarily(design, clkName, pblock);
                 pblockDcpName = runDirectory + File.separator + "pblock" + pb + "_" + INITIAL_DCP_NAME;
                 design.writeCheckpoint(pblockDcpName);
             }


### PR DESCRIPTION
- ArrayBuilder: Add support for writing possible placement locations or chosen placement locations to file, option to read manual placement from file, out-of-context option that adds flip-flops around array for top-level IO, and various bug-fixes and cleanups.
- InlineFlopTools: Add method to more smartly choose flip-flop placement and allow up to 5 flip-flops to be placed in a single slice.
- PerformanceExplorer: Added options to ensure external routability (using InlineFlopTools) and to automatically pick the best implementation.