### PR TITLE
[NetTools] Adds alternate pretty print for Nets/Clock Spine

### DIFF
--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -263,8 +263,8 @@ public class NetTools {
      * @param net The net to generate the tree of nodes from.
      * @return String representation of the net's routing tree with tree characters.
      */
-    public static String getNetNodeTree(Net net) { 
-        return getNetNodeTree(net, n -> false);
+    public static String getNetTreeString(Net net) { 
+        return getNetTreeString(net, n -> false);
     }
 
     /**
@@ -276,8 +276,8 @@ public class NetTools {
      *               be excluded.
      * @return String representation of the net's routing tree with tree characters.
      */
-    public static String getNetNodeTree(Net net, Function<Node, Boolean> filter) {
-        return getNetNodeTree(net, filter, n -> n.toString());
+    public static String getNetTreeString(Net net, Function<Node, Boolean> filter) {
+        return getNetTreeString(net, filter, n -> n.toString());
     }
 
     /**
@@ -291,7 +291,7 @@ public class NetTools {
      *                       when printed.
      * @return String representation of the net's routing tree with tree characters.
      */
-    public static String getNetNodeTree(Net net, Function<Node, Boolean> filter,
+    public static String getNetTreeString(Net net, Function<Node, Boolean> filter,
             Function<Node, String> customToString) {
         List<NodeTree> subtrees = getNodeTrees(net, filter);
         if (subtrees.isEmpty()) {
@@ -321,6 +321,6 @@ public class NetTools {
                 + " (" + n.getIntentCode() + ") CR="
                         + n.getTile().getClockRegion();
         Function<Node, Boolean> excludeFilter = n -> n.getIntentCode() == IntentCode.NODE_PINFEED;
-        return getNetNodeTree(net, excludeFilter, customToString);
+        return getNetTreeString(net, excludeFilter, customToString);
     }
 }


### PR DESCRIPTION
Adds some helpful debugging pretty print methods for nets, especially useful for printing clock spines:

```
Subtree 0:
CLK_REBUF_BUFGS_HSR_CORE_X0Y0/CLK_BUFGCE_63_O_PIN (NODE_GLOBAL_BUFG) CR=X0Y0
└─ CLK_REBUF_BUFGS_HSR_CORE_X0Y0/CLK_BUFGCE_63_O (NODE_GLOBAL_BUFG) CR=X0Y0
   └─ CLK_REBUF_BUFGS_HSR_CORE_X0Y0/CLK_CMT_MUX_16_ENC_23_CLK_OUT (NODE_GLOBAL_GCLK) CR=X0Y0
      └─ CLK_REBUF_BUFGS_HSR_CORE_X0Y0/CLK_HROUTE_1_23 (NODE_GLOBAL_HROUTE_HSR) CR=X0Y0
         └─ CLK_REBUF_BUFGS_HSR_CORE_1_X0Y0/CLK_HROUTE_1_23 (NODE_GLOBAL_HROUTE_HSR) CR=X1Y0
            └─ CLK_REBUF_BUFGS_HSR_CORE_X9Y0/CLK_HROUTE_1_23 (NODE_GLOBAL_HROUTE_HSR) CR=X2Y0
               └─ CLK_VERT_TO_HSR_VNOC_OCO_TILE_X25Y0/CLK_HROUTE23 (NODE_GLOBAL_HROUTE_HSR) CR=X1Y1
                  └─ CLK_REBUF_VERT_SSIT_HSR_CBO_TILE_X25Y87/IF_WRAP_CLK_V_BOT_CLK_VROUTE23 (NODE_GLOBAL_VROUTE) CR=X1Y1
                     └─ CLK_REBUF_VERT_SSIT_MB_BAO_TILE_X25Y183/IF_WRAP_CLK_V_BOT_CLK_VROUTE23 (NODE_GLOBAL_VROUTE) CR=X1Y2
                        └─ CLK_REBUF_VERT_SSIT_MT_ACO_TILE_X25Y279/IF_WRAP_CLK_V_BOT_CLK_VROUTE23 (NODE_GLOBAL_VROUTE) CR=X1Y3
                           └─ CLK_REBUF_VERT_SSIT_TOP_COO_TILE_X25Y327/IF_WRAP_CLK_V_BOT_CLK_VROUTE23 (NODE_GLOBAL_VROUTE) CR=X1Y4
                              └─ CLK_REBUF_VERT_SSIT_BOT_OCO_TILE_X25Y336/IF_WRAP_CLK_V_SLR_CLK_VROUTE23 (NODE_GLOBAL_VROUTE) CR=X1Y5
                                 └─ CLK_REBUF_VERT_SSIT_MB_CBO_TILE_X25Y423/IF_WRAP_CLK_V_BOT_CLK_VROUTE23 (NODE_GLOBAL_VROUTE) CR=X1Y5
                                    └─ CLK_REBUF_VERT_SSIT_MT_BAO_TILE_X25Y519/IF_WRAP_CLK_V_BOT_CLK_VROUTE23 (NODE_GLOBAL_VROUTE) CR=X1Y6
                                       └─ CLK_REBUF_VERT_SSIT_TOP_AOO_TILE_X25Y615/IF_WRAP_CLK_V_BOT_CLK_VROUTE23 (NODE_GLOBAL_VROUTE) CR=X1Y7
                                          ├─ CLK_REBUF_VERT_SSIT_TOP_AOO_TILE_X25Y615/CLK_CMT_MUX_3TO1_28_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y7
                                          │  └─ CLK_REBUF_VERT_SSIT_TOP_AOO_TILE_X25Y615/CLK_CMT_MUX_4TO1_110_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y7
                                          │     └─ CLK_REBUF_VERT_SSIT_BOT_OCO_TILE_X25Y624/IF_WRAP_CLK_V_SLR_CLK_VDISTR_SHARED23 (NODE_GLOBAL_VDISTR_SHARED) CR=X1Y8
                                          │        └─ CLK_REBUF_VERT_SSIT_BOT_OCO_TILE_X25Y624/CLK_CMT_MUX_4TO1_29_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y8
                                          │           └─ CLK_REBUF_VERT_SSIT_BOT_OCO_TILE_X25Y624/CLK_CMT_MUX_2TO1_14_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y8
                                          │              └─ CLK_REBUF_VERT_SSIT_MB_CBO_TILE_X25Y711/IF_WRAP_CLK_V_BOT_CLK_VDISTR23 (NODE_GLOBAL_VDISTR) CR=X1Y8
                                          │                 ├─ CLK_VNOC_PSS_SSIT_BOT_CCO_TILE_X25Y671/CLKE2_PD_OPT_DELAY_SSIT_132_I (NODE_GLOBAL_HDISTR) CR=X1Y8
                                          │                 └─ CLK_VNOC_PSS_SSIT_BOT_CCO_TILE_X25Y671/CLKE2_PD_OPT_DELAY_SSIT_156_I (NODE_GLOBAL_HDISTR) CR=X1Y8
                                          └─ CLK_REBUF_VERT_SSIT_TOP_AOO_TILE_X25Y615/CLK_CMT_MUX_4TO1_77_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y7
                                             └─ CLK_REBUF_VERT_SSIT_TOP_AOO_TILE_X25Y615/CLK_CMT_MUX_2TO1_38_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y7
                                                └─ CLK_REBUF_VERT_SSIT_TOP_AOO_TILE_X25Y615/IF_WRAP_CLK_V_BOT_CLK_VDISTR_LEV21_23 (NODE_GLOBAL_VDISTR_LVL21) CR=X1Y7
                                                   └─ CLK_REBUF_VERT_SSIT_MT_BAO_TILE_X25Y519/CLK_CMT_MUX_2TO1_57_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y6
                                                      └─ CLK_REBUF_VERT_SSIT_MT_BAO_TILE_X25Y519/CLK_CMT_MUX_4TO1_29_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y6
                                                         └─ CLK_REBUF_VERT_SSIT_MT_BAO_TILE_X25Y519/CLK_CMT_MUX_2TO1_59_CLK_OUT (NODE_GLOBAL_GCLK) CR=X1Y6
                                                            └─ CLK_REBUF_VERT_SSIT_TOP_AOO_TILE_X25Y615/IF_WRAP_CLK_V_BOT_CLK_VDISTR23 (NODE_GLOBAL_VDISTR) CR=X1Y7
                                                               ├─ RCLK_BRAM_CLKBUF_CORE_X8Y575/IF_HCLK_R_CLK_HDISTR23 (NODE_GLOBAL_HDISTR) CR=X0Y7
                                                               └─ CLK_VNOC_SSIT_TOP_AAO_TILE_X25Y575/CLKE2_PD_OPT_DELAY_SSIT_144_I (NODE_GLOBAL_HDISTR) CR=X1Y7
```
