### PR TITLE
Partitioner Feature Additions: Mapping generation, net-span partition report, LUTs/partition report, verbose hypergraph reports, LUTCount CLI, mapping constraint partition input

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -116,7 +116,9 @@ import com.xilinx.rapidwright.util.ReplaceEDIFInDCP;
 import com.xilinx.rapidwright.util.ReportRouteStatus;
 import com.xilinx.rapidwright.util.StringTools;
 import com.xilinx.rapidwright.util.Unzip;
+import com.xilinx.rapidwright.util.LUTCount;
 import com.xilinx.rapidwright.util.performance_evaluation.PerformanceEvaluation;
+import com.xilinx.rapidwright.debug.memory.audit.ReadNetlist;
 
 public class MainEntrypoint {
     interface MainStyleFunction<E extends Throwable> {
@@ -221,6 +223,8 @@ public class MainEntrypoint {
         addFunction("TileColumnPattern", TileColumnPattern::main);
         addFunction("Unzip", Unzip::main);
         addFunction("UpdateRoutingUsingSATRouter", UpdateRoutingUsingSATRouter::main);
+        addFunction("ReadNetlist", ReadNetlist::main);
+        addFunction("LUTCount", LUTCount::main);
     }
 
     private static void listModes(PrintStream ps) {

--- a/src/com/xilinx/rapidwright/debug/memory/audit/ReadNetlist.java
+++ b/src/com/xilinx/rapidwright/debug/memory/audit/ReadNetlist.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.debug.memory.audit;
+
+import java.io.File;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.edif.EDIFTools;
+
+/**
+ * Memory audit utility for reading netlists.
+ */
+public class ReadNetlist {
+
+    /**
+     * Prints memory usage.
+     *
+     * @param label The label for this audit point.
+     */
+    private static void memAudit(String label) {
+        Runtime rt = Runtime.getRuntime();
+        long total = rt.totalMemory();
+        long free = rt.freeMemory();
+        long used = total - free;
+        System.out.printf("PARTITIONER DEBUG: %s -> used=%d MB total=%d MB free=%d MB%n",
+                label, used / (1024 * 1024), total / (1024 * 1024), free / (1024 * 1024));
+    }
+
+    /**
+     * Main entry point.
+     *
+     * @param args Command line arguments.
+     */
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.err.println("Usage: ReadNetlist <netlist.[edf|dcp]>");
+            return;
+        }
+
+        File input = new File(args[0]);
+        if (!input.exists()) {
+            System.err.printf("ERROR: File not found: %s%n", args[0]);
+            return;
+        }
+
+        memAudit("readnetlist mem usg before read");
+        System.out.println("Reading netlist....");
+        Design design = null;
+        if (args[0].endsWith(".dcp")) {
+            design = Design.readCheckpoint(args[0]);
+        } else {
+            design = new Design(EDIFTools.readEdifFile(args[0]));
+        }
+        memAudit("readnetlist mem usg after read");
+
+        // kept reference to prevent GC until after waiting
+        if (design == null) {
+            System.err.println("ERROR: Failed to load design.");
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/partition/CellsWriter.java
+++ b/src/com/xilinx/rapidwright/edif/partition/CellsWriter.java
@@ -1,0 +1,139 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.partition;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Writes cells.txt (one partition name per line) into the output directory.
+ *
+ * Simply displays the name of the partitions ex:
+ *   Line 1: FPGA_A
+ *   Line 2: FPGA_B
+ *   Line 3: FPGA_C
+ *   Line 4: FPGA_D
+ */
+public final class CellsWriter {
+
+    private CellsWriter() {
+        // no instances.
+    }
+
+    /**
+     * Writes cells.txt using the provided list of names (one per line, in order).
+     *
+     * @param outputDirectory The output directory.
+     * @param partitionNames The list of partition names.
+     */
+    public static void write(Path outputDirectory, List<String> partitionNames) {
+        if (partitionNames == null) {
+            throw new IllegalArgumentException("partitionNames is null");
+        }
+        try {
+            if (outputDirectory != null) {
+                Files.createDirectories(outputDirectory);
+            }
+            Path cellsFilePath = outputDirectory.resolve("cells.txt");
+            Files.write(cellsFilePath, partitionNames, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Writes cells.txt for a given number of partitions, generating names using partitionlabel.
+     *
+     * @param outputDirectory The output directory.
+     * @param numPartitions The number of partitions.
+     */
+    public static void write(Path outputDirectory, int numPartitions) {
+        write(outputDirectory, generateNames(numPartitions));
+    }
+
+    /**
+     * Writes cells.txt from an index->name map and fills any missing indices with generated labels.
+     *
+     * @param outputDirectory The output directory.
+     * @param indexToName A map of partition indices to names.
+     */
+    public static void write(Path outputDirectory, Map<Integer, String> indexToName) {
+        if (indexToName == null || indexToName.isEmpty()) {
+            write(outputDirectory, Collections.emptyList());
+            return;
+        }
+        int maxIdx = -1;
+        for (Integer idx : indexToName.keySet()) {
+            if (idx != null && idx > maxIdx) {
+                maxIdx = idx;
+            }
+        }
+        if (maxIdx < 0) {
+            write(outputDirectory, Collections.emptyList());
+            return;
+        }
+        List<String> partitionNames = new ArrayList<>(maxIdx + 1);
+        for (int i = 0; i <= maxIdx; i++) {
+            String name = indexToName.get(i);
+            if (name == null || name.trim().isEmpty()) {
+                name = generateName(i);
+            }
+            partitionNames.add(name);
+        }
+        write(outputDirectory, partitionNames);
+    }
+
+    /**
+     * Generates a list of canonical partition names ["fpga_a","fpga_b",...] using partitionlabel.
+     *
+     * @param partitionCount The number of partitions.
+     * @return A list of generated partition names.
+     */
+    public static List<String> generateNames(int partitionCount) {
+        if (partitionCount <= 0) {
+            return Collections.emptyList();
+        }
+        List<String> partitionNames = new ArrayList<>(partitionCount);
+        for (int i = 0; i < partitionCount; i++) {
+            partitionNames.add(PartitionLabel.indexToFpgaLabel(i));
+        }
+        return partitionNames;
+    }
+
+    /**
+     * Generates a single canonical partition name "fpga_*" via partitionlabel.
+     *
+     * @param partitionIndex The partition index.
+     * @return The generated partition name.
+     */
+    public static String generateName(int partitionIndex) {
+        return PartitionLabel.indexToFpgaLabel(partitionIndex);
+    }
+
+}

--- a/src/com/xilinx/rapidwright/edif/partition/FpgaIoCutAnalyzer.java
+++ b/src/com/xilinx/rapidwright/edif/partition/FpgaIoCutAnalyzer.java
@@ -1,0 +1,475 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.partition;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFDirection;
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFHierNet;
+import com.xilinx.rapidwright.edif.EDIFHierPortInst;
+import com.xilinx.rapidwright.edif.EDIFNet;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
+
+/**
+ * Analyzes FPGA-level IO cuts with direction awareness.
+ * 
+ * Unlike the topology-unaware PartitionPairCounter which counts nets touching
+ * multiple partitions in the coarsened hypergraph, this analyzer:
+ * 
+ * 1. Identifies signal DIRECTION (driver vs load) using EDIF port directions
+ * 2. Counts signals at the FPGA partition boundary level
+ * 3. Reports directional flow: FPGA_A -> FPGA_B vs FPGA_B -> FPGA_A
+ * 4. Filters out constant nets (VCC, GND, const0, const1)
+ * 5. Separately categorizes global signals (clock, reset)
+ */
+public final class FpgaIoCutAnalyzer {
+
+    private FpgaIoCutAnalyzer() {
+        // No instances
+    }
+
+    /**
+     * Result container for FPGA IO cut analysis.
+     */
+    public static class FpgaIoCutResult {
+        /** Directional cut counts: key = "FPGA_A->FPGA_B", value = count */
+        public final Map<String, Integer> directionalCuts = new LinkedHashMap<>();
+        
+        /** Nets identified as clock signals crossing partitions */
+        public final List<String> clockNets = new ArrayList<>();
+        
+        /** Nets identified as reset signals crossing partitions */
+        public final List<String> resetNets = new ArrayList<>();
+        
+        /** Constant nets that were filtered out */
+        public final List<String> filteredConstantNets = new ArrayList<>();
+        
+        /** Total data signals (excluding clock/reset/constants) */
+        public int totalDataSignals = 0;
+        
+        /** Debug: nets that couldn't be fully analyzed */
+        public final List<String> unanalyzedNets = new ArrayList<>();
+    }
+
+    /**
+     * Analyzes the netlist for FPGA-level IO cuts with direction awareness.
+     * 
+     * @param netlist The EDIF netlist to analyze
+     * @param leafInsts Map of coarsened leaf instances to their vertex indices
+     * @param nameToPart Map from instance name to partition index
+     * @return Analysis result with directional cuts and categorized signals
+     */
+    public static FpgaIoCutResult analyze(
+            EDIFNetlist netlist,
+            Map<EDIFHierCellInst, Integer> leafInsts,
+            Map<String, Integer> nameToPart) {
+        
+        FpgaIoCutResult result = new FpgaIoCutResult();
+        
+        // Build reverse lookup: instance name -> partition label
+        Map<String, String> instToFpgaLabel = new HashMap<>();
+        for (Map.Entry<String, Integer> entry : nameToPart.entrySet()) {
+            String instName = entry.getKey();
+            int partIdx = entry.getValue();
+            String fpgaLabel = PartitionLabel.indexToFpgaLabel(partIdx);
+            instToFpgaLabel.put(instName, fpgaLabel);
+        }
+        
+        System.out.println("DEBUG: FpgaIoCutAnalyzer start");
+        System.out.println("DEBUG: instToFpgaLabel size: " + instToFpgaLabel.size());
+        if (!instToFpgaLabel.isEmpty()) {
+            System.out.println("DEBUG: Sample mapping: " + instToFpgaLabel.entrySet().iterator().next());
+        }
+        
+        // Track processed nets to avoid duplicates
+        Set<String> processedNets = new HashSet<>();
+        
+        // Iterate through all leaf instances and their connected nets
+        int netsProcessed = 0;
+        for (EDIFHierCellInst leafInst : leafInsts.keySet()) {
+            for (EDIFHierPortInst portInst : leafInst.getHierPortInsts()) {
+                EDIFHierNet hierNet = portInst.getHierarchicalNet();
+                if (hierNet == null) continue;
+                
+                // Get canonical net name to avoid processing same net multiple times
+                String netName = hierNet.getHierarchicalNetName();
+                if (netName == null) {
+                    netName = hierNet.toString();
+                }
+                if (processedNets.contains(netName)) continue;
+                processedNets.add(netName);
+                netsProcessed++;
+                
+                EDIFNet net = hierNet.getNet();
+                if (net != null && (net.isVCC() || net.isGND())) {
+                    result.filteredConstantNets.add(netName);
+                    continue;
+                }
+                
+                // Analyze this net for cross-partition signals
+                analyzeNetForCrossings(hierNet, leafInsts, instToFpgaLabel, result, netName);
+            }
+        }
+        System.out.println("DEBUG: Nets processed: " + netsProcessed);
+        
+        return result;
+    }
+
+    // Debug counter for first few nets
+    private static int debugNetCount = 0;
+    private static final int DEBUG_NET_LIMIT = 5;
+    
+    /**
+     * Analyzes a single net for FPGA boundary crossings.
+     */
+    private static void analyzeNetForCrossings(
+            EDIFHierNet hierNet,
+            Map<EDIFHierCellInst, Integer> leafInsts,
+            Map<String, String> instToFpgaLabel,
+            FpgaIoCutResult result,
+            String netName) {
+        
+        boolean debugThis = (debugNetCount < DEBUG_NET_LIMIT);
+        
+        // Find all port instances on this net
+        Collection<EDIFHierPortInst> allPortInsts = hierNet.getPortInsts();
+        if (allPortInsts == null || allPortInsts.isEmpty()) {
+            if (debugThis) {
+                System.out.println("DEBUG NET [" + netName + "]: No port instances found");
+                debugNetCount++;
+            }
+            return;
+        }
+        
+        if (debugThis) {
+            System.out.println("DEBUG NET [" + netName + "]: Found " + allPortInsts.size() + " port instances");
+        }
+        
+        // Separate drivers from loads
+        List<PartitionedPort> drivers = new ArrayList<>();
+        List<PartitionedPort> loads = new ArrayList<>();
+        int nullPiCount = 0;
+        int nullParentCount = 0;
+        int nullFpgaLabelCount = 0;
+        
+        for (EDIFHierPortInst portInst : allPortInsts) {
+            // Get direction from the underlying port instance
+            EDIFPortInst pi = portInst.getPortInst();
+            if (pi == null) {
+                nullPiCount++;
+                continue;
+            }
+            EDIFDirection direction = pi.getDirection();
+            
+            // Get the actual cell instance that owns this port (not the hierarchical context)
+            EDIFCellInst cellInst = pi.getCellInst();
+            if (cellInst == null) {
+                // This is a top-level port (e.g., clk, reset input to the design)
+                nullParentCount++;
+                continue;
+            }
+            
+            // Get the cell instance name - this is what we need to match against the partition map
+            String cellInstName = cellInst.getName();
+            
+            // Also try to construct full hierarchical path
+            EDIFHierCellInst hierContext = portInst.getHierarchicalInst();
+            String fullHierPath = "";
+            if (hierContext != null && hierContext.toString() != null && !hierContext.toString().isEmpty()) {
+                fullHierPath = hierContext.toString() + "/" + cellInstName;
+            } else {
+                fullHierPath = cellInstName;
+            }
+            
+            // Find which partition this instance belongs to using cell instance name
+            String fpgaLabel = resolveInstanceByName(cellInstName, fullHierPath, instToFpgaLabel);
+            if (fpgaLabel == null) {
+                nullFpgaLabelCount++;
+                if (debugThis && nullFpgaLabelCount <= 3) {
+                    System.out.println("DEBUG NET [" + netName + "]: Could not resolve - cellInstName=[" + 
+                        cellInstName + "] fullHierPath=[" + fullHierPath + "]");
+                }
+                continue;
+            }
+            
+            PartitionedPort pp = new PartitionedPort(portInst, fpgaLabel);
+            
+            if (direction == EDIFDirection.OUTPUT) {
+                drivers.add(pp);
+            } else if (direction == EDIFDirection.INPUT) {
+                loads.add(pp);
+            } else if (direction == EDIFDirection.INOUT) {
+                // INOUT pins can be both driver and load
+                drivers.add(pp);
+                loads.add(pp);
+            }
+        }
+        
+        if (debugThis) {
+            System.out.println("DEBUG NET [" + netName + "]: drivers=" + drivers.size() + 
+                " loads=" + loads.size() + " nullPi=" + nullPiCount + 
+                " nullParent=" + nullParentCount + " nullFpgaLabel=" + nullFpgaLabelCount);
+            debugNetCount++;
+        }
+        
+        // If no drivers or no loads, no crossing possible
+        if (drivers.isEmpty() || loads.isEmpty()) {
+            return;
+        }
+        
+        // Check for clock/reset patterns
+        boolean isClockNet = isClockSignal(netName);
+        boolean isResetNet = isResetSignal(netName);
+        
+        // For each driver, check if any loads are in different partitions
+        Set<String> crossingsForThisNet = new HashSet<>();
+        
+        for (PartitionedPort driver : drivers) {
+            for (PartitionedPort load : loads) {
+                if (!driver.fpgaLabel.equals(load.fpgaLabel)) {
+                    // This is a cross-partition signal!
+                    String crossingKey = driver.fpgaLabel + "->" + load.fpgaLabel;
+                    crossingsForThisNet.add(crossingKey);
+                }
+            }
+        }
+        
+        // Record the crossings
+        if (!crossingsForThisNet.isEmpty()) {
+            if (isClockNet) {
+                result.clockNets.add(netName);
+            } else if (isResetNet) {
+                result.resetNets.add(netName);
+            } else {
+                result.totalDataSignals++;
+                for (String crossing : crossingsForThisNet) {
+                    result.directionalCuts.put(crossing, 
+                        result.directionalCuts.getOrDefault(crossing, 0) + 1);
+                }
+            }
+        }
+    }
+
+    /**
+     * Resolves an instance to its FPGA partition label using name matching.
+     * Tries simple name first, then full hierarchical path, then partial matches.
+     * 
+     * @param simpleName The simple cell instance name (e.g., "result_reg[16]")
+     * @param fullHierPath The full hierarchical path (e.g., "hw_top/result_reg[16]")
+     * @param instToFpgaLabel Map from instance name to FPGA label
+     * @return The FPGA label, or null if not found
+     */
+    private static String resolveInstanceByName(
+            String simpleName,
+            String fullHierPath,
+            Map<String, String> instToFpgaLabel) {
+        
+        // Try simple name first (this is what instLookup uses)
+        if (simpleName != null && instToFpgaLabel.containsKey(simpleName)) {
+            return instToFpgaLabel.get(simpleName);
+        }
+        
+        // Try full hierarchical path
+        if (fullHierPath != null && !fullHierPath.isEmpty() && instToFpgaLabel.containsKey(fullHierPath)) {
+            return instToFpgaLabel.get(fullHierPath);
+        }
+        
+        // Try partial path matching - check if this instance is a child of a mapped instance
+        if (fullHierPath != null && !fullHierPath.isEmpty()) {
+            for (Map.Entry<String, String> entry : instToFpgaLabel.entrySet()) {
+                String mappedPath = entry.getKey();
+                // Check if fullHierPath starts with mappedPath (instance is child of mapped)
+                if (fullHierPath.startsWith(mappedPath + "/") || fullHierPath.equals(mappedPath)) {
+                    return entry.getValue();
+                }
+                // Check if mappedPath starts with fullHierPath (mapped is child of this instance)
+                if (mappedPath.startsWith(fullHierPath + "/")) {
+                    return entry.getValue();
+                }
+            }
+        }
+        
+        // Try matching with just the last component of the path
+        if (fullHierPath != null && fullHierPath.contains("/")) {
+            String[] parts = fullHierPath.split("/");
+            for (int i = parts.length - 1; i >= 0; i--) {
+                String partialPath = String.join("/", java.util.Arrays.copyOfRange(parts, i, parts.length));
+                if (instToFpgaLabel.containsKey(partialPath)) {
+                    return instToFpgaLabel.get(partialPath);
+                }
+                // Also check if any mapped path contains this partial path
+                for (Map.Entry<String, String> entry : instToFpgaLabel.entrySet()) {
+                    String mappedPath = entry.getKey();
+                    if (mappedPath.endsWith("/" + partialPath) || mappedPath.equals(partialPath)) {
+                        return entry.getValue();
+                    }
+                }
+            }
+        }
+        
+        return null;
+    }
+
+    /**
+     * Checks if a net name appears to be a clock signal.
+     * 
+     * TODO: Better source of truth? EDIF net domain?
+     */
+    private static boolean isClockSignal(String netName) {
+        if (netName == null) return false;
+        String lower = netName.toLowerCase();
+        // Common clock naming patterns
+        return lower.equals("clk") || 
+               lower.equals("clock") ||
+               lower.endsWith("/clk") ||
+               lower.endsWith("/clock") ||
+               lower.contains("_clk") ||
+               lower.contains("clk_");
+    }
+
+    /**
+     * Checks if a net name appears to be a reset signal.
+     * 
+     * TODO: Better source of truth? EDIF net domain?
+     */
+    private static boolean isResetSignal(String netName) {
+        if (netName == null) return false;
+        String lower = netName.toLowerCase();
+        // Common reset naming patterns
+        return lower.equals("reset") || 
+               lower.equals("rst") ||
+               lower.equals("resetn") ||
+               lower.equals("rst_n") ||
+               lower.endsWith("/reset") ||
+               lower.endsWith("/rst") ||
+               lower.contains("_reset") ||
+               lower.contains("_rst");
+    }
+
+    /**
+     * Writes the FPGA IO cut analysis to a file.
+     * 
+     * @param outputDir Output directory
+     * @param result Analysis result to write
+     */
+    public static void writeReport(Path outputDir, FpgaIoCutResult result) {
+        Path outputFile = outputDir.resolve("fpga_io_cuts.txt");
+        
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile.toFile()))) {
+            writer.write("=== FPGA IO Cut Report (Direction-Aware) ===\n");
+            writer.write("\n");
+            
+            // Directional data signal counts
+            writer.write("--- Data Signals by Direction ---\n");
+            if (result.directionalCuts.isEmpty()) {
+                writer.write("  No data signal crossings detected.\n");
+            } else {
+                // Sort entries for consistent output
+                List<Map.Entry<String, Integer>> sorted = new ArrayList<>(result.directionalCuts.entrySet());
+                sorted.sort((a, b) -> a.getKey().compareTo(b.getKey()));
+                
+                for (Map.Entry<String, Integer> entry : sorted) {
+                    writer.write(String.format("  %s: %d signal(s)\n", 
+                        entry.getKey(), entry.getValue()));
+                }
+            }
+            writer.write("\n");
+            
+            // Summary
+            writer.write("--- Summary ---\n");
+            writer.write(String.format("  Total data signals crossing FPGA boundaries: %d\n", 
+                result.totalDataSignals));
+            writer.write(String.format("  Clock nets crossing: %d\n", result.clockNets.size()));
+            writer.write(String.format("  Reset nets crossing: %d\n", result.resetNets.size()));
+            writer.write(String.format("  Constant nets filtered: %d\n", 
+                result.filteredConstantNets.size()));
+            writer.write("\n");
+            
+            // Clock net details
+            if (!result.clockNets.isEmpty()) {
+                writer.write("--- Clock Nets ---\n");
+                for (String clkNet : result.clockNets) {
+                    writer.write(String.format("  %s\n", clkNet));
+                }
+                writer.write("\n");
+            }
+            
+            // Reset net details
+            if (!result.resetNets.isEmpty()) {
+                writer.write("--- Reset Nets ---\n");
+                for (String rstNet : result.resetNets) {
+                    writer.write(String.format("  %s\n", rstNet));
+                }
+                writer.write("\n");
+            }
+            
+            // Filtered constants (for debugging)
+            if (!result.filteredConstantNets.isEmpty()) {
+                writer.write("--- Filtered Constant Nets ---\n");
+                int maxToShow = Math.min(10, result.filteredConstantNets.size());
+                for (int i = 0; i < maxToShow; i++) {
+                    writer.write(String.format("  %s\n", result.filteredConstantNets.get(i)));
+                }
+                if (result.filteredConstantNets.size() > maxToShow) {
+                    writer.write(String.format("  ... and %d more\n", 
+                        result.filteredConstantNets.size() - maxToShow));
+                }
+                writer.write("\n");
+            }
+            
+            PartitionTools.logPartitionerDebug(null, 
+                "Partitioner artifact written: %s", outputFile.toString());
+            
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Helper class to associate a port instance with its FPGA partition.
+     */
+    private static class PartitionedPort {
+        final EDIFHierPortInst portInst;
+        final String fpgaLabel;
+        
+        PartitionedPort(EDIFHierPortInst portInst, String fpgaLabel) {
+            this.portInst = portInst;
+            this.fpgaLabel = fpgaLabel;
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/partition/HierMappingWriter.java
+++ b/src/com/xilinx/rapidwright/edif/partition/HierMappingWriter.java
@@ -1,0 +1,746 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.partition;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.util.FileTools;
+
+/**
+ * Generates mapping.txt containing a hierarchy aware 
+ * mapping of instances to partitions post-MtKaHyPar partitioning.
+ *
+ * Example,
+ * If fft_top/stage_16 is wholly contained into partition 1 'FPGA_B' 
+ * then only one line should be written which references stage_16, "fft_top/stage_16 FPGA_B"
+ * 
+ * If stage_16 is not wholly contained we go one level deeper until wholly contained 
+ * or we reach leaf instances.
+ * "fft_top/stage_16/butterfly_0 FPGA_A"
+ * "fft_top/stage_16/butterfly_1 FPGA_B"
+ */
+public final class HierMappingWriter {
+
+    /**
+     * Trie node representing a hierarchical instance path segment.
+     *
+     * - name: the segment at this level (for example, "stage_16").
+     * - children: sub-segments under this node.
+     * - leafCounts: one count per partition per explicit path)
+     * - counts: aggregated counts over this node’s subtree (leafCounts + all children)
+     *           lets us easily decide if wholly contained or not
+     */
+    private static final class Node {
+        String name;
+        Map<String, Node> children = new LinkedHashMap<>();
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        Map<String, Integer> leafCounts = new LinkedHashMap<>();
+    }
+
+    /**
+     * Builds mapping lines from input partition sets (read from files in partitionDir) and
+     * returns a list of "<path> <partition>" lines.
+     *
+     * @param partitionDir The directory containing partition files.
+     * @param cellsFile The path to the cells.txt file.
+     * @param defaultPartitionName The name of the default partition (optional).
+     * @return A list of mapping lines.
+     */
+    public static List<String> buildMappingFromPartitionFiles(String partitionDir
+            , String cellsFile
+            , String defaultPartitionName) {
+        List<String> partitions = readPartitionNames(Paths.get(cellsFile));
+        Map<String, Set<String>> partToPaths = readPartitionInstanceSets(Paths.get(partitionDir),
+                new LinkedHashSet<>(partitions));
+        Node root = buildTrie(partToPaths);
+        computeCounts(root);
+        List<String> out = new ArrayList<>();
+        selectAndEmitMappings(root, "", out, false);
+
+        if (defaultPartitionName != null && !partitions.contains(defaultPartitionName)) {
+            PartitionTools.logPartitionerDebug(null,
+                    "warning: default partition '%s' not found in cells.txt",
+                    defaultPartitionName);
+        }
+
+        return out;
+    }
+
+    /**
+     * Writes mapping lines to a file.
+     *
+     * Ensure the parent directories exist so the file emits cleanly even on fresh runs.
+     *
+     * @param lines The list of mapping lines to write.
+     * @param outputPath The path to the output file.
+     */
+    public static void writeMappingFile(List<String> lines, String outputPath) {
+        try {
+            Path out = Paths.get(outputPath);
+            Path parent = out.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Files.write(out, lines, StandardCharsets.UTF_8);
+        } catch (IOException e) { // more guards the better.
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * RapidWright partitioner api: writes mapping.txt in outDir.
+     *
+     * @param outDir The output directory.
+     * @param netlist The EDIF netlist.
+     * @param partitions A map of partition IDs to sets of instance names.
+     * @param instLutCountMap A map of instance LUT counts (unused but kept for API consistency).
+     */
+    public static void write(Path outDir
+            , EDIFNetlist netlist
+            , Map<Integer, Set<String>> partitions
+            , Map<EDIFHierCellInst, Integer> instLutCountMap) {
+        // ============================================================================
+        // STEP 1
+        // Ensure cells.txt has fpga_* names for all partitions based on indices;
+        // will generate or extend labels when needed.
+        // ============================================================================
+        Path cellsFile = outDir.resolve("cells.txt");
+
+        int maxIdx = -1;
+        for (Integer idx : partitions.keySet()) {
+            if (idx != null && idx > maxIdx) {
+                maxIdx = idx;
+            }
+        }
+        int numParts = Math.max(0, maxIdx + 1);
+
+        List<String> names = readPartitionNames(cellsFile);
+        if (names.size() < numParts) {
+            List<String> gen = CellsWriter.generateNames(numParts);
+            if (names.isEmpty()) {
+                names = gen;
+            } else {
+                List<String> extended = new ArrayList<>(names);
+                for (int i = names.size(); i < numParts; i++) {
+                    extended.add(gen.get(i));
+                }
+                names = extended;
+            }
+            CellsWriter.write(outDir, names);
+        }
+
+        // ============================================================================
+        // STEP 2
+        // Build part-to-paths keyed by partition names (canonical labels); missing indices
+        // get generated names so the map is complete.
+        // ============================================================================
+        Map<String, Set<String>> partToPaths = new LinkedHashMap<>();
+        for (Map.Entry<Integer, Set<String>> entry : partitions.entrySet()) {
+            int idx = entry.getKey();
+            String name = (idx >= 0 && idx < names.size())
+                    ? names.get(idx) : CellsWriter.generateName(idx);
+            partToPaths.put(name, entry.getValue() != null
+                    ? entry.getValue() : new LinkedHashSet<>());
+        }
+
+        // ============================================================================
+        // STEP 3
+        // Build the trie and compute per-subtree counts, then select lines using the
+        // containment + home rules.
+        // ============================================================================
+        Node root = buildTrie(partToPaths);
+        computeCounts(root);
+        List<String> lines = new ArrayList<>();
+        selectAndEmitMappings(root, "", lines, false);
+
+        // ============================================================================
+        // STEP 4
+        // Prefix every path with the top cell name (prefer the top cell’s type name) and
+        // append a single top 'home' line at the end for readability.
+        // ============================================================================
+        String topName = null;
+        try {
+            EDIFHierCellInst topHierCellInst = netlist.getTopHierCellInst();
+            topName = (topHierCellInst != null) ? topHierCellInst.getCellName() : null;
+            if (topName == null || topName.isEmpty()) {
+                topName = (topHierCellInst != null) ? topHierCellInst.getInst().getName() : null;
+            }
+        } catch (Exception ignored) {
+            // ignore
+        }
+        if (topName == null || topName.isEmpty()) {
+            topName = "top";
+        }
+        List<String> prefixed = new ArrayList<>(lines.size() + 1);
+        for (String line : lines) {
+            int spaceIndex = line.indexOf(' ');
+            String path = spaceIndex >= 0 ? line.substring(0, spaceIndex) : line;
+            String destination = spaceIndex >= 0 ? line.substring(spaceIndex + 1) : "";
+            if (logicDiscoveryPolicy.pathHasExcludedSegment(path)) {
+                continue;
+            }
+            String fullSourcePath = topName + "/" + path;
+            prefixed.add(fullSourcePath + " " + destination);
+        }
+        String topHomePartition = chooseHomePartition(root.counts);
+        if (topHomePartition != null) {
+            prefixed.add(topName + " " + topHomePartition);
+        }
+
+        // ============================================================================
+        // STEP 5
+        // Sort and debug print the mapping order.
+        // ============================================================================
+        int showLimit = Math.min(5, prefixed.size());
+        PartitionTools.logPartitionerDebug(null,
+                "MAPPING_ORDER_DEBUG: pre-sort -> totalLines=%d topName=%s topHome=%s",
+                prefixed.size(), topName, topHomePartition);
+        for (int i = 0; i < showLimit; i++) {
+            PartitionTools.logPartitionerDebug(null,
+                    "MAPPING_ORDER_DEBUG: pre-sort[%d] depth=%d line=%s",
+                    i, depthOfPath(prefixed.get(i)), prefixed.get(i));
+        }
+        if (prefixed.size() > 10) {
+            PartitionTools.logPartitionerDebug(null,
+                    "MAPPING_ORDER_DEBUG: pre-sort ... (middle lines omitted)");
+            for (int i = prefixed.size() - showLimit; i < prefixed.size(); i++) {
+                PartitionTools.logPartitionerDebug(null,
+                        "MAPPING_ORDER_DEBUG: pre-sort[%d] depth=%d line=%s",
+                        i, depthOfPath(prefixed.get(i)), prefixed.get(i));
+            }
+        }
+        prefixed = sortByPathDepth(prefixed);
+        PartitionTools.logPartitionerDebug(null,
+                "MAPPING_ORDER_DEBUG: post-sort -> totalLines=%d", prefixed.size());
+        for (int i = 0; i < showLimit; i++) {
+            PartitionTools.logPartitionerDebug(null,
+                    "MAPPING_ORDER_DEBUG: post-sort[%d] depth=%d line=%s",
+                    i, depthOfPath(prefixed.get(i)), prefixed.get(i));
+        }
+        if (prefixed.size() > 10) {
+            PartitionTools.logPartitionerDebug(null,
+                    "MAPPING_ORDER_DEBUG: post-sort ... (middle lines omitted)");
+            for (int i = prefixed.size() - showLimit; i < prefixed.size(); i++) {
+                PartitionTools.logPartitionerDebug(null,
+                        "MAPPING_ORDER_DEBUG: post-sort[%d] depth=%d line=%s",
+                        i, depthOfPath(prefixed.get(i)), prefixed.get(i));
+            }
+        }
+        java.util.Map<Integer, Integer> depthCounts = new java.util.HashMap<>();
+        int maxDepth = 0;
+        for (String line : prefixed) {
+            int d = depthOfPath(line);
+            depthCounts.put(d, depthCounts.getOrDefault(d, 0) + 1);
+            if (d > maxDepth) {
+                maxDepth = d;
+            }
+        }
+        PartitionTools.logPartitionerDebug(null,
+                "MAPPING_ORDER_DEBUG: depth-stats -> maxDepth=%d uniqueDepths=%d",
+                maxDepth, depthCounts.size());
+        for (int d = maxDepth; d >= 0; d--) {
+            Integer count = depthCounts.get(d);
+            if (count != null) {
+                PartitionTools.logPartitionerDebug(null,
+                        "MAPPING_ORDER_DEBUG: depth=%d count=%d", d, count);
+            }
+        }
+
+        Path mappingFile = outDir.resolve("mapping.txt");
+        writeMappingFile(prefixed, mappingFile.toString());
+    }
+
+    /**
+     * Convenience main to emit mapping lines from a directory of partition files and a cells.txt.
+     *
+     * @param args Command line arguments: partitionDir, cells.txt, output_mapping.txt,
+     *             [defaultPartitionName].
+     */
+    public static void main(String[] args) {
+        if (args.length < 3 || args.length > 4) {
+            PartitionTools.logPartitionerDebug(null,
+                    "usage: <partitionDir> <cells.txt> <output_mapping.txt> " +
+                            "[defaultPartitionName]");
+            return;
+        }
+        String partitionDir = args[0];
+        String cellsFile = args[1];
+        String outputFile = args[2];
+        String defaultPartitionName = args.length == 4 ? args[3] : null;
+
+        List<String> mapping = buildMappingFromPartitionFiles(partitionDir,
+                cellsFile,
+                defaultPartitionName);
+        writeMappingFile(mapping, outputFile);
+    }
+
+    /**
+     * Reads partition labels from cells.txt and returns them in order.
+     *
+     * We ignore comments and blanks and keep order deterministic.
+     *
+     * @param cellsFile The path to the cells.txt file.
+     * @return A list of partition names.
+     */
+    private static List<String> readPartitionNames(Path cellsFile) {
+        List<String> partitions = new ArrayList<>();
+        if (cellsFile != null && Files.isRegularFile(cellsFile)) {
+            for (String line : FileTools.getLinesFromTextFile(cellsFile.toString())) {
+                String trimmed = trimComment(line);
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                partitions.add(trimmed);
+            }
+        }
+        return partitions;
+    }
+
+    /**
+     * Reads instance paths for each partition label from the given directory.
+     *
+     * @param partitionDir The directory containing partition files.
+     * @param partitions A set of partition names to look for.
+     * @return A map of partition names to sets of instance paths.
+     */
+    private static Map<String, Set<String>> readPartitionInstanceSets(Path partitionDir
+            , Set<String> partitions) {
+        Map<String, Set<String>> partToPaths = new LinkedHashMap<>();
+
+        for (String p : partitions) {
+            Set<String> paths = new LinkedHashSet<>();
+
+            Path file1 = partitionDir.resolve(p);
+            Path file2 = partitionDir.resolve(p + ".txt");
+
+            boolean readOk = false;
+            if (Files.isRegularFile(file1)) {
+                readOk = true;
+                for (String line : safeReadLines(file1)) {
+                    String trimmedLine = trimComment(line);
+                    if (trimmedLine.isEmpty()) {
+                        continue;
+                    }
+                    paths.add(trimmedLine);
+                }
+            } else if (Files.isRegularFile(file2)) {
+                readOk = true;
+                for (String line : safeReadLines(file2)) {
+                    String trimmedLine = trimComment(line);
+                    if (trimmedLine.isEmpty()) {
+                        continue;
+                    }
+                    paths.add(trimmedLine);
+                }
+            } else {
+                Path matched = findFileCaseInsensitive(partitionDir, p);
+                if (matched != null && Files.isRegularFile(matched)) {
+                    readOk = true;
+                    for (String line : safeReadLines(matched)) {
+                        String trimmedLine = trimComment(line);
+                        if (trimmedLine.isEmpty()) {
+                            continue;
+                        }
+                        paths.add(trimmedLine);
+                    }
+                }
+            }
+
+            if (!readOk) {
+                PartitionTools.logPartitionerDebug(null,
+                        "info: no file found for partition '%s' in dir %s",
+                        p, partitionDir);
+            }
+
+            partToPaths.put(p, paths);
+        }
+
+        return partToPaths;
+    }
+
+    /**
+     * Safe read of file lines with utf-8.
+     *
+     * @param file The file to read.
+     * @return A list of lines from the file.
+     */
+    private static List<String> safeReadLines(Path file) {
+        try {
+            return Files.readAllLines(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Case-insensitive search for a file that matches either "<name>" or "<name>.txt"
+     * in a directory.
+     *
+     * @param dir The directory to search in.
+     * @param targetName The name to search for.
+     * @return The path to the matching file, or null if not found.
+     */
+    private static Path findFileCaseInsensitive(Path dir, String targetName) {
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(dir)) {
+            for (Path path : directoryStream) {
+                String name = path.getFileName().toString();
+                if (name.equalsIgnoreCase(targetName)
+                        || name.equalsIgnoreCase(targetName + ".txt")) {
+                    if (Files.isRegularFile(path)) {
+                        return path;
+                    }
+                }
+            }
+        } catch (IOException e) {
+            // ignore, something to fill in this spot? error print?
+        }
+        return null;
+    }
+
+    /**
+     * Trims comments and whitespace; treats lines starting with '#' or '//' as comments.
+     *
+     * @param s The string to trim.
+     * @return The trimmed string, or an empty string if it was a comment.
+     */
+    private static String trimComment(String s) {
+        if (s == null) {
+            return "";
+        }
+        String trimmed = s.trim();
+        if (trimmed.isEmpty()) {
+            return "";
+        }
+        if (trimmed.startsWith("#")) {
+            return "";
+        }
+        if (trimmed.startsWith("//")) {
+            return "";
+        }
+        return trimmed;
+    }
+
+    /**
+     * Builds a trie over all instance paths for all partitions.
+     *
+     * @param partToPaths A map of partition names to sets of instance paths.
+     * @return The root node of the trie.
+     */
+    private static Node buildTrie(Map<String, Set<String>> partToPaths) {
+        Node root = new Node();
+        root.name = "";
+
+        for (Map.Entry<String, Set<String>> entry : partToPaths.entrySet()) {
+            String partition = entry.getKey();
+            for (String path : entry.getValue()) {
+                addPath(root, path, partition);
+            }
+        }
+        return root;
+    }
+
+    /**
+     * Inserts an instance path into the trie and records a leaf contribution at the terminal
+     * node for the given partition.
+     *
+     * @param root The root node of the trie.
+     * @param fullPath The full instance path.
+     * @param partition The partition name.
+     */
+    private static void addPath(Node root, String fullPath, String partition) {
+        List<String> segs = splitPath(fullPath);
+        Node cur = root;
+        for (String seg : segs) {
+            Node nxt = cur.children.get(seg);
+            if (nxt == null) {
+                nxt = new Node();
+                nxt.name = seg;
+                cur.children.put(seg, nxt);
+            }
+            cur = nxt;
+        }
+        cur.leafCounts.put(partition, cur.leafCounts.getOrDefault(partition, 0) + 1);
+    }
+
+    /**
+     * Splits a hierarchical path on '/' while leaving each segment intact.
+     *
+     * @param path The path to split.
+     * @return A list of path segments.
+     */
+    private static List<String> splitPath(String path) {
+        if (path == null || path.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String[] parts = path.split("/");
+        return Arrays.asList(parts);
+    }
+
+    /**
+     * Computes per-subtree aggregated counts for every node in the trie.
+     *
+     * @param node The root node of the subtree.
+     * @return A map of aggregated counts per partition.
+     */
+    private static Map<String, Integer> computeCounts(Node node) {
+        Map<String, Integer> aggregatedCounts = new LinkedHashMap<>();
+        mergeCounts(aggregatedCounts, node.leafCounts);
+        for (Node child : node.children.values()) {
+            Map<String, Integer> childCounts = computeCounts(child);
+            mergeCounts(aggregatedCounts, childCounts);
+        }
+        node.counts = aggregatedCounts;
+        return aggregatedCounts;
+    }
+
+    /**
+     * Adds a delta to a counts map for a given partition key.
+     *
+     * @param map The map to update.
+     * @param key The partition key.
+     * @param delta The value to add.
+     */
+    private static void addCount(Map<String, Integer> map, String key, int delta) {
+        if (key == null) {
+            return;
+        }
+        map.put(key, map.getOrDefault(key, 0) + delta);
+    }
+
+    /**
+     * Merges entries from mapB into mapA by adding counts per partition.
+     *
+     * @param mapA The destination map.
+     * @param mapB The source map.
+     */
+    private static void mergeCounts(Map<String, Integer> mapA, Map<String, Integer> mapB) {
+        for (Map.Entry<String, Integer> entry : mapB.entrySet()) {
+            addCount(mapA, entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Subtracts entries of mapB from mapA on a copy and prunes non-positive results.
+     *
+     * Useful to compute leftovers after child prints.
+     *
+     * @param mapA The map to subtract from.
+     * @param mapB The map to subtract.
+     * @return A new map containing the result.
+     */
+    private static Map<String, Integer> subtractCounts(Map<String, Integer> mapA
+            , Map<String, Integer> mapB) {
+        Map<String, Integer> out = new LinkedHashMap<>();
+        for (Map.Entry<String, Integer> entry : mapA.entrySet()) {
+            out.put(entry.getKey(), entry.getValue());
+        }
+        for (Map.Entry<String, Integer> entry : mapB.entrySet()) {
+            out.put(entry.getKey(), out.getOrDefault(entry.getKey(), 0) - entry.getValue());
+        }
+        pruneNonPositive(out);
+        return out;
+    }
+
+    /**
+     * Removes entries from a counts map where the value is null, zero, or negative.
+     *
+     * @param map The map to prune.
+     */
+    private static void pruneNonPositive(Map<String, Integer> map) {
+        List<String> toRemove = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry : map.entrySet()) {
+            if (entry.getValue() == null || entry.getValue() <= 0) {
+                toRemove.add(entry.getKey());
+            }
+        }
+        for (String key : toRemove) {
+            map.remove(key);
+        }
+    }
+
+    /**
+     * Returns true if the counts map has exactly one partition present (wholly contained).
+     *
+     * @param counts The counts map.
+     * @return True if wholly contained, false otherwise.
+     */
+    private static boolean isWhollyContained(Map<String, Integer> counts) {
+        if (counts.isEmpty()) {
+            return false;
+        }
+        return counts.size() == 1;
+    }
+
+    /**
+     * Returns the sole partition label if counts are wholly contained; otherwise null.
+     *
+     * @param counts The counts map.
+     * @return The partition label, or null.
+     */
+    private static String singlePartition(Map<String, Integer> counts) {
+        if (!isWhollyContained(counts)) {
+            return null;
+        }
+        for (String key : counts.keySet()) {
+            return key;
+        }
+        return null;
+    }
+
+    /**
+     * Picks the “home” partition for a node using
+     * the largest count (ties broken lexicographically).
+     *
+     * TODO : May need revision based on requested changes to regroupinstances / mapping.txt
+     * needing to change based on that. this part is likely to change...
+     *
+     * @param counts The counts map.
+     * @return The home partition label, or null.
+     */
+    private static String chooseHomePartition(Map<String, Integer> counts) {
+        if (counts == null || counts.isEmpty()) {
+            return null;
+        }
+        int max = -1;
+        String best = null;
+        for (Map.Entry<String, Integer> entry : counts.entrySet()) {
+            int value = entry.getValue() == null ? 0 : entry.getValue();
+            if (value > max || (value == max
+                    && (best == null || entry.getKey().compareTo(best) < 0))) {
+                max = value;
+                best = entry.getKey();
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Selects mapping lines by walking the trie and emits them into 'out'.
+     *
+     * @param node The current trie node.
+     * @param prefixPath The path prefix for this node.
+     * @param out The list to collect mapping lines.
+     * @param inSplit Whether we are currently in a split node.
+     * @return A map of relocated counts.
+     */
+    private static Map<String, Integer> selectAndEmitMappings(Node node
+            , String prefixPath
+            , List<String> out
+            , boolean inSplit) {
+        String currentPath = prefixPath;
+        if (node.name != null && !node.name.isEmpty()) {
+            if (currentPath.isEmpty()) {
+                currentPath = node.name;
+            } else {
+                currentPath = currentPath + "/" + node.name;
+            }
+        }
+
+        if (isWhollyContained(node.counts) && !currentPath.isEmpty()) {
+            String p = singlePartition(node.counts);
+            if (!logicDiscoveryPolicy.pathHasExcludedSegment(currentPath)) {
+                out.add(currentPath + " " + p);
+            }
+            return new LinkedHashMap<>(node.counts);
+        }
+
+        Map<String, Integer> relocatedFromChildren = new LinkedHashMap<>();
+        for (Node child : node.children.values()) {
+            Map<String, Integer> childRelocatedCounts = selectAndEmitMappings(child
+                    , currentPath
+                    , out
+                    , true);
+            mergeCounts(relocatedFromChildren, childRelocatedCounts);
+        }
+
+        Map<String, Integer> leftover = subtractCounts(node.counts, relocatedFromChildren);
+
+        if (!currentPath.isEmpty()) {
+            String home = chooseHomePartition(node.counts);
+            if (home != null && !leftover.isEmpty()) {
+                if (!logicDiscoveryPolicy.pathHasExcludedSegment(currentPath)) {
+                    out.add(currentPath + " " + home);
+                }
+                return new LinkedHashMap<>(node.counts);
+            }
+        }
+
+        return relocatedFromChildren;
+    }
+
+    /**
+     * Returns lines sorted by path depth, then lexicographically. Useful when post-processing
+     * is needed for readability.
+     *
+     * @param lines The list of lines to sort.
+     * @return A new sorted list of lines.
+     */
+    public static List<String> sortByPathDepth(List<String> lines) {
+        List<String> out = new ArrayList<>(lines);
+        Collections.sort(out, (a, b) -> {
+            int depthA = depthOfPath(a);
+            int depthB = depthOfPath(b);
+            if (depthA != depthB) {
+                return Integer.compare(depthB, depthA);
+            }
+            return a.compareTo(b);
+        });
+        return out;
+    }
+
+    /**
+     * Computes a simple depth metric for "<path> <partition>" lines by counting '/' in the path.
+     *
+     * @param mappingLine The mapping line string.
+     * @return The depth of the path.
+     */
+    private static int depthOfPath(String mappingLine) {
+        int spaceIndex = mappingLine.indexOf(' ');
+        String path = spaceIndex >= 0 ? mappingLine.substring(0, spaceIndex) : mappingLine;
+        if (path.isEmpty()) {
+            return 0;
+        }
+        int depth = 0;
+        for (int i = 0; i < path.length(); i++) {
+            if (path.charAt(i) == '/') {
+                depth++;
+            }
+        }
+        return depth + 1;
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/partition/IoCutWriter.java
+++ b/src/com/xilinx/rapidwright/edif/partition/IoCutWriter.java
@@ -1,0 +1,134 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.partition;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+
+/**
+ * Writes io_cuts.txt (direction-agnostic connection summary).
+ * Optionally writes detailed human-readable hypergraph nets.txt report.
+ */
+public final class IoCutWriter {
+
+    private IoCutWriter() {
+        // no instances.
+    }
+
+    /**
+     * Writes io_cuts.txt (in outDir) and optionally the detailed nets.txt.
+     * @param outDir Output directory
+     * @param inputEdif The input EDIF file path used to derive artifact names
+     * @param netlist The EDIF netlist
+     * @param instLookup Array mapping vertex IDs to instance names
+     * @param partitions Map of partition IDs to sets of instance names
+     * @param generateEdifNets Whether to generate the detailed nets.txt report
+     */
+    public static void write(Path outDir
+            , Path inputEdif
+            , EDIFNetlist netlist
+            , String[] instLookup
+            , Map<Integer, Set<String>> partitions
+            , boolean generateEdifNets) {
+        // build a deterministic name -> partition id lookup so we can translate each
+        // hypergraph member to its block id.
+        Map<String, Integer> nameToPart = new LinkedHashMap<>();
+        for (Map.Entry<Integer, Set<String>> partitionEntry : partitions.entrySet()) {
+            for (String instanceName : partitionEntry.getValue()) {
+                nameToPart.put(instanceName, partitionEntry.getKey());
+            }
+        }
+
+        // derive artifact paths w/ the input edif; these are produced earlier in the flow:
+        // - .hgr lists each edge as a space-separated list of vertex ids
+        // - .eidmap is a 1-based list of hierarchical net names aligned with the edges in .hgr
+        // - .nets.txt is the verbose connectivity report we keep centralized here for convenience
+        String base = inputEdif.getFileName().toString();
+        Path hgr = outDir.resolve(base + ".hgr");
+        Path eidmap = outDir.resolve(base + ".eidmap");
+        Path netsOut = outDir.resolve(base + ".nets.txt");
+
+        // write the direction-agnostic io cuts into io_cuts.txt.
+        // this uses .hgr membership and ignores driver direction, emitting counts for both
+        // permutations.
+        writeIoCutsUndirected(outDir, hgr, instLookup, nameToPart);
+
+        // generate the detailed per-net report
+        if (generateEdifNets) {
+            writeDetailedNetsReport(hgr, eidmap, instLookup, nameToPart, netsOut);
+        }
+    }
+
+    /**
+     * Writes io_cuts.txt using PartitionPairCounter.
+     * @param outDir Output directory
+     * @param hgrFile Path to the hypergraph (.hgr) file
+     * @param instLookup Array mapping vertex IDs to instance names
+     * @param nameToPart Map from instance names to partition IDs
+     */
+    private static void writeIoCutsUndirected(Path outDir
+            , Path hgrFile
+            , String[] instLookup
+            , Map<String, Integer> nameToPart) {
+        Map<String, Integer> pairCounts = PartitionPairCounter.countPartitionPairs(
+                hgrFile, instLookup, nameToPart);
+        Path ioCuts = outDir.resolve("io_cuts.txt");
+        PartitionPairCounter.writePairCountsToFile(ioCuts, pairCounts);
+    }
+
+    /**
+     * Writes detailed nets.txt using existing PartitionTools logic.
+     * @param hgrFile Path to the hypergraph (.hgr) file
+     * @param eidmapFile Path to the edge ID mapping (.eidmap) file
+     * @param instLookup Array mapping vertex IDs to instance names
+     * @param nameToPart Map from instance names to partition IDs
+     * @param netsOut Path where nets.txt report will be written
+     */
+    private static void writeDetailedNetsReport(Path hgrFile
+            , Path eidmapFile
+            , String[] instLookup
+            , Map<String, Integer> nameToPart
+            , Path netsOut) {
+        try {
+            PartitionTools.writeConnectivityReportWithNames(hgrFile,
+                    eidmapFile,
+                    instLookup,
+                    nameToPart,
+                    netsOut);
+            PartitionTools.logPartitionerDebug(null, "Partitioner artifact written: %s",
+                    netsOut.toString());
+        } catch (UncheckedIOException ex) {
+            PartitionTools.logPartitionerDebug(null,
+                    "WARNING: failed to write nets report: %s",
+                    ex.getMessage());
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/partition/LUTCountingUtils.java
+++ b/src/com/xilinx/rapidwright/edif/partition/LUTCountingUtils.java
@@ -1,0 +1,135 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.partition;
+
+import java.util.Map;
+
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+
+/**
+ * LUT counting utilities for partition, allows us to traverse monolithic netlists
+ * and count LUTs per hierarchical instance, with caching to avoid recomputation.
+ */
+public final class LUTCountingUtils {
+
+    static long dbgCacheHits = 0;
+    static long dbgRecursiveCalls = 0;
+    static long dbgInstMapWrites = 0;
+    static long dbgCacheHitInstMapWrites = 0;
+    static int dbgCacheHitLogBudget = 10;
+    static long dbgSubtreePopulations = 0;
+    static long dbgSubtreeInstances = 0;
+
+    private LUTCountingUtils() {
+    }
+
+    /**
+     * Populates instance map from cache. When we hit a cache entry, we already know 
+     * the LUT count for that cell type, quickly fill instMap for entire subtree.
+     * 
+     * @param hierInst Hierarchical instance
+     * @param cellTypeCache Cell type to LUT count cache
+     * @param instMap Instance to LUT count map
+     */
+    public static void populateFromCache(EDIFHierCellInst hierInst,
+            Map<EDIFCell, Integer> cellTypeCache,
+            Map<EDIFHierCellInst, Integer> instMap) {
+        if (instMap == null) {
+            return;
+        }
+        Integer lutCount = cellTypeCache.get(hierInst.getCellType());
+        if (lutCount != null) {
+            instMap.put(hierInst, lutCount);
+            dbgInstMapWrites++;
+            dbgSubtreeInstances++;
+        }
+        if (!hierInst.getCellType().isLeafCellOrBlackBox()) {
+            for (EDIFCellInst childInst : hierInst.getCellType().getCellInsts()) {
+                populateFromCache(hierInst.getChild(childInst), cellTypeCache, instMap);
+            }
+        }
+    }
+
+    /**
+     * Recursively computes LUT count for hierarchical cell instance. Utilize caching 
+     * to avoid recalculating known cell types.
+     * 
+     * @param hierInst Hierarchical cell instance
+     * @param cellTypeCache Cell type cache
+     * @param instMap Instance map
+     * @return LUT count
+     */
+    public static Integer computeLUTCount(EDIFHierCellInst hierInst,
+            Map<EDIFCell, Integer> cellTypeCache,
+            Map<EDIFHierCellInst, Integer> instMap) {
+        Integer totalLUTs = 0;
+        for (EDIFCellInst childInst : hierInst.getCellType().getCellInsts()) {
+            if (childInst.getCellType().isLeafCellOrBlackBox()) {
+                int lutVal = logicDiscoveryPolicy.isLogicLUT(
+                        childInst.getCellType().getName()) ? 1 : 0;
+                totalLUTs += lutVal;
+            } else if (cellTypeCache.containsKey(childInst.getCellType())) {
+                dbgCacheHits++;
+                Integer cachedVal = cellTypeCache.get(childInst.getCellType());
+                EDIFHierCellInst childHierInst = hierInst.getChild(childInst);
+                if (dbgCacheHitLogBudget > 0) {
+                    PartitionTools.logPartitionerDebug(System.err,
+                            "cache hit -> parentPath=%s childInst=%s cellType=%s "
+                            + "childPath=%s cachedLUTs=%d",
+                            hierInst.toString(), childInst.getName(),
+                            childInst.getCellType().getName(),
+                            childHierInst.toString(), cachedVal);
+                    dbgCacheHitLogBudget--;
+                }
+                totalLUTs += cachedVal;
+                if (instMap != null) {
+                    long beforeSubtree = dbgSubtreeInstances;
+                    populateFromCache(childHierInst, cellTypeCache, instMap);
+                    dbgCacheHitInstMapWrites++;
+                    dbgSubtreePopulations++;
+                    long subtreeCount = dbgSubtreeInstances - beforeSubtree;
+                    if (dbgSubtreePopulations <= 5) {
+                        PartitionTools.logPartitionerDebug(System.err,
+                                "subtree populated -> childPath=%s subtreeInstances=%d",
+                                childHierInst.toString(), subtreeCount);
+                    }
+                }
+            } else {
+                dbgRecursiveCalls++;
+                totalLUTs += computeLUTCount(hierInst.getChild(childInst),
+                        cellTypeCache, instMap);
+            }
+        }
+        Integer prevCount = cellTypeCache.put(hierInst.getCellType(), totalLUTs);
+        if (prevCount != null && !prevCount.equals(totalLUTs)) {
+            throw new RuntimeException("ERROR: Inconsistent netlist");
+        }
+        if (instMap != null) {
+            instMap.put(hierInst, totalLUTs);
+            dbgInstMapWrites++;
+        }
+        return totalLUTs;
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/partition/MtKaHyParPartitioner.java
+++ b/src/com/xilinx/rapidwright/edif/partition/MtKaHyParPartitioner.java
@@ -42,67 +42,111 @@ public class MtKaHyParPartitioner implements AbstractPartitioner {
 
     private int numOfThreads = 2;
 
-    private double epsilon = 0.03;
+    private double epsilon = 0.03; // Imbalance for partition
     
-    private String objective = "cut";
+    private String objective = "cut"; // Cost function 
+    
+    private String presetType = "default";
     
     private Path outputDir = null; // Use current working directory
 
     private int seed = 0;
 
+    private Path fixedVerticesFile = null; // Manual partition constraints
+
+    /**
+     * Executes the MtKaHyPar partitioning tool with configured parameters.
+     * @return Exit code from the partitioner execution
+     */
     @Override
     public Integer runPartitioner() {
+        // If fixed vertices are present, override incompatible presets
+        String effectivePreset = presetType;
+        if (fixedVerticesFile != null) {
+            if ("deterministic".equals(effectivePreset) || "large_k".equals(effectivePreset)) {
+                System.out.println("partitioner debug: fixed vertices present; " +
+                   "overriding preset to quality");
+                effectivePreset = "quality";
+            }
+        }
         String cmd = name 
                 + " -h " + getInputFile() 
-                + " --preset-type=default "
+                + " --preset-type=" + effectivePreset + " "
                 + " -t " + numOfThreads
                 + " -k " + getKPartitions() 
                 + " --seed " + seed
                 + " --epsilon " + epsilon
                 + " --objective "+ objective
-                + " --write-partition-file=true";
-
-//        String[] cmd = new String[] {name
-//                , "-h" , getInputFile().toString() 
-//                , "--preset-type=default"
-//                , "-t" , Integer.toString(numOfThreads)
-//                , "-k" , Integer.toString(getKPartitions()) 
-//                , "--seed " , Integer.toString(seed)
-//                , "--epsilon " , Double.toString(epsilon)
-//                , "--objective ", objective
-//                , "--write-partition-file=true" };
+                + " --write-partition-file=true"
+                + " --verbose=true" // Displays detailed information on the partitioning process
+                + " --show-detailed-timings=true"; // sub-timings of each phase of partitioning
+        if (fixedVerticesFile != null) {
+            cmd += " -f " + fixedVerticesFile;
+        }
 
         
-        String[] environ = new String[] {};
+        String[] environ = null; // inherit env
         File runDir = getOutputDir().toFile();
 
         return FileTools.runCommand(cmd, true, environ, runDir);
     }
 
+    /**
+     * Gets the name of this partitioner.
+     * @return The partitioner name "MtKaHyPar"
+     */
     @Override
     public String Name() {
         return name;
     }
 
+    /**
+     * Sets the number of partitions to create.
+     * @param k The number of partitions
+     */
     @Override
     public void setKPartitions(int k) {
         this.k = k;
     }
 
+    /**
+     * Sets the input hypergraph file path.
+     * @param filePath Path to the input .hgr file
+     */
     @Override
     public void setInputFile(Path filePath) {
         this.inputFile = filePath;
     }
 
+    /**
+     * Gets the input hypergraph file path.
+     * @return Path to the input file
+     */
     @Override
     public Path getInputFile() {
         return inputFile;
     }
 
+    /**
+     * Gets the output directory for partition results.
+     * @return Path to output directory
+     */
     public Path getOutputDir() {
         return outputDir == null ? Paths.get(System.getProperty("user.dir")) : outputDir;
     }
 
+    /**
+     * Sets the output directory for partition results.
+     * @param d Path to output directory
+     */
+    public void setOutputDir(Path d) {
+        this.outputDir = d;
+    }
+
+    /**
+     * Gets the expected output partition file path.
+     * @return Path to the partition solution file
+     */
     @Override
     public Path getOutputFile() {
         Path outputFile = getOutputDir()
@@ -111,8 +155,80 @@ public class MtKaHyParPartitioner implements AbstractPartitioner {
         return outputFile;
     }
 
+    /**
+     * Gets the number of partitions configured.
+     * @return The number of partitions
+     */
     @Override
     public Integer getKPartitions() {
         return k;
     }
+
+    /**
+     * Sets the number of threads for partitioning.
+     * @param t Number of threads to use
+     */
+    public void setNumThreads(int t) {
+        this.numOfThreads = t;
+    }
+
+    /**
+     * Sets the partition imbalance tolerance.
+     * @param e Epsilon value for imbalance
+     */
+    public void setEpsilon(double e) {
+        this.epsilon = e;
+    }
+
+    /**
+     * Sets the random seed for partitioning.
+     * @param s Seed value for reproducibility
+     */
+    public void setSeed(int s) {
+        this.seed = s;
+    }
+
+    /**
+     * Sets the partitioner preset configuration type.
+     * @param p Preset type like "default" or "deterministic"
+     */
+    public void setPresetType(String p) {
+        this.presetType = p;
+    }
+
+    /**
+     * Sets the partitioning objective function.
+     * @param o Objective like "cut", "km1", or "soed"
+     */
+    public void setObjective(String o) {
+        if (o != null && !o.isEmpty()) {
+            this.objective = o;
+        }
+    }
+
+    /**
+     * Gets the current partitioning objective function.
+     * @return The objective function name
+     */
+    public String getObjective() {
+        return this.objective;
+    }
+
+    /**
+     * Sets the fixed vertices constraint file path.
+     * @param p Path to the .fix file
+     */
+    public void setFixedVerticesFile(Path p) {
+        this.fixedVerticesFile = p;
+    }
+
+    /**
+     * Gets the fixed vertices constraint file path.
+     * @return Path to the .fix file or null
+     */
+    public Path getFixedVerticesFile() {
+        return this.fixedVerticesFile;
+    }
+
+
 }

--- a/src/com/xilinx/rapidwright/edif/partition/PartitionLabel.java
+++ b/src/com/xilinx/rapidwright/edif/partition/PartitionLabel.java
@@ -1,0 +1,62 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.partition;
+
+/**
+ * Logic to convert from partition index 
+ * to FPGA partition label using the following
+ * naming scheme:
+ *   0..25  -> A..Z
+ *   26..51 -> AZ..ZZ
+ *   52..77 -> AZZ..ZZZ
+ *
+ * similar to "excel-style (bijective) base-26"
+ */
+final class PartitionLabel {
+
+    private PartitionLabel() {}
+
+    private static final char[] ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+
+    /**
+     * Converts partition index to FPGA label string.
+     * @param idx The partition index to convert
+     * @return FPGA label string like "FPGA_A" or "FPGA_BZ"
+     */
+    static String indexToFpgaLabel(int idx) {
+        if (idx < 0) throw new IllegalArgumentException("partition index must be non-negative");
+        String suffix;
+        if (idx < 26) {
+            suffix = String.valueOf(ALPHA[idx]);
+        } else {
+            int t = idx - 26;
+            int q = t / 26;   //how many trailing 'Z' to add
+            int r = t % 26;   //leading letter
+            StringBuilder sb = new StringBuilder();
+            sb.append(ALPHA[r]);
+            for (int i = 0; i < q + 1; i++) sb.append('Z');
+            suffix = sb.toString();
+        }
+        return "FPGA_" + suffix;
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/partition/PartitionPairCounter.java
+++ b/src/com/xilinx/rapidwright/edif/partition/PartitionPairCounter.java
@@ -1,0 +1,164 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.partition;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+* Reports the number of nets shared by both partition A and partition B. 
+* For every net if it touches partition A and partition B increment the A-B count. 
+* This is a undirected and topology-agnostic report.
+*
+* TODO: ‘IO Cut’ maybe a misleading title for this output.
+* 
+* TODO: Perhaps name output to something more accurate; “Undirected Pairwise Net Sharing”.
+* Introduce a io cut reporter with directionality considered and have this be your “IO Cuts” report.
+ */
+public final class PartitionPairCounter {
+
+    private PartitionPairCounter() {
+    }
+
+    /**
+     * Counts how many nets connect between each pair of partitions.
+     * 
+     * @param hgrFile Hypergraph file path
+     * @param instLookup Vertex ID to instance name array
+     * @param nameToPart Instance name to partition ID map
+     * @return Partition pair counts map
+     */
+    public static Map<String, Integer> countPartitionPairs(Path hgrFile,
+            String[] instLookup, Map<String, Integer> nameToPart) {
+        Map<String, Integer> pairCounts = new LinkedHashMap<>();
+        try (BufferedReader hgrReader = new BufferedReader(
+                new FileReader(hgrFile.toFile()))) {
+            // skip header line (contains edge count and vertex count).
+            String header = hgrReader.readLine();
+            
+            // process each net (hyperedge) in the hypergraph file.
+            // each line after the header represents one net and 
+            // contains space-separated vertex IDs.
+            String line;
+            while ((line = hgrReader.readLine()) != null) {
+                String[] tokens = line.trim().isEmpty() ?
+                        new String[0] : line.trim().split("\\s+");
+                Set<Integer> partitionIds = new HashSet<>();
+                // for each vertex ID determine which partition it belongs to.
+                for (String t : tokens) {
+                    if (t.isEmpty()) {
+                        continue;
+                    }
+                    int vertexId;
+                    try {
+                        vertexId = Integer.parseInt(t);
+                    } catch (NumberFormatException nfe) {
+                        continue;
+                    }
+                    // look up instance name for this vertex ID.
+                    String instanceName = (vertexId >= 0 && vertexId < instLookup.length)
+                            ? instLookup[vertexId] : null;
+                    // look up partition ID for this instance.
+                    Integer part = (instanceName == null) ?
+                            null : nameToPart.get(instanceName);
+                    
+                    // add partition to the set if found.
+                    if (part != null) {
+                        partitionIds.add(part.intValue());
+                    }
+                }
+                
+                // skip nets that don't span multiple partitions (internal nets).
+                if (partitionIds.size() < 2) {
+                    continue;
+                }
+                List<Integer> partitionIdList = new ArrayList<>(partitionIds);
+                // for each unique pair of partitions touched by this net, increment the count.
+                for (int i = 0; i < partitionIdList.size(); i++) {
+                    for (int j = i + 1; j < partitionIdList.size(); j++) {
+                        // Convert partition indices to letter based labels
+                        String partitionLabelA =
+                                PartitionLabel.indexToFpgaLabel(partitionIdList.get(i));
+                        String partitionLabelB =
+                                PartitionLabel.indexToFpgaLabel(partitionIdList.get(j));
+                        
+                        // create keys for both orderings of this partition pair.
+                        // We store counts in both directions (A,B) 
+                        // and (B,A) so lookups work regardless of order
+                        String pairKeyForward = partitionLabelA + "," + partitionLabelB;
+                        String pairKeyBackward = partitionLabelB + "," + partitionLabelA;
+                        // increment count for both orderings.
+                        pairCounts.put(pairKeyForward,
+                                pairCounts.getOrDefault(pairKeyForward, 0) + 1);
+                        pairCounts.put(pairKeyBackward,
+                                pairCounts.getOrDefault(pairKeyBackward, 0) + 1);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return pairCounts;
+    }
+
+    /**
+     * Writes partition pair counts to file.
+     * 
+     * @param outputFile Output file path
+     * @param pairCounts Partition pair counts map
+     */
+    public static void writePairCountsToFile(Path outputFile,
+            Map<String, Integer> pairCounts) {
+        List<String> keys = new ArrayList<>(pairCounts.keySet());
+        Collections.sort(keys);
+        List<String> lines = new ArrayList<>(keys.size());
+        for (String pairKey : keys) {
+            int separatorIndex = pairKey.indexOf(',');
+            String partitionLabelA = pairKey.substring(0, separatorIndex);
+            String partitionLabelB = pairKey.substring(separatorIndex + 1);
+            int pairCount = pairCounts.get(pairKey);
+            
+            //format will be "FPGA_A--count--FPGA_B".
+            lines.add(partitionLabelA + "--" + pairCount + "--" + partitionLabelB);
+        }
+        try {
+            Files.write(outputFile, lines, StandardCharsets.UTF_8);
+            PartitionTools.logPartitionerDebug(null,
+                    "Partitioner artifact written: %s", outputFile.toString());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/partition/PartitionTools.java
+++ b/src/com/xilinx/rapidwright/edif/partition/PartitionTools.java
@@ -30,6 +30,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -50,34 +52,32 @@ import com.xilinx.rapidwright.edif.EDIFNetlist;
  */
 public class PartitionTools {
 
+
     /**
-     * Calculates the number of LUTs in a given hierarchical cell instance.
-     * 
-     * @param inst    The hierarchical cell instance to calculate a LUT count.
-     * @param map     A caching map to avoid recalculating LUTs for each cell type.
-     * @param instMap A map that keeps track of all hierarchical instances and their
-     *                LUT counts.
-     * @return The number of LUTs in the hierarchical cell instance.
+     * Helper to print partitioner debug messages with a consistent prefix.
+     * @param stream Output stream for debug messages
+     * @param format Format string for the message
+     * @param args Arguments for the format string
      */
-    public static Integer getLUTCount(EDIFHierCellInst inst, Map<EDIFCell, Integer> map,
+    public static void logPartitionerDebug(java.io.PrintStream stream, String format, 
+            Object... args) {
+        if (stream == null) {
+            stream = System.out;
+        }
+        stream.printf("PARTITIONER DEBUG: " + format + "%n", args);
+    }
+
+    /**
+     * Calculates LUT count for hierarchical instance.
+     * @param hierInst Hierarchical cell instance
+     * @param cellTypeCache Cell type cache
+     * @param instMap Instance map
+     * @return LUT count
+     */
+    public static Integer getLUTCount(EDIFHierCellInst hierInst,
+            Map<EDIFCell, Integer> cellTypeCache,
             Map<EDIFHierCellInst, Integer> instMap) {
-        Integer totalLUTs = 0;
-        for (EDIFCellInst i : inst.getCellType().getCellInsts()) {
-            if (i.getCellType().isLeafCellOrBlackBox()) {
-                totalLUTs += i.getCellType().getName().contains("LUT") ? 1 : 0;
-            } else if (map.containsKey(i.getCellType())) {
-                totalLUTs += map.get(i.getCellType());
-            } else {
-                totalLUTs += getLUTCount(inst.getChild(i), map, instMap);
-            }
-        }
-        Integer prevCount = map.put(inst.getCellType(), totalLUTs);
-        if (prevCount != null && !prevCount.equals(totalLUTs)) {
-            throw new RuntimeException("ERROR: Inconsistent netlist");
-        }
-        instMap.put(inst, totalLUTs);
-    
-        return totalLUTs;
+        return LUTCountingUtils.computeLUTCount(hierInst, cellTypeCache, instMap);
     }
 
     /**
@@ -91,60 +91,119 @@ public class PartitionTools {
      * @return A map of all coarsened leaf hierarchical instances mapped to a unique
      *         index.
      */
-    public static Map<EDIFHierCellInst, Integer> identifyLeafInstances(EDIFNetlist netlist, int lutCount, 
+    public static Map<EDIFHierCellInst, Integer> identifyLeafInstances(EDIFNetlist netlist,
+            int lutCount, 
             Map<EDIFHierCellInst, Integer> instMap) {
         EDIFHierCellInst topInst = netlist.getTopHierCellInst();
         Map<EDIFCell, Integer> lutCountMap = new HashMap<>();
+        LUTCountingUtils.dbgCacheHits = 0;
+        LUTCountingUtils.dbgRecursiveCalls = 0;
+        LUTCountingUtils.dbgInstMapWrites = 0;
+        LUTCountingUtils.dbgCacheHitInstMapWrites = 0;
+        LUTCountingUtils.dbgCacheHitLogBudget = 10;
+        logPartitionerDebug(System.err,
+                "identifyLeafInstances start -> topInst=%s lutCountThreshold=%d",
+                topInst.toString(), lutCount);
         getLUTCount(topInst, lutCountMap, instMap);
+        logPartitionerDebug(System.err,
+                "getLUTCount complete -> topLUTs=%d instMapSize=%d lutCountMapSize=%d "
+                + "cacheHitInstMapWrites=%d",
+                instMap.get(topInst), instMap.size(), lutCountMap.size(),
+                LUTCountingUtils.dbgCacheHitInstMapWrites);
+        int dbgNullLUTCountDecisions = 0;
+        int dbgNullButHier = 0;
+        int dbgNullButLeaf = 0;
 
         Map<EDIFHierCellInst, Integer> leafInsts = new HashMap<>();
-        Queue<EDIFHierCellInst> q = new LinkedList<>();
-        q.add(topInst);
-        while (!q.isEmpty()) {
-            EDIFHierCellInst curr = q.poll();
-            Integer lutSize = instMap.get(curr);
+        Queue<EDIFHierCellInst> instQueue = new LinkedList<>();
+        instQueue.add(topInst);
+        while (!instQueue.isEmpty()) {
+            EDIFHierCellInst currentInst = instQueue.poll();
+
+            //A null here means LUTCounting did not populate instMap for this instance
+            //we MUST still make a coarsening decision, log and treat as eligible 
+            //leaf vertex.
+            Integer lutSize = instMap.get(currentInst);
+            if (lutSize == null) {
+                //debug only, track case where LUT size is missing
+                //but we had to decide if leaf or to descend
+                dbgNullLUTCountDecisions++;
+                if (currentInst.getCellType().isLeafCellOrBlackBox()) {
+                    dbgNullButLeaf++;
+                    if (dbgNullButLeaf <= 10) {
+                        logPartitionerDebug(System.err, 
+                            "null LUT count (leaf) -> instPath=%s cellType=%s isLeaf=%s",
+                            currentInst.toString(), currentInst.getCellType().getName(), 
+                            currentInst.getCellType().isLeafCellOrBlackBox());
+                    }
+                //split up debug logs so we can see if missing LUT counts are on primitive leaf cells 
+                //or on hierarchical (Which is not a leaf) cell.
+                } else {
+                    dbgNullButHier++;
+                    if (dbgNullButHier <= 10) {
+                        logPartitionerDebug(System.err, 
+                            "null LUT count (hier) -> instPath=%s cellType=%s depth=%d " 
+                            + "childCount=%d",
+                            currentInst.toString(), currentInst.getCellType().getName(), 
+                            currentInst.getDepth(), 
+                            currentInst.getCellType().getCellInsts().size());
+                    }
+                }
+            }
             if (lutSize == null || lutSize <= lutCount) {
-                leafInsts.put(curr, leafInsts.size()+1);
+                leafInsts.put(currentInst, leafInsts.size() + 1);
                 continue;
             }
             assert (lutSize > lutCount);
-            for (EDIFCellInst child : curr.getCellType().getCellInsts()) {
-                q.add(curr.getChild(child));
+            for (EDIFCellInst childInst : currentInst.getCellType().getCellInsts()) {
+                instQueue.add(currentInst.getChild(childInst));
             }
         }
     
+        logPartitionerDebug(System.out,
+                "lutCount stats -> cacheHits=%d recursiveCalls=%d instMapWrites=%d "
+                + "cacheHitInstMapWrites=%d uniqueCells=%d instMapSize=%d",
+                LUTCountingUtils.dbgCacheHits, LUTCountingUtils.dbgRecursiveCalls,
+                LUTCountingUtils.dbgInstMapWrites, LUTCountingUtils.dbgCacheHitInstMapWrites,
+                lutCountMap.size(), instMap.size());
+        logPartitionerDebug(System.out,
+                "identifyLeafInstances -> leaves=%d nullLUTCountDecisions=%d nullButHier=%d "
+                + "nullButLeaf=%d",
+                leafInsts.size(), dbgNullLUTCountDecisions, dbgNullButHier, dbgNullButLeaf);
+        logPartitionerDebug(System.err,
+                "fix validation -> cacheHits=%d cacheHitInstMapWrites=%d shouldMatch=%s "
+                + "subtreePopulations=%d subtreeInstances=%d",
+                LUTCountingUtils.dbgCacheHits, LUTCountingUtils.dbgCacheHitInstMapWrites,
+                (LUTCountingUtils.dbgCacheHits == LUTCountingUtils.dbgCacheHitInstMapWrites),
+                LUTCountingUtils.dbgSubtreePopulations, LUTCountingUtils.dbgSubtreeInstances);
         return leafInsts;
     }
     
     /**
      * Create an array of cell instance string names such that the strings are
      * stored at their respective index.
-     * 
-     * @param leafInsts The map of cell instances to their assigned index.
-     * @return The string array of cell instance names stored at their assigned
-     *         index.
+     * @param leafInsts The map of cell instances to their assigned index
+     * @return String array of instance names at assigned indices
      */
     public static String[] createInstLookupArray(Map<EDIFHierCellInst, Integer> leafInsts) {
         String[] lookup = new String[leafInsts.size() + 1];
         lookup[0] = null;
-        for (Entry<EDIFHierCellInst, Integer> e : leafInsts.entrySet()) {
-            lookup[e.getValue()] = e.getKey().toString();
+        for (Entry<EDIFHierCellInst, Integer> entry : leafInsts.entrySet()) {
+            lookup[entry.getValue()] = entry.getKey().toString();
         }
         return lookup;
     }
 
     /**
      * Writes out instance names to integers to store the enumerated mapping.
-     * 
-     * @param mappingFile A file that maps index to instance name (one per line) to
-     *                    the partitioned solution can be decoded.
-     * @param leafInsts   Current enumeration map for the instances used.
+     * @param mappingFile File that maps index to instance name
+     * @param instLookup Current enumeration map for instances
      */
     public static void writeInstMappingFile(Path mappingFile, String[] instLookup) {
-        try (BufferedWriter bw = new BufferedWriter(new FileWriter(mappingFile.toFile()))) {
-            bw.write(instLookup.length + "\n");
-            for (int i = 1; i < instLookup.length; i++) {
-                bw.write(instLookup[i] + "\n");
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(mappingFile.toFile()))) {
+            writer.write(instLookup.length + "\n");
+            for (int index = 1; index < instLookup.length; index++) {
+                writer.write(instLookup[index] + "\n");
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -154,60 +213,198 @@ public class PartitionTools {
     /**
      * Creates the hMETIS formatted problem file for the partitioner. This follows
      * conventional hMETIS file format.
-     * 
-     * @param filePath  Path to the output file.
-     * @param edgesMap  Map of edges to be included in the output file.
-     * @param leafInsts Map of nodes or leaves to be included in the output file.
+     * @param filePath Path to the output .hgr file
+     * @param edgesMap Map of edges to include
+     * @param leafInsts Map of nodes to include
+     * @param writeEidmap Whether to write edge ID mapping file
      */
-    public static void writeHMetisFile(Path filePath, Map<EDIFHierNet, Set<EDIFHierCellInst>> edgesMap, 
-            Map<EDIFHierCellInst, Integer> leafInsts) { 
-        try (BufferedWriter bw = new BufferedWriter(new FileWriter(filePath.toFile()))) {
-            // <Total Edge Count> <Total Node Count>
-            bw.write(edgesMap.size() + " " + leafInsts.size() + "\n");
-            for (Entry<EDIFHierNet, Set<EDIFHierCellInst>> e : edgesMap.entrySet()) {
-                for (EDIFHierCellInst i : e.getValue()) {
-                    Integer nodeIdx = leafInsts.get(i);
-                    if (nodeIdx == null) {
-                        throw new RuntimeException(
-                                "ERROR: Inconsistent netlist, cannot export .hgr.");
+    public static void writeHMetisFile(Path filePath, 
+            Map<EDIFHierNet, Set<EDIFHierCellInst>> edgesMap, 
+            Map<EDIFHierCellInst, Integer> leafInsts, boolean writeEidmap) {
+        // Derive .eidmap path alongside .hgr (replace .hgr suffix if present)
+        Path eidmapPath;
+        String base = filePath.toString();
+        if (base.endsWith(".hgr")) {
+            eidmapPath = Paths.get(base.substring(0, base.length() - 4) + ".eidmap");
+        } else {
+            eidmapPath = Paths.get(base + ".eidmap");
+        }
+        if (writeEidmap) {
+            try (BufferedWriter hgrWriter = new BufferedWriter(new FileWriter(filePath.toFile()));
+                 BufferedWriter eidmapWriter = new BufferedWriter(
+                     new FileWriter(eidmapPath.toFile()))) {
+                // <total edge count> <total node count>
+                hgrWriter.write(edgesMap.size() + " " + leafInsts.size() + "\n");
+                int unnamedCounter = 0; // assign unique ids for unnamed nets
+                for (Entry<EDIFHierNet, Set<EDIFHierCellInst>> entry : edgesMap.entrySet()) {
+                    // Write net name safely even if key is null
+                    // Might be a better way to resolve this?
+                    String netName = (entry.getKey() == null) ? 
+                        "<unnamed_net_" + (++unnamedCounter) + ">" : entry.getKey().toString();
+                    eidmapWriter.write(netName);
+                    eidmapWriter.write("\n");
+                    for (EDIFHierCellInst hierInst : entry.getValue()) {
+                        Integer nodeIdx = leafInsts.get(hierInst);
+                        if (nodeIdx == null) {
+                            throw new RuntimeException(
+                                    "ERROR: Inconsistent netlist, cannot export .hgr.");
+                        }
+                        hgrWriter.write(nodeIdx + " ");
                     }
-                    bw.write(nodeIdx + " ");
+                    hgrWriter.write("\n");
                 }
-                bw.write("\n");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } else {
+            try (BufferedWriter hgrWriter = new BufferedWriter(new FileWriter(filePath.toFile()))) {
+                // <total edge count> <total node count>
+                hgrWriter.write(edgesMap.size() + " " + leafInsts.size() + "\n");
+                for (Entry<EDIFHierNet, Set<EDIFHierCellInst>> entry : edgesMap.entrySet()) {
+                    for (EDIFHierCellInst hierInst : entry.getValue()) {
+                        Integer nodeIdx = leafInsts.get(hierInst);
+                        if (nodeIdx == null) {
+                            throw new RuntimeException(
+                                    "ERROR: Inconsistent netlist, cannot export .hgr.");
+                        }
+                        hgrWriter.write(nodeIdx + " ");
+                    }
+                    hgrWriter.write("\n");
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 
     /**
      * Reads the output of the partitioner and creates a map of the partitions using
      * cell instance names.
-     * 
-     * @param fileName     The file generated from the partitioner to read in.
-     * @param nameMappings The cell instances names stored by their assigned index.
-     * @return A map keyed by partition index to the respective set of cell instance
-     *         names to be included in that partition.
+     * @param solutionFile The partitioner output file to read
+     * @param instLookup Cell instance names by assigned index
+     * @return Map of partition index to instance names
      */
-    public static Map<Integer, Set<String>> readSolutionFile(Path solutionFile, String[] instLookup) {
+    public static Map<Integer, Set<String>> readSolutionFile(Path solutionFile, 
+            String[] instLookup) {
         Map<Integer, Set<String>> partitions = new HashMap<>();
     
-        try (BufferedReader br = new BufferedReader(new FileReader(solutionFile.toFile()))) {
+        try (BufferedReader reader = new BufferedReader(new FileReader(solutionFile.toFile()))) {
             String line = null;
-            int i = 1;
-            while ((line = br.readLine()) != null) {
-                int part = Integer.parseInt(line.trim());
-                Set<String> partition = partitions.computeIfAbsent(part, s -> new HashSet<>());
-                String name = instLookup[i];
-                if (!partition.add(name)) {
+            int lineIndex = 1;
+            while ((line = reader.readLine()) != null) {
+                int partitionId = Integer.parseInt(line.trim());
+                Set<String> set = partitions.computeIfAbsent(partitionId, s -> new HashSet<>());
+                String name = instLookup[lineIndex];
+                if (!set.add(name)) {
                     System.err.println("Found duplicate entry in partition file: " + line);
                 }
-                i++;
+                lineIndex++;
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     
         return partitions;
+    }
+
+    /**
+     * Writes a human-readable connectivity report with net names using:
+     *  - .hgr         edge -> list of vertex IDs
+     *  - .eidmap      edge ID -> net name
+     *  - instLookup   vertex ID -> instance name
+     *  - nameToPart   instance name -> partition index
+     *
+     * output for every net and edge
+     *   <net_id> : <net_name>
+     *     cut=<true|false> partitions={p0:cnt0, p1:cnt1, ...}
+     *     <vid>: <instance_name> p=<partition>
+     * @param hgrFile Path to hypergraph file
+     * @param eidmapFile Path to edge ID mapping file
+     * @param instLookup Vertex ID to instance name mapping
+     * @param nameToPart Instance name to partition mapping
+     * @param netsOut Output path for connectivity report
+     */
+    public static void writeConnectivityReportWithNames(Path hgrFile, Path eidmapFile, String[] 
+            instLookup, Map<String, Integer> nameToPart, Path netsOut) {
+        try (BufferedReader hgrReader = new BufferedReader(new FileReader(hgrFile.toFile()));
+             BufferedReader eidmapReader = new BufferedReader(new FileReader(eidmapFile.toFile()));
+             BufferedWriter reportWriter = new BufferedWriter(new FileWriter(netsOut.toFile()))) {
+
+            // Load eidmap: 1-based edge IDs
+            ArrayList<String> netNames = new ArrayList<>();
+            String line;
+            while ((line = eidmapReader.readLine()) != null) {
+                netNames.add(line);
+            }
+
+            // Read header line from .hgr
+            String header = hgrReader.readLine(); // may be "E V" or "E V fmt"
+            int edgeIdx = 0;
+
+            while ((line = hgrReader.readLine()) != null) {
+                edgeIdx++;
+                String netName = edgeIdx <= netNames.size() ? netNames.get(edgeIdx - 1)
+                        : ("<edge_" + edgeIdx + ">");
+
+                String[] tokens = line.trim().isEmpty() ? 
+                    new String[0] : line.trim().split("\\s+");
+                Map<Integer, Integer> partCounts = new HashMap<>();
+                ArrayList<String> members = new ArrayList<>();
+
+                for (String token : tokens) {
+                    if (token.isEmpty()) continue;
+                    int vertexId;
+                    try {
+                        vertexId = Integer.parseInt(token);
+                    } catch (NumberFormatException numberFormatException) {
+                        continue;
+                    }
+                    String instName = (vertexId >= 0 && vertexId < instLookup.length) ? 
+                        instLookup[vertexId] : null;
+                    Integer partition = (instName == null) ? null : nameToPart.get(instName);
+                    int partitionId = (partition == null) ? -1 : partition.intValue();
+                    partCounts.put(partitionId, partCounts.getOrDefault(partitionId, 0) + 1);
+                    String partitionLabel = (partitionId >= 0) ? 
+                        PartitionLabel.indexToFpgaLabel(partitionId) : "UNASSIGNED";
+                    members.add(String.format("  %d: %s part=%s", 
+                        vertexId, instName, partitionLabel));
+                }
+                boolean cut = partCounts.size() > 1;
+
+                reportWriter.write(String.format("Net %d: %s%n", edgeIdx, netName));
+                // Print blocks with pin counts
+                StringBuilder description = new StringBuilder();
+                description.append("  cut=").append(cut ? "true" : "false").append(" blocks: ");
+                if (partCounts.isEmpty()) {
+                    description.append("none");
+                } else {
+                    java.util.List<java.util.Map.Entry<Integer,Integer>> entries = 
+                        new java.util.ArrayList<>(partCounts.entrySet());
+                    // Sort by block id
+                    entries.sort((a,b) -> Integer.compare(a.getKey(), b.getKey())); 
+                    for (int i = 0; i < entries.size(); i++) {
+                        int blockId = entries.get(i).getKey();
+                        int pinCount = entries.get(i).getValue();
+                        String blockLabel = (blockId >= 0) ? 
+                            PartitionLabel.indexToFpgaLabel(blockId) : "UNASSIGNED";
+                        description.append(blockLabel).append("=").append(pinCount).append(" ")
+                            .append(pinCount == 1 ? "pin" : "pins");
+                        if (i + 1 < entries.size()) description.append(", ");
+                    }
+                }
+                //'blocks' lists how many pins of net are inside each partition
+                //pn is the partition id p2 = partition 2, p0 = partition 0
+                //'p0=1 pin, p1=1 pin' means one pin in p0 and one pin in p1; 
+                //'p6=2 pins' means two pins in p6
+                reportWriter.write(description.toString());
+                reportWriter.write("\n");
+                for (String member : members) {
+                    reportWriter.write(member);
+                    reportWriter.write("\n");
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/src/com/xilinx/rapidwright/edif/partition/Partitioner.java
+++ b/src/com/xilinx/rapidwright/edif/partition/Partitioner.java
@@ -27,6 +27,9 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -39,6 +42,7 @@ import com.xilinx.rapidwright.edif.EDIFHierNet;
 import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFTools;
+import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.MessageGenerator;
 
@@ -47,89 +51,777 @@ import com.xilinx.rapidwright.util.MessageGenerator;
  */
 public class Partitioner {
 
+    /**
+     * Logs current memory usage for debugging.
+     * @param label Description label for the audit point
+     */
+    private static void memAudit(String label) {
+        Runtime rt = Runtime.getRuntime();
+        long total = rt.totalMemory();
+        long free = rt.freeMemory();
+        long used = total - free;
+        PartitionTools.logPartitionerDebug(
+                System.out,
+                "%s -> used=%d MB total=%d MB free=%d MB",
+                label, used / (1024 * 1024), total / (1024 * 1024), free / (1024 * 1024));
+    }
+
+    /**
+     * Creates and returns the default partitioner instance.
+     * @return A new MtKaHyParPartitioner instance
+     */
     public static AbstractPartitioner getDefaultPartitioner() {
         MtKaHyParPartitioner p = new MtKaHyParPartitioner();
         return p;
     }
+
+    /**
+     * Prints command-line usage information to console.
+     */
+    private static void printUsage() {
+        System.out.println("===================================================================");
+        System.out.println("                       RAPIDWRIGHT PARTITIONER");
+        System.out.println("===================================================================");
+        System.out.println();
+        System.out.println("Usage:");
+        System.out.println("  <input.edf|input.dcp>");
+        System.out.println("  <# of partitions>");
+        System.out.println("  <leafLUTCountLimit>");
+        System.out.println();
+        System.out.println("Optional Flags:");
+        System.out.println("  --seed N                    Set seed");
+        System.out.println("  --epsilon E                 Set partition imbalance");
+        System.out.println("  --threads T                 Set number of threads");
+        System.out.println("  --partition_config TYPE     Set preset (default/deterministic)");
+        System.out.println("  --objective OBJ             Set objective (cut/km1/soed)");
+        System.out.println("  --part_dir DIR              Set output directory");
+        System.out.println("  --mapping_constraints PATH  Specify constraints file");
+        System.out.println("  --constraints_debug         Enable constraint debugging");
+        System.out.println("  --skip_detailed_reports     Skip detailed report generation,");
+        System.out.println("                              HIGHLY advised for large designs.");
+        System.out.println();
+        System.out.println("===================================================================");
+    }
     
+    /**
+     * Main entry point for the partitioner tool.
+     * @param args Command-line arguments for partitioning
+     */
     public static void main(String[] args) {
-        if (args.length != 3) {
-            System.out.println("<input.edf> <# of partitions> <leafLUTCountLimit>");
+        if (args.length < 3) {
+            printUsage();
             return;
         }
-        Path inputEDIF = Paths.get(args[0]);
+        Path inputPath = Paths.get(args[0]);
         int k = Integer.parseInt(args[1]);
         int leafLUTCountLimit = Integer.parseInt(args[2]);
         CodePerfTracker t = new CodePerfTracker("Partitioner");
+        
+        boolean generateEdifNets = false; // Human readable hypergraph artifacts
+        Path constraintsFile = null;
+        boolean constraintsDebug = false;
+        boolean skipDetailedReports = false;
+        
 
-        t.start("Read EDIF");
-        EDIFNetlist n = EDIFTools.readEdifFile(inputEDIF);
+
+
+        // ============================================================================
+        // ARGUMENT PARSING & INITIALIZATION
+        // Parses command-line flags and sets up initial configuration variables.
+        // Establishes the output directory where all partition artifacts will be written.
+        // Determines whether to generate detailed reports based on the skip_detailed_reports flag.
+        // ============================================================================
+        Path outDir = (inputPath.getParent() == null)
+                ? Paths.get(System.getProperty("user.dir"))
+                : inputPath.getParent();
+        // parse early flags that affect artifact emission and locations
+        for (int i = 3; i < args.length; i++) {
+            String arg = args[i];
+            if ("--part_dir".equals(arg) && i + 1 < args.length) {
+                outDir = Paths.get(args[++i]);
+            } else if (arg.startsWith("--part_dir=")) {
+                outDir = Paths.get(arg.substring("--part_dir=".length()));
+            } else if ("--mapping_constraints".equals(arg) && i + 1 < args.length) {
+                constraintsFile = Paths.get(args[++i]);
+            } else if (arg.startsWith("--mapping_constraints=")) {
+                constraintsFile = Paths.get(arg.substring("--mapping_constraints=".length()));
+            } else if ("--constraints_debug".equals(arg)) {
+                constraintsDebug = true;
+            } else if (arg.startsWith("--constraints_debug=")) {
+                //used for debugging constrained partition mode.
+                String val = arg.substring("--constraints_debug=".length()).trim();
+                constraintsDebug = "1".equals(val) || "true".equalsIgnoreCase(val) ||
+                        "yes".equalsIgnoreCase(val);
+            } else if ("--skip_detailed_reports".equals(arg)) { //human-readable partition outputs
+                skipDetailedReports = true;
+            } else if (arg.startsWith("--skip_detailed_reports=")) {
+                String val = arg.substring("--skip_detailed_reports=".length()).trim();
+                skipDetailedReports = "1".equals(val) || "true".equalsIgnoreCase(val) ||
+                        "yes".equalsIgnoreCase(val);
+            }
+        }
+        generateEdifNets = !skipDetailedReports;
+        try {
+            Files.createDirectories(outDir);
+        } catch (IOException ioe) {
+            throw new UncheckedIOException(ioe);
+        }
+
+
+
+        // ============================================================================
+        // INPUT READING & VALIDATION
+        // Reads the input design from either a DCP or EDIF file.
+        // Validates that the design is not encrypted, which is unsupported.
+        // Extracts the netlist for partitioning and tracks memory usage.
+        // ============================================================================
+        memAudit("rapidwright mem usg input before");
+        t.start("Read Input");
+        EDIFNetlist netlist;
+        String inLower = inputPath.toString().toLowerCase();
+        if (inLower.endsWith(".dcp")) {
+            Design design = Design.readCheckpoint(inputPath.toString());
+            netlist = design.getNetlist();
+            int encryptedCount = netlist.getEncryptedCells().size();
+            if (encryptedCount > 0) {
+                throw new RuntimeException("ERROR: Encrypted DCP detected (encryptedCells=" + 
+                        encryptedCount + "). Encrypted DCPs are unsupported.");
+            }
+        } else {
+            netlist = EDIFTools.readEdifFile(inputPath);
+        }
         t.stop();
+        memAudit("rapidwright mem usg input after");
 
+
+
+        // ============================================================================
+        // NETLIST COARSENING
+        // Identifies leaf instances in the netlist hierarchy based on the LUT count threshold.
+        // For DCP inputs, backfills missing LUT counts for hierarchical instances.
+        // Validates that the leaf LUT count limit is within acceptable bounds.
+        // ============================================================================
         t.start("Coarsen Netlist");
         Map<EDIFHierCellInst, Integer> instLutCountMap = new HashMap<>();
-        Map<EDIFHierCellInst, Integer> leafInsts = PartitionTools.identifyLeafInstances(n,
+        Map<EDIFHierCellInst, Integer> leafInsts = PartitionTools.identifyLeafInstances(netlist,
                 leafLUTCountLimit, instLutCountMap);
         System.out.println("Identified " + leafInsts.size() + " leaves");
-        int totalLUTs = instLutCountMap.get(n.getTopHierCellInst());
+        {
+            final int SAMPLE_TARGET = 100_000;
+            final int STEP = Math.max(1, leafInsts.size() / SAMPLE_TARGET);
+            long sampledHier = 0;
+            long missingHier = 0;
+            int idx = 0;
+            for (EDIFHierCellInst ci : leafInsts.keySet()) {
+                if ((idx++ % STEP) != 0) continue;
+                if (!ci.getCellType().isLeafCellOrBlackBox()) {
+                    sampledHier++;
+                    if (!instLutCountMap.containsKey(ci)) {
+                        missingHier++;
+                    }
+                }
+            }
+            double pct = sampledHier == 0 ? 0.0 : 100.0 * missingHier / sampledHier;
+            /* 
+             * Reports sampled coverage of missing lut counts among hierarchical 
+             * leaves to confirm incomplete instance coverage
+             */
+            PartitionTools.logPartitionerDebug(
+                    System.out,
+                    "leafInsts coverage -> sampledHier=%d missingHier=%d pct=%.4f step=%d",
+                    sampledHier, missingHier, pct, STEP); 
+        }
+        if (inLower.endsWith(".dcp")) {
+            PartitionTools.logPartitionerDebug(
+                    System.err,
+                    "DCP backfill start -> leafCount=%d",
+                    leafInsts.size());
+            int backfillAttempts = 0;
+            int backfillSuccess = 0;
+            int backfillSkipped = 0;
+            java.util.Map<com.xilinx.rapidwright.edif.EDIFCell, java.lang.Integer> lutCountCache;
+            // Caches LUT counts to avoid expensive re-calculation during backfill process.
+            lutCountCache = new java.util.HashMap<>();
+            for (EDIFHierCellInst leaf : leafInsts.keySet()) {
+                if (!leaf.getCellType().isLeafCellOrBlackBox()) {
+                    if (instLutCountMap.get(leaf) == null) {
+                        backfillAttempts++;
+                        if (backfillAttempts <= 10) {
+                            PartitionTools.logPartitionerDebug(
+                                    System.err,
+                                    "DCP backfill attempt -> instPath=%s cellType=%s",
+                                    leaf.toString(), leaf.getCellType().getName());
+                        }
+                        PartitionTools.getLUTCount(leaf, lutCountCache, instLutCountMap);
+                        if (instLutCountMap.get(leaf) != null) {
+                            backfillSuccess++;
+                            if (backfillSuccess <= 10) {
+                                PartitionTools.logPartitionerDebug(
+                                        System.err,
+                                        "DCP backfill success -> instPath=%s lutCount=%d",
+                                        leaf.toString(), instLutCountMap.get(leaf));
+                            }
+                        }
+                    } else {
+                        backfillSkipped++;
+                    }
+                }
+            }
+            PartitionTools.logPartitionerDebug(
+                    System.err,
+                    "DCP backfill complete -> attempts=%d success=%d skipped=%d",
+                    backfillAttempts, backfillSuccess, backfillSkipped);
+        }
+        int totalLUTs = instLutCountMap.get(netlist.getTopHierCellInst());
         if (leafLUTCountLimit >= totalLUTs || leafLUTCountLimit < 1) {
             throw new RuntimeException("ERROR: Invalid leafLUTCountLimit '" + leafLUTCountLimit
                     + "', must be less than total LUT count in netlist or 1 or greater.");
         }
         t.stop();
 
+
+
+        // ============================================================================
+        // EDGE DISCOVERY
+        // Builds a map of nets (edges) to the instances (vertices) they connect.
+        // Uses parent-level nets to avoid duplication and handle hierarchical connectivity.
+        // Creates the hypergraph structure that will be partitioned.
+        // ============================================================================
         t.start("Find Edges");
         Map<EDIFHierNet, Set<EDIFHierCellInst>> edgesMap = new HashMap<>();
         for (Entry<EDIFHierCellInst, Integer> e : leafInsts.entrySet()) {
             for (EDIFHierPortInst pi : e.getKey().getHierPortInsts()) {
                 EDIFHierNet connectedNet = pi.getHierarchicalNet();
-                EDIFHierNet parentNet = n.getParentNet(connectedNet);
-                if (edgesMap.containsKey(parentNet))
+                // Skip ambiguous nets, TODO: better way to handle this edge case?
+                EDIFHierNet parentNet = null;
+                try {
+                    parentNet = netlist.getParentNet(connectedNet);
+                } catch (RuntimeException ex) {
+                    parentNet = null;
+                }
+                EDIFHierNet keyNet = (parentNet != null) ? parentNet : connectedNet;
+                if (edgesMap.containsKey(keyNet))
                     continue;
-                edgesMap.put(parentNet, connectedNet.getConnectedInsts(leafInsts.keySet()));
+                edgesMap.put(keyNet, connectedNet.getConnectedInsts(leafInsts.keySet())); 
             }
         }
         t.stop();
 
-        t.start("Write hMETIS File");
-        Path hMetisFile = Paths.get(inputEDIF.toString() + ".hgr");
-        PartitionTools.writeHMetisFile(hMetisFile, edgesMap, leafInsts);
-        t.stop();
-        
-        t.start("Run Partitioner");
-        AbstractPartitioner p = getDefaultPartitioner();
-        p.setInputFile(hMetisFile);
-        p.setKPartitions(k);
-        p.runPartitioner();
-        t.stop();
-        
-        t.start("Read Partition Solution");
-        Path outputFile = p.getOutputFile();
-        String[] instLookup = PartitionTools.createInstLookupArray(leafInsts);
-        Map<Integer, Set<String>> partitions = PartitionTools.readSolutionFile(outputFile, instLookup);
 
-        MessageGenerator.printHeader("Partition Solution Report");
-        for (int i = 0; i < partitions.size(); i++) {
-            int lutCount = 0;
-            Set<String> names = partitions.get(i);
-            Path partitionFile = Paths.get(inputEDIF.toString() + ".part" + i);
-            try (BufferedWriter bw = new BufferedWriter(new FileWriter(partitionFile.toFile()))) {
-                for (String name : names) {
-                    bw.write(name + "\n");
-                    EDIFHierCellInst inst = n.getHierCellInstFromName(name);
-                    if (inst.getCellType().isLeafCellOrBlackBox()) {
-                        lutCount += inst.getCellName().contains("LUT") ? 1 : 0;
-                    } else {
-                        lutCount += instLutCountMap.get(inst);
+
+        // ============================================================================
+        // HYPERGRAPH FILE GENERATION
+        // Writes the hypergraph to a .hgr file in hMETIS format for the partitioner.
+        // Optionally generates a .eidmap file mapping edge IDs to net names.
+        // Frees the edge map memory to reduce memory footprint before partitioning.
+        // ============================================================================
+        t.start("Write hMETIS File");
+        Path hMetisFile = outDir.resolve(inputPath.getFileName().toString() + ".hgr");
+        PartitionTools.writeHMetisFile(hMetisFile, edgesMap, leafInsts, generateEdifNets);
+        t.stop();
+
+        //free edgesMap memory after .hgr file is written
+        edgesMap.clear();
+        edgesMap = null;
+        System.gc();
+
+
+
+        // ============================================================================
+        // FIXED VERTICES COMPUTATION
+        // Processes user-provided mapping constraints to fix certain instances to
+        // specific partitions. Matches constraint paths against leaf instances and
+        // assigns partition IDs. Generates a .fix file that tells the partitioner
+        // which vertices are constrained.
+        // ============================================================================
+        Path fixedVertexFile = null; // generate fixed vertices file if constraints were provided
+        if (constraintsFile != null) {
+            // build label->index map
+            java.util.Map<String, Integer> labelToIndex = new java.util.HashMap<>();
+            for (int idx = 0; idx < k; idx++) {
+                String lbl = PartitionLabel.indexToFpgaLabel(idx);
+                labelToIndex.put(lbl, Integer.valueOf(idx));
+            }
+            // init fix array (1-based vertex ids)
+            int numVertices = leafInsts.size();
+            int[] vertexPartitionAssignments = new int[numVertices + 1];
+            for (int i = 0; i <= numVertices; i++) vertexPartitionAssignments[i] = -1;
+            int numFixedVertices = 0;
+
+            // parse mapping_constraints.txt and expand to vertices
+            try (BufferedReader cr = new BufferedReader(new FileReader(constraintsFile.toFile()))) {
+                String cline;
+                while ((cline = cr.readLine()) != null) {
+                    String orig = cline.trim();
+                    if (orig.isEmpty() || orig.startsWith("#")) continue; //comments and blankline
+                    String[] toks = orig.split("\\s+");
+                    if (toks.length != 2) {
+                        throw new RuntimeException(
+                                "constraint '" + orig + "' was not found valid in design");
+                    }
+                    String path = toks[0];
+                    String label = toks[1];
+                    Integer blockIndex = labelToIndex.get(label);
+                    if (blockIndex == null) {
+                        throw new RuntimeException(
+                                "constraint '" + orig + "' was not found valid in design");
+                    }
+                    int matched = 0;
+                    for (Entry<EDIFHierCellInst, Integer> e : leafInsts.entrySet()) {
+                        String name = e.getKey().toString();
+                        int vertex_id = e.getValue().intValue();
+                        boolean leafContainsPath = path.equals(name) || 
+                                path.startsWith(name + "/");
+                        boolean pathContainsLeaf = name.equals(path) || 
+                                name.startsWith(path + "/");
+                        if (leafContainsPath || pathContainsLeaf) {
+                            if (vertexPartitionAssignments[vertex_id] == -1) {
+                                vertexPartitionAssignments[vertex_id] = blockIndex.intValue();
+                                numFixedVertices++;
+                            } else if (vertexPartitionAssignments[vertex_id] != 
+                                    blockIndex.intValue()) {
+                                throw new RuntimeException(
+                                        "constraint '" + orig + "' was not found valid in design");
+                            }
+                            matched++;
+                        }
+                    }
+                    if (constraintsDebug) {
+                        //vertex (LEAF) matches when constraint path is inside leaf
+                        // or leaf is inside the constrained subtree.
+                        System.out.printf(
+                                "partitioner debug: constraint '%s' matched %d vertices%n",
+                                orig, matched);
+                    }
+                    if (matched == 0) {
+                        throw new RuntimeException(
+                                "constraint '" + orig + "' was not found valid in design");
                     }
                 }
-                System.out.printf("  Partition %3d %10d LUTs %s\n", i, lutCount, partitionFile);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+
+            // derive fix file path from .hgr
+            // will show constrained modules to MtKahyPar,
+            // -1 values for unconstrained vertices
+            String hypergraphBasePath = hMetisFile.toString();
+            if (hypergraphBasePath.endsWith(".hgr")) {
+                fixedVertexFile = Paths.get(
+                        hypergraphBasePath.substring(0, hypergraphBasePath.length() - 4) + ".fix");
+            } else {
+                fixedVertexFile = Paths.get(hypergraphBasePath + ".fix");
+            }
+            try (BufferedWriter fw = new BufferedWriter(new FileWriter(fixedVertexFile.toFile()))) {
+                for (int vertex_id = 1; vertex_id <= numVertices; vertex_id++) {
+                    fw.write(Integer.toString(vertexPartitionAssignments[vertex_id]));
+                    fw.write("\n");
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            System.out.printf("partitioner debug: fix-file=%s vertices=%d fixed=%d%n",
+                    fixedVertexFile, leafInsts.size(), numFixedVertices);
         }
-        System.out.println("-----------------------------------------------------------");
-        System.out.printf("        Total : %10d LUTs\n\n\n", totalLUTs);
+        
+
+
+
+        // ============================================================================
+        // PARTITIONER EXECUTION
+        // Configures the external MtKaHyPar partitioning tool with user-specified parameters.
+        // Sets options like seed, epsilon, threads, preset type, and objective function.
+        // Executes the partitioner and tracks memory usage before and after.
+        // ============================================================================
+        t.start("Run Partitioner");
+        AbstractPartitioner partitioner = getDefaultPartitioner();
+        partitioner.setInputFile(hMetisFile);
+        partitioner.setKPartitions(k);
+        // optional args
+        if (partitioner instanceof MtKaHyParPartitioner) {
+            MtKaHyParPartitioner mtPartitioner = (MtKaHyParPartitioner) partitioner;
+            // ensure external tool runs and writes outputs into outDir
+            mtPartitioner.setOutputDir(outDir);
+            // pass fixed vertices file if detected
+            if (fixedVertexFile != null) {
+                mtPartitioner.setFixedVerticesFile(fixedVertexFile);
+            }
+            for (int i = 3; i < args.length; i++) {
+                String arg = args[i];
+                if (arg.equals("--seed") && i + 1 < args.length) {
+                    mtPartitioner.setSeed(Integer.parseInt(args[++i]));
+                } else if (arg.startsWith("--seed=")) {
+                    mtPartitioner.setSeed(Integer.parseInt(arg.substring("--seed=".length())));
+                } else if (arg.equals("--epsilon") && i + 1 < args.length) {
+                    mtPartitioner.setEpsilon(Double.parseDouble(args[++i]));
+                } else if (arg.startsWith("--epsilon=")) {
+                    mtPartitioner.setEpsilon(Double.parseDouble(
+                            arg.substring("--epsilon=".length())));
+                } else if (arg.equals("--threads") && i + 1 < args.length) {
+                    mtPartitioner.setNumThreads(Integer.parseInt(args[++i]));
+                } else if (arg.startsWith("--threads=")) {
+                    mtPartitioner.setNumThreads(Integer.parseInt(
+                            arg.substring("--threads=".length())));
+                } else if (arg.equals("--partition_config") && i + 1 < args.length) {
+                    mtPartitioner.setPresetType(args[++i]);
+                } else if (arg.startsWith("--partition_config=")) {
+                    mtPartitioner.setPresetType(arg.substring("--partition_config=".length()));
+                } else if (arg.equals("--objective") && i + 1 < args.length) {
+                    mtPartitioner.setObjective(args[++i]);
+                } else if (arg.startsWith("--objective=")) {
+                    mtPartitioner.setObjective(arg.substring("--objective=".length()));
+                }
+            }
+            // print user flags summary
+            System.out.printf("Partitioner flag: objective=%s%n", mtPartitioner.getObjective());
+            System.out.printf("Partitioner flag: part_dir=%s%n", outDir);
+            System.out.printf("Partitioner flag: mapping_constraints=%s%n",
+                  constraintsFile != null ? constraintsFile.toString() : "none");
+            System.out.printf("Partitioner flag: skip_detailed_reports=%s%n",
+                    skipDetailedReports ? "on" : "off");
+        }
+        memAudit("rapidwright mem usg before partitioner run");
+        partitioner.runPartitioner();
+        memAudit("rapidwright mem usg after partitioner run");
+        t.stop();
+        
+
+
+
+        // ============================================================================
+        // SOLUTION PROCESSING - BARE BONES MODE
+        // Reads the partition solution and computes per-partition LUT counts
+        // efficiently. Generates minimal output artifacts: io_cuts.txt,
+        // lut_report.txt, cells.txt, and mapping.txt. Skips detailed reports like
+        // .eidmap and .nets.txt to reduce artifact size.
+        // ============================================================================
+        t.start("Read Partition Solution");
+        Path outputFile = partitioner.getOutputFile();
+        String[] instLookup = PartitionTools.createInstLookupArray(leafInsts);
+        Map<Integer, Set<String>> partitions;
+        partitions = PartitionTools.readSolutionFile(outputFile, instLookup);
+        if (skipDetailedReports) {
+            int numVertices = instLookup.length - 1;
+            int[] vertexToPartition = new int[numVertices + 1];
+            try (BufferedReader br = new BufferedReader(new FileReader(outputFile.toFile()))) {
+                String line = null;
+                int i = 1;
+                while ((line = br.readLine()) != null) {
+                    int part = Integer.parseInt(line.trim());
+                    vertexToPartition[i++] = part;
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            EDIFHierCellInst[] instanceByVertexID = new EDIFHierCellInst[numVertices + 1];
+            for (Entry<EDIFHierCellInst, Integer> e : leafInsts.entrySet()) {
+                int vertex_id = e.getValue().intValue();
+                instanceByVertexID[vertex_id] = e.getKey();
+            }
+            int[] lutCountByVertexID = new int[numVertices + 1];
+            int dbgLeafLUTs = 0;
+            int dbgHierLUTs = 0;
+            int dbgHierMissing = 0;
+            int dbgHierFound = 0;
+            java.util.Map<String, Integer> dbgMissingCellTypes = new java.util.HashMap<>();
+            java.util.Map<String, Integer> dbgMissingParentTypes = new java.util.HashMap<>();
+            for (int vertex_id = 1; vertex_id <= numVertices; vertex_id++) {
+                EDIFHierCellInst inst = instanceByVertexID[vertex_id];
+                if (inst == null) continue;
+                if (inst.getCellType().isLeafCellOrBlackBox()) {
+                    lutCountByVertexID[vertex_id] = logicDiscoveryPolicy.leafLutCount(inst);
+                    dbgLeafLUTs += lutCountByVertexID[vertex_id];
+                } else {
+                    Integer cnt = instLutCountMap.get(inst);
+                    lutCountByVertexID[vertex_id] = (cnt == null) ? 0 : cnt.intValue();
+                    dbgHierLUTs += lutCountByVertexID[vertex_id];
+                    if (cnt == null) {
+                        dbgHierMissing++;
+                        String cellType = inst.getCellType().getName();
+                        dbgMissingCellTypes.put(cellType,
+                                dbgMissingCellTypes.getOrDefault(cellType, 0) + 1);
+                        if (inst.getParent() != null) {
+                            String parentType = inst.getParent().getCellType().getName();
+                            dbgMissingParentTypes.put(parentType,
+                                    dbgMissingParentTypes.getOrDefault(parentType, 0) + 1);
+                        }
+                        if (dbgHierMissing <= 10) {
+                            String parentInfo = (inst.getParent() != null) ?
+                                    inst.getParent().getCellType().getName() : "null";
+                            PartitionTools.logPartitionerDebug(
+                                    System.err,
+                                    "skip_detailed_reports hier missing -> vertex_id=%d " +
+                                    "instPath=%s cellType=%s parentType=%s lutCount=0 (missing)",
+                                    vertex_id, inst.toString(),
+                                    inst.getCellType().getName(), parentInfo);
+                        }
+                    } else {
+                        dbgHierFound++;
+                    }
+                }
+            }
+            PartitionTools.logPartitionerDebug(
+                    System.err,
+                    "skip_detailed_reports lutCountByVertexID -> leafLUTs=%d " +
+                            "hierLUTs=%d hierMissing=%d hierFound=%d",
+                    dbgLeafLUTs, dbgHierLUTs, dbgHierMissing, dbgHierFound);
+            if (!dbgMissingCellTypes.isEmpty()) {
+                PartitionTools.logPartitionerDebug(
+                        System.err,
+                        "skip_detailed_reports missing cell types -> uniqueTypes=%d",
+                        dbgMissingCellTypes.size());
+                java.util.List<java.util.Map.Entry<String, Integer>> sorted;
+                sorted = new java.util.ArrayList<>(dbgMissingCellTypes.entrySet());
+                sorted.sort((a, b) -> Integer.compare(b.getValue(), a.getValue()));
+                for (int i = 0; i < Math.min(10, sorted.size()); i++) {
+                    PartitionTools.logPartitionerDebug(
+                            System.err,
+                            "missing cell type -> type=%s count=%d",
+                            sorted.get(i).getKey(), sorted.get(i).getValue());
+                }
+            }
+            if (!dbgMissingParentTypes.isEmpty()) {
+                PartitionTools.logPartitionerDebug(
+                        System.err,
+                        "missing instances parent types -> uniqueParents=%d",
+                        dbgMissingParentTypes.size());
+                java.util.List<java.util.Map.Entry<String, Integer>> sortedParents;
+                sortedParents = new java.util.ArrayList<>(dbgMissingParentTypes.entrySet());
+                sortedParents.sort((a, b) -> Integer.compare(b.getValue(), a.getValue()));
+                for (int i = 0; i < Math.min(10, sortedParents.size()); i++) {
+                    PartitionTools.logPartitionerDebug(
+                            System.err,
+                            "missing parent type -> type=%s childrenMissing=%d",
+                            sortedParents.get(i).getKey(), sortedParents.get(i).getValue());
+                }
+            }
+            Path hgr = outDir.resolve(inputPath.getFileName().toString() + ".hgr");
+            java.util.Map<String, Integer> nameToPartMap = new java.util.LinkedHashMap<>();
+            for (int vertex_id = 1; vertex_id <= numVertices; vertex_id++) {
+                String instanceName = instLookup[vertex_id];
+                if (instanceName != null) {
+                    nameToPartMap.put(instanceName,
+                            Integer.valueOf(vertexToPartition[vertex_id]));
+                }
+            }
+            Map<String, Integer> pairCounts = PartitionPairCounter.countPartitionPairs(
+                    hgr, instLookup, nameToPartMap);
+            Path ioCutsFile = outDir.resolve("io_cuts.txt");
+            PartitionPairCounter.writePairCountsToFile(ioCutsFile, pairCounts);
+            java.util.ArrayList<Integer> lutCounts = new java.util.ArrayList<>();
+            int maxPart = -1;
+            for (int vertex_id = 1; vertex_id <= numVertices; vertex_id++) {
+                int partIndex = vertexToPartition[vertex_id];
+                if (partIndex > maxPart) maxPart = partIndex;
+            }
+            for (int i = 0; i <= maxPart; i++) lutCounts.add(0);
+            for (int vertex_id = 1; vertex_id <= numVertices; vertex_id++) {
+                int partIndex = vertexToPartition[vertex_id];
+                if (partIndex < 0) continue;
+                lutCounts.set(partIndex, lutCounts.get(partIndex) + lutCountByVertexID[vertex_id]);
+            }
+            long sumLuts = 0;
+            for (int c : lutCounts) sumLuts += c;
+            PartitionTools.logPartitionerDebug(
+                    System.err,
+                    "skip_detailed_reports partition sum -> sumLUTs=%d " +
+                            "topLevelTotal=%d diff=%d",
+                    sumLuts, totalLUTs, (sumLuts - totalLUTs));
+            int meanLuts = (lutCounts.isEmpty()) ?
+                    0 : (int) Math.ceil(sumLuts / (double) lutCounts.size());
+            Path lutReport = outDir.resolve("lut_report.txt");
+            try (BufferedWriter lw = new BufferedWriter(new FileWriter(lutReport.toFile()))) {
+                for (int idx = 0; idx < lutCounts.size(); idx++) {
+                    String label = PartitionLabel.indexToFpgaLabel(idx);
+                    lw.write(lutCounts.get(idx) + "LUTS " + label);
+                    lw.write("\n");
+                }
+                lw.write(meanLuts + "LUTS mean");
+                lw.write("\n");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            System.out.println("Partitioner artifact written: " + lutReport);
+            if (sumLuts != totalLUTs) {
+                System.err.printf("ERROR: LUT count policy mismatch: " + 
+                    "per-partitions sum=%d, top-level total=%d%n", sumLuts, totalLUTs);
+            }
+            try {
+                HierMappingWriter.write(outDir, netlist, partitions, instLutCountMap);
+                System.out.println("Partitioner artifact written: " + 
+                    outDir.resolve("cells.txt"));
+                System.out.println("Partitioner artifact written: " + 
+                    outDir.resolve("mapping.txt"));
+            } catch (RuntimeException ex) {
+                System.err.println("WARNING: failed to write hierarchical mapping artifacts: " + 
+                    ex.getMessage());
+            }
+        } else {
+
+
+
+            // ============================================================================
+            // SOLUTION PROCESSING - FULL MODE
+            // Reads the partition solution and writes detailed per-partition instance
+            // files. Computes LUT counts for each partition with fallback recomputation
+            // if needed. Generates comprehensive artifacts including io cuts, nets
+            // report, and hierarchical mappings.
+            // ============================================================================
+            try {
+                IoCutWriter.write(outDir, inputPath, netlist, instLookup, partitions,
+                        generateEdifNets);
+            } catch (RuntimeException ex) {
+                System.err.println("WARNING: failed to write io cuts / nets artifacts: " +
+                        ex.getMessage());
+            }
+            // Caches instance LUT counts to speed up report generation.
+            java.util.Map<String, Integer> lutByName = new java.util.HashMap<>();
+
+            {
+                int mismatches = 0;
+                int maxCheck = Math.min(1000, instLookup.length - 1);
+                for (int j = 1; j <= maxCheck; j++) {
+                    String nm = instLookup[j];
+                    if (nm == null) continue;
+                    if (netlist.getHierCellInstFromName(nm) == null) {
+                        mismatches++;
+                    }
+                }
+                if (mismatches > 0) {
+                    PartitionTools.logPartitionerDebug(
+                            System.err,
+                            "name roundtrip -> mismatches=%d checked=%d",
+                            mismatches, maxCheck);
+                } else {
+                    PartitionTools.logPartitionerDebug(System.out, "name roundtrip -> ok");
+                }
+            }
+            MessageGenerator.printHeader("Partition Solution Report");
+            final int DBG_MAX_MISS_LOGS = 100;
+            int dbgMissingLUTCountTotal = 0;
+            int dbgMissingLUTCountPrinted = 0;
+            int dbgLeafLUTsTotal = 0;
+            int dbgHierLUTsTotal = 0;
+            int dbgRecomputeAttempts = 0;
+            int dbgRecomputeSuccess = 0;
+            int dbgCachedByName = 0;
+            java.util.ArrayList<Integer> lutCounts = new java.util.ArrayList<>();
+            for (int i = 0; i < partitions.size(); i++) {
+                int lutCount = 0;
+                int partLeafLUTs = 0;
+                int partHierLUTs = 0;
+                Set<String> names = partitions.get(i);
+                String partLabel = PartitionLabel.indexToFpgaLabel(i);
+                Path partitionFile = outDir.resolve(
+                        inputPath.getFileName().toString() + "." + partLabel);
+                try (BufferedWriter bw = new BufferedWriter(
+                        new FileWriter(partitionFile.toFile()))) {
+                    for (String name : names) {
+                        bw.write(name + "\n");
+                        EDIFHierCellInst inst = netlist.getHierCellInstFromName(name);
+                        if (inst.getCellType().isLeafCellOrBlackBox()) {
+                            int leafLUTs = logicDiscoveryPolicy.leafLutCount(inst);
+                            lutCount += leafLUTs;
+                            partLeafLUTs += leafLUTs;
+                        } else {
+                            Integer hierLutCount = instLutCountMap.get(inst);
+                            if (hierLutCount == null) {
+                                Integer cached = lutByName.get(name);
+                                if (cached != null) {
+                                    hierLutCount = cached;
+                                    dbgCachedByName++;
+                                }
+                            }
+                            if (hierLutCount == null) {
+                                dbgMissingLUTCountTotal++;
+                                if (dbgMissingLUTCountPrinted < DBG_MAX_MISS_LOGS) {
+                                    PartitionTools.logPartitionerDebug(
+                                            System.err,
+                                            "missing lut count -> name=%s instPath=%s type=%s " +
+                                                    "depth=%d isLeafOrBB=%s",
+                                            name, inst.toString(), inst.getCellType().getName(),
+                                            inst.getDepth(),
+                                            inst.getCellType().isLeafCellOrBlackBox());
+                                    dbgMissingLUTCountPrinted++;
+                                }
+                                dbgRecomputeAttempts++;
+                                Integer recomputed = PartitionTools.getLUTCount(inst,
+                                        new java.util.HashMap<>(), instLutCountMap);
+                                if (recomputed != null) {
+                                    hierLutCount = recomputed;
+                                    lutByName.put(name, hierLutCount);
+                                    dbgRecomputeSuccess++;
+                                }
+                            }
+                            if (hierLutCount == null) {
+                                hierLutCount = 0;
+                            }
+                            lutCount += hierLutCount.intValue();
+                            partHierLUTs += hierLutCount.intValue();
+                        }
+                    }
+                    dbgLeafLUTsTotal += partLeafLUTs;
+                    dbgHierLUTsTotal += partHierLUTs;
+                    System.out.printf("  Partition %3d %10d LUTs %s\n", i, lutCount, partitionFile);
+                    lutCounts.add(Integer.valueOf(lutCount));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+            PartitionTools.logPartitionerDebug(
+                    System.err,
+                    "all partitions -> leafLUTsTotal=%d hierLUTsTotal=%d " +
+                            "cachedByName=%d recomputeAttempts=%d recomputeSuccess=%d",
+                    dbgLeafLUTsTotal, dbgHierLUTsTotal, dbgCachedByName,
+                    dbgRecomputeAttempts, dbgRecomputeSuccess);
+            long sumLuts = 0;
+            for (int c : lutCounts) sumLuts += c;
+            PartitionTools.logPartitionerDebug(
+                    System.err,
+                    "non-skip_detailed_reports partition sum -> " + 
+                        "sumLUTs=%d topLevelTotal=%d diff=%d",
+                        sumLuts, totalLUTs, (sumLuts - totalLUTs));
+
+            int meanLuts = (lutCounts.isEmpty()) ?
+                    0 : (int) Math.ceil(sumLuts / (double) lutCounts.size());
+            Path lutReport = outDir.resolve("lut_report.txt");
+            try (BufferedWriter lw = new BufferedWriter(new FileWriter(lutReport.toFile()))) {
+                for (int idx = 0; idx < lutCounts.size(); idx++) {
+                    String label = PartitionLabel.indexToFpgaLabel(idx);
+                    lw.write(lutCounts.get(idx) + "LUTS " + label);
+                    lw.write("\n");
+                }
+                lw.write(meanLuts + "LUTS mean");
+                lw.write("\n");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            System.out.println("Partitioner artifact written: " + lutReport);
+            if (sumLuts != totalLUTs) {
+                System.err.printf(
+                        "ERROR: LUT count policy mismatch: per-partitions sum=%d, " +
+                                "top-level total=%d%n",
+                        sumLuts, totalLUTs);
+            }
+            PartitionTools.logPartitionerDebug(
+                    System.out,
+                    "missing lut count summary -> total=%d printed=%d limit=%d",
+                    dbgMissingLUTCountTotal, dbgMissingLUTCountPrinted, DBG_MAX_MISS_LOGS);
+            System.out.println("-----------------------------------------------------------");
+            System.out.printf("        Total : %10d LUTs\n\n\n", totalLUTs);
+
+            try {
+                HierMappingWriter.write(outDir, netlist, partitions, instLutCountMap);
+                System.out.println("Partitioner artifact written: " +
+                        outDir.resolve("cells.txt"));
+                System.out.println("Partitioner artifact written: " +
+                        outDir.resolve("mapping.txt"));
+            } catch (RuntimeException ex) {
+                System.err.println("WARNING: failed to write hierarchical " +
+                        "mapping artifacts: " + ex.getMessage());
+            }
+        }
+
         t.stop();
         t.printSummary();
     }

--- a/src/com/xilinx/rapidwright/edif/partition/logicDiscoveryPolicy.java
+++ b/src/com/xilinx/rapidwright/edif/partition/logicDiscoveryPolicy.java
@@ -1,0 +1,108 @@
+/*
+ *
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif.partition;
+
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+
+/**
+ * logicDiscoveryPolicy is a source-of-truth utility for
+ * discovering logic-related properties in the EDIF/DCP domain.
+ * For example, determining if a cell is a look up table.
+ */
+public final class logicDiscoveryPolicy {
+
+    // List of protected names that should be excluded from mapping generation. 
+    // GND and VCC will be re-created locally in the partition / module as needed,
+    // GND, VCC should not be results you see in mapping.txt
+    private static final java.util.LinkedHashSet<String> EXCLUSION_NAMES =
+            new java.util.LinkedHashSet<>(java.util.Arrays.asList(
+                    "VCC", "GND", "<const0>", "<const1>"
+            ));
+
+    private logicDiscoveryPolicy() {
+        // no instances
+    }
+
+
+    /**
+     * Returns true if a cell type name represents a LUT used as logic.
+     * 
+     * Treat any cell type whose name contains "LUT" as a logic LUT.
+     * substring match to be consistent with legacy policy.
+     * 
+     * TODO : More concrete & fact-checked discovery policy?
+     * @param type_name The cell type name to check
+     * @return True if the type name contains "LUT"
+     */
+    public static boolean isLogicLUT(String type_name) {
+        if (type_name == null) return false;
+        return type_name.contains("LUT");
+    }
+
+    /**
+     * Returns 1 if the given instance is a leaf and its type is a LUT.
+     * @param inst The hierarchical cell instance to check
+     * @return 1 if leaf LUT, 0 otherwise
+     */
+    public static int leafLutCount(EDIFHierCellInst inst) {
+        if (inst == null) return 0;
+        if (!inst.getCellType().isLeafCellOrBlackBox()) return 0;
+        boolean is_lut = isLogicLUT(inst.getCellType().getName());
+        return is_lut ? 1 : 0;
+    }
+
+    /**
+     * Checks if a token should be excluded from processing.
+     * @param s The token string to check
+     * @return True if token is VCC, GND, or similar
+     */
+    public static boolean isExcludedToken(String s) {
+        if (s == null) {
+            return false;
+        }
+        if (EXCLUSION_NAMES.contains(s)) {
+            return true;
+        }
+        String t = s.toLowerCase(java.util.Locale.ROOT);
+        return "vcc".equals(t) || "gnd".equals(t);
+    }
+
+    /**
+     * Checks if a hierarchical path contains any excluded segments.
+     * @param path The hierarchical path to check
+     * @return True if path contains excluded segments
+     */
+    public static boolean pathHasExcludedSegment(String path) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+        String[] segs = path.split("/");
+        for (String seg : segs) {
+            if (isExcludedToken(seg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/com/xilinx/rapidwright/util/LUTCount.java
+++ b/src/com/xilinx/rapidwright/util/LUTCount.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Perry Newlin
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFHierCellInst;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import com.xilinx.rapidwright.edif.partition.PartitionTools;
+
+/**
+ * CLI utility to count logic LUT usage from EDIF (.edf/.edif) or Vivado DCP (.dcp).
+ */
+public final class LUTCount {
+
+    private LUTCount() {
+        // no instances
+    }
+
+    /**
+     * Prints usage information.
+     */
+    private static void usage() {
+        System.out.println("Usage:");
+        System.out.println("  LUTCount <input.edf|input.dcp>");
+        System.out.println();
+        System.out.println("Examples:");
+        System.out.println("  rapidwright LUTCount design.edf");
+        System.out.println("  rapidwright LUTCount design.dcp");
+    }
+
+    /**
+     * Main entry point.
+     *
+     * @param args Command line arguments.
+     */
+    public static void main(String[] args) {
+        if (args.length != 1) {
+            usage();
+            return;
+        }
+
+        Path inputPath = Paths.get(args[0]);
+
+        // read netlist (EDIF or DCP)
+        EDIFNetlist netlist;
+        boolean isDcp = inputPath.toString().toLowerCase().endsWith(".dcp");
+        if (isDcp) {
+            Design design = Design.readCheckpoint(inputPath.toString());
+            netlist = design.getNetlist();
+            int encryptedCount = netlist.getEncryptedCells().size();
+            if (encryptedCount > 0) {
+                System.err.println("ERROR: Encrypted DCP detected (encryptedCells="
+                        + encryptedCount + "). Encrypted DCPs are unsupported.");
+                System.exit(1);
+            }
+        } else {
+            netlist = EDIFTools.readEdifFile(inputPath);
+        }
+
+        // compute logic-only LUT count via PartitionTools aggregation
+        EDIFHierCellInst topInst = netlist.getTopHierCellInst();
+        Map<EDIFCell, Integer> lutCache = new HashMap<>();
+        int logicLuts = PartitionTools.getLUTCount(topInst, lutCache, null);
+
+        System.out.println("-----------------------------------------------------------");
+        System.out.println("LUT Count Report");
+        System.out.println("Input     : " + inputPath);
+        System.out.println("-----------------------------------------------------------");
+        System.out.printf("Logic LUTs: %d%n", logicLuts);
+    }
+
+}


### PR DESCRIPTION
A series of QoL features and additions to the partitioner branch.

- Added hierarchical mapping output (mapping.txt), if an entire submodule `TOP/Counter` is wholly contained in partition 1 (FPGA_B) then produce only one line `TOP/Counter FPGA_B`
- Added _optional_ human readable hypergraph reports. After a partition a user can easily see which nets have been cut and their names.
- Added a dedicated LUT report .txt file output which shows how many LUTs have been assigned per partition.
- Exposed KaHyPar hypergraph switches to command line interface
- Added partition constraints, this allows the user to specify a mapping constraint which KaHyPar will interpret as a .fix input for assigning some submodule to exactly one partition.  
- Changed partition naming to be FPGA_<...>.
- Added a cells.txt output which displays every partition name. 
- Added command line interface option to specify output location of partition.
- Relocated the LUT counting functionality to a single location (source of truth)
- Added verbose logging to partition process to display caught edge cases and memory usage.
- Enabled KaHyPar verbose timing output.
- Added partition support for .DCP input.
- Added read netlist command line interface tool. Allows user to test memory usage on monolithic netlists.
- Added LUT count command line interface tool. Allows user to provide a netlist and RapidWright will return total LUT count of top level.