### PR TITLE
[EDIFNetlist] Adds encrypted cells check flag and hasEncryptedCells()

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -991,9 +991,8 @@ public class DesignTools {
 
         postBlackBoxCleanup(hierarchicalCellName, design, keepBoundaryRouting);
 
-        List<String> encryptedCells = cell.getNetlist().getEncryptedCells();
-        if (encryptedCells != null && encryptedCells.size() > 0) {
-            design.getNetlist().addEncryptedCells(encryptedCells);
+        if (cell.getNetlist().hasEncryptedCells()) {
+            design.getNetlist().addEncryptedCells(cell.getNetlist().getEncryptedCells());
         }
     }
 

--- a/src/com/xilinx/rapidwright/design/merge/MergeDesigns.java
+++ b/src/com/xilinx/rapidwright/design/merge/MergeDesigns.java
@@ -108,9 +108,8 @@ public class MergeDesigns {
         }
 
         // Merge encrypted cells
-        List<String> encryptedCells = design1.getNetlist().getEncryptedCells();
-        if (encryptedCells != null && encryptedCells.size() > 0) {
-            design0.getNetlist().addEncryptedCells(encryptedCells);
+        if (design1.getNetlist().hasEncryptedCells()) {
+            design0.getNetlist().addEncryptedCells(design1.getNetlist().getEncryptedCells());
         }
 
         design0.getNetlist().removeUnusedCellsFromAllWorkLibraries();

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -24,6 +24,7 @@
 package com.xilinx.rapidwright.edif;
 
 import java.io.BufferedOutputStream;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -108,6 +109,8 @@ public class EDIFNetlist extends EDIFName {
     private String origDirectory;
 
     private List<String> encryptedCells;
+
+    private boolean encryptedCellsValidated = false;
 
     private boolean trackCellChanges = false;
 
@@ -2014,13 +2017,47 @@ public class EDIFNetlist extends EDIFName {
      * @return A list of EDN filenames that may populate encrypted cells within the netlist.
      */
     public List<String> getEncryptedCells() {
-        return encryptedCells != null ? encryptedCells : Collections.emptyList();
+        if (encryptedCells != null) {
+            if (!encryptedCellsValidated) {
+                validateEncryptedCells();
+            }
+            return encryptedCells;
+        }
+        return Collections.emptyList();
+    }
+    
+    /**
+     * Checks if this design has encrypted cells.
+     * 
+     * @return If this design has at least one encrypted cell in it, false if none.
+     */
+    public boolean hasEncryptedCells() { 
+       return getEncryptedCells().size() > 0; 
+    }
+
+    private void validateEncryptedCells() {
+        // Verify that at least one of the edn files collected are actually in the design
+        for (String edn : encryptedCells) {
+            int start = edn.lastIndexOf(File.separator);
+            int end = edn.lastIndexOf(".edn");
+            String cellName = edn.substring(start == -1 ? 0 : start + 1, end);
+            EDIFCell cell = getCell(cellName);
+            if (cell != null && cell.isLeafCellOrBlackBox()) {
+                encryptedCellsValidated = true;
+                return;
+            }
+        }
+        // The EDN files in encryptedCells are unrelated to this design, let's remove them.
+        encryptedCells.clear();
+        encryptedCellsValidated = true;
     }
 
     public void setEncryptedCells(List<String> encryptedCells) {
         if (encryptedCells == null || encryptedCells.isEmpty()) {
+            encryptedCellsValidated = true;
             this.encryptedCells = null;
         } else {
+            encryptedCellsValidated = false;
             this.encryptedCells = encryptedCells;
         }
     }
@@ -2033,6 +2070,7 @@ public class EDIFNetlist extends EDIFName {
             setEncryptedCells(encryptedCells);
             return;
         }
+        encryptedCellsValidated = false;
         this.encryptedCells.addAll(encryptedCells);
     }
 
@@ -2044,7 +2082,6 @@ public class EDIFNetlist extends EDIFName {
      * @param tclPath Path to the existing Tcl load script for the accompanying DCP file
      */
     public void addTclLoadEncryptedCells(Path tclPath) {
-
         List<String> encryptedCells = new ArrayList<>();
         for (String line : FileTools.getLinesFromTextFile(tclPath.toFile().getAbsolutePath())) {
             if (line.startsWith(READ_EDIF_CMD) && line.endsWith(".edn")) {

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -1097,24 +1097,8 @@ public class EDIFTools {
         try {
             ensureCorrectPartInEDIF(edif, partName);
             edif.exportEDIF(out);
-            if (dcpFileName != null && edif.getEncryptedCells() != null) {
-                if (edif.getEncryptedCells().size() > 0) {
-                    // Verify that at least one of the edn files collected are actually in the design
-                    boolean verifiedEncryptedCell = false;
-                    for (String edn : edif.getEncryptedCells()) {
-                        int start = edn.lastIndexOf(File.separator);
-                        int end = edn.lastIndexOf(".edn");
-                        String cellName = edn.substring(start == -1 ? 0 : start + 1, end);
-                        EDIFCell cell = edif.getCell(cellName);
-                        if (cell != null && cell.isLeafCellOrBlackBox()) {
-                            verifiedEncryptedCell = true;
-                            break;
-                        }
-                    }
-                    if (verifiedEncryptedCell) {
-                        writeTclLoadScriptForPartialEncryptedDesigns(edif, dcpFileName, partName);
-                    }
-                }
+            if (dcpFileName != null && edif.hasEncryptedCells()) {
+                writeTclLoadScriptForPartialEncryptedDesigns(edif, dcpFileName, partName);
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/com/xilinx/rapidwright/util/VivadoTools.java
+++ b/src/com/xilinx/rapidwright/util/VivadoTools.java
@@ -135,8 +135,8 @@ public class VivadoTools {
      */
     public static ReportRouteStatusResult reportRouteStatus(Design design) {
         final Path dcp = writeCheckpoint(design);
-        boolean encrypted = !design.getNetlist().getEncryptedCells().isEmpty();
-        ReportRouteStatusResult rrs = reportRouteStatus(dcp, dcp.getParent(), encrypted);
+        boolean hasEncryptedCells = design.getNetlist().hasEncryptedCells();
+        ReportRouteStatusResult rrs = reportRouteStatus(dcp, dcp.getParent(), hasEncryptedCells);
 
         FileTools.deleteFolder(dcp.getParent().toString());
 
@@ -153,8 +153,8 @@ public class VivadoTools {
     public static String reportRouteStatus(Design design, String netName) {
         final Path dcp = writeCheckpoint(design);
         try {
-            boolean encrypted = !design.getNetlist().getEncryptedCells().isEmpty();
-            return reportRouteStatus(netName, dcp, dcp.getParent(), encrypted);
+            boolean hasEncryptedCells = design.getNetlist().hasEncryptedCells();
+            return reportRouteStatus(netName, dcp, dcp.getParent(), hasEncryptedCells);
         } finally {
             FileTools.deleteFolder(dcp.getParent().toString());
         }
@@ -382,10 +382,10 @@ public class VivadoTools {
      * @return The results of `report_route_status`.
      */
     public static ReportRouteStatusResult routeDesignAndGetStatus(Design design, Path workdir) {
-        boolean encrypted = !design.getNetlist().getEncryptedCells().isEmpty();
+        boolean hasEncryptedCells = design.getNetlist().hasEncryptedCells();
         Path dcp = workdir.resolve("routeDesignAndGetStatus.dcp");
         design.writeCheckpoint(dcp);
-        return routeDesignAndGetStatus(dcp, workdir, encrypted);
+        return routeDesignAndGetStatus(dcp, workdir, hasEncryptedCells);
     }
 
     /**
@@ -398,10 +398,10 @@ public class VivadoTools {
      * @return The results of `report_route_status`.
      */
     public static ReportRouteStatusResult placeAndRouteDesignAndGetStatus(Design design, Path workdir) {
-        boolean encrypted = !design.getNetlist().getEncryptedCells().isEmpty();
+        boolean hasEncryptedCells = design.getNetlist().hasEncryptedCells();
         Path dcp = workdir.resolve("placeAndRouteDesignAndGetStatus.dcp");
         design.writeCheckpoint(dcp);
-        return placeAndRouteDesignAndGetStatus(dcp, workdir, encrypted);
+        return placeAndRouteDesignAndGetStatus(dcp, workdir, hasEncryptedCells);
     }
 
     /**
@@ -505,10 +505,10 @@ public class VivadoTools {
      * @return True if the port exists in Vivado, false otherwise.
      */
     public static Design roundTripDCPThruVivado(Design design, Path workdir) {
-        boolean encrypted = !design.getNetlist().getEncryptedCells().isEmpty();
+        boolean hasEncryptedCells = design.getNetlist().hasEncryptedCells();
         Path dcp = workdir.resolve("roundTrip.dcp");
         design.writeCheckpoint(dcp);
-        Path outputDcp = roundTripDCPThruVivado(dcp, "output", workdir, encrypted);
+        Path outputDcp = roundTripDCPThruVivado(dcp, "output", workdir, hasEncryptedCells);
         return Design.readCheckpoint(outputDcp);
     }
 }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFTools.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFTools.java
@@ -24,6 +24,7 @@
 
 package com.xilinx.rapidwright.edif;
 
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -467,8 +468,11 @@ public class TestEDIFTools {
         Assertions.assertFalse(testPort2.getName().startsWith(EDIFTools.VIVADO_PRESERVE_PORT_INTERFACE));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void testWriteEDIFFilterUnrelatedEDNFiles(@TempDir Path dir) {
+    public void testWriteEDIFFilterUnrelatedEDNFiles(@TempDir Path dir)
+            throws NoSuchFieldException, SecurityException, IllegalArgumentException,
+            IllegalAccessException {
         String name = "picoblaze_ooc_X10Y235.dcp";
         Path dcp = dir.resolve(name);
         Path edf = dir.resolve(name.replace(".dcp", ".edf"));
@@ -485,7 +489,11 @@ public class TestEDIFTools {
         // .edn file, keeping a record of possible encrypted cells as it goes.  
         d = Design.readCheckpoint(dcp, edf);
 
-        Assertions.assertEquals(1, d.getNetlist().getEncryptedCells().size());
+        {
+            Field encCellsList = EDIFNetlist.class.getDeclaredField("encryptedCells");
+            encCellsList.setAccessible(true);
+            Assertions.assertEquals(1, ((List<String>) encCellsList.get(d.getNetlist())).size());
+        }
 
         String outputName = "test";
         Path loadScript = dir.resolve(outputName + EDIFTools.LOAD_TCL_SUFFIX);


### PR DESCRIPTION
Previous to this PR, when calling `EDIFNetlist.getEncryptedCells()`, the method would potentially return a list of `.edn` files that were not necessarily used in the design.  This PR has a check flag that indicates if the encrypted cells stored in `EDIFNetlist.encryptedCells` have been validated or not.  The ensures that if the user calls `EDIFNetlist.hasEncryptedCells()` or `EDIFNetlist.getEncryptedCels()`, the returned results will always have been validated.