### PR TITLE
[VersalClockRouting] Mark sink pins as routed once LCBs are connected

### DIFF
--- a/src/com/xilinx/rapidwright/router/VersalClockRouting.java
+++ b/src/com/xilinx/rapidwright/router/VersalClockRouting.java
@@ -409,7 +409,8 @@ public class VersalClockRouting {
      * @param distLines A map of target clock regions and their respective horizontal distribution lines
      * @param lcbTargets The target LCB nodes to route the clock
      */
-    public static void routeDistributionToLCBs(Net clk, Map<ClockRegion, Node> distLines, Set<Node> lcbTargets, Function<Node, NodeStatus> getNodeStatus) {
+    public static void routeDistributionToLCBs(Net clk, Map<ClockRegion, Node> distLines,
+            Map<Node, List<SitePinInst>> lcbTargets, Function<Node, NodeStatus> getNodeStatus) {
         Map<ClockRegion, Set<NodeWithPrevAndCost>> startingPoints = getStartingPoints(distLines);
         routeToLCBs(clk, startingPoints, lcbTargets, getNodeStatus);
     }
@@ -425,12 +426,14 @@ public class VersalClockRouting {
         return startingPoints;
     }
 
-    public static void routeToLCBs(Net clk, Map<ClockRegion, Set<NodeWithPrevAndCost>> startingPoints, Set<Node> lcbTargets, Function<Node, NodeStatus> getNodeStatus) {
+    public static void routeToLCBs(Net clk, Map<ClockRegion, Set<NodeWithPrevAndCost>> startingPoints,
+            Map<Node, List<SitePinInst>> lcbTargets, Function<Node, NodeStatus> getNodeStatus) {
         Queue<NodeWithPrevAndCost> q = new PriorityQueue<>();
         Set<PIP> allPIPs = new HashSet<>();
         Set<Node> visited = new HashSet<>();
 
-        nextLCB: for (Node lcb : lcbTargets) {
+        nextLCB: for (Entry<Node, List<SitePinInst>> e : lcbTargets.entrySet()) {
+            Node lcb = e.getKey();
             q.clear();
             visited.clear();
             Tile lcbTile = lcb.getTile();
@@ -453,6 +456,10 @@ public class VersalClockRouting {
                     Set<NodeWithPrevAndCost> s = startingPoints.get(currCR);
                     for (Node n : path) {
                         s.add(new NodeWithPrevAndCost(n));
+                    }
+
+                    for (SitePinInst sink : e.getValue()) {
+                        sink.setRouted(true);
                     }
 
                     continue nextLCB;

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -338,7 +338,7 @@ public class GlobalSignalRouting {
         VersalClockRouting.routeNonLCBPins(clk, usedCRsAndNonLCBPinsTuple.getSecond(), getNodeStatus);
 
         Map<Node, List<SitePinInst>> lcbMappings = VersalClockRouting.routeLCBsToSinks(clk, getNodeStatus);
-        VersalClockRouting.routeDistributionToLCBs(clk, upDownDistLines, lcbMappings.keySet(), getNodeStatus);
+        VersalClockRouting.routeDistributionToLCBs(clk, upDownDistLines, lcbMappings, getNodeStatus);
 
         // Populate used routing track for any other clocks being routed
         if (usedRoutingTracks != null) {


### PR DESCRIPTION
When routing a clock, we route the net in phases.  The sinks are actually connected first to their respective leaf clock buffers (LCBs) and then the LCBs are connected to the horizontal distribution lines. The `isRouted()` flag is not being set on regular clock sinks so this PR addresses this issue by marking them accordingly after the batch of `SitePinInst` objects for each LCB are routed.  