### PR TITLE
Add test case for fixes to getCorrespondingTile when called on certain SLL tiles

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -1454,8 +1454,10 @@ public class DesignTools {
             String lut6 = bel.getName().replace('5', '6');
             if (siteInst.getCell(lut6) == null) {
                 SitePinInst a6Spi = siteInst.getSitePinInst(lut6.substring(0,2));
-                siteInst.unrouteIntraSiteNet(a6Spi.getBELPin(), siteInst.getBELPin(lut6, "A6"));
-                handlePinRemovals(a6Spi, deferRemovals);
+                if (a6Spi != null) {
+                    siteInst.unrouteIntraSiteNet(a6Spi.getBELPin(), siteInst.getBELPin(lut6, "A6"));
+                    handlePinRemovals(a6Spi, deferRemovals);
+                }
             }
         }
 

--- a/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
+++ b/test/src/com/xilinx/rapidwright/design/TestDesignTools.java
@@ -35,7 +35,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.xilinx.rapidwright.device.Node;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -47,6 +46,7 @@ import com.xilinx.rapidwright.design.blocks.UtilizationType;
 import com.xilinx.rapidwright.device.BEL;
 import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.device.Site;
@@ -1712,5 +1712,25 @@ public class TestDesignTools {
         if (isVersal) {
             Assertions.assertTrue(si.getNetFromSiteWire("FF_CLK_MOD_CLK_OUT").isGNDNet());
         }
+    }
+
+    @Test
+    public void testFullyUnplaceCell() {
+        Design d = RapidWrightDCP.loadDCP("microblazeAndILA_3pblocks.dcp");
+
+        // Placed on a B5LUT where the B6LUT is unoccupied
+        Cell c = d.getCell("base_mb_i/mdm_1/U0/MDM_Core_I1/JTAG_CONTROL_I/Use_Serial_Unified_Completion.count[2]_i_1");
+        
+        // Manufacturing a scenario where the A6 input pin is not there, seen in another design
+        SiteInst si = c.getSiteInst();
+        SitePinInst spi = si.getSitePinInst("B6");
+        Assertions.assertTrue(spi.getNet().isVCCNet());
+        spi.getNet().removePin(spi, true);
+        si.removePin(spi);
+        
+        DesignTools.fullyUnplaceCell(c, null);
+        
+        Assertions.assertFalse(c.isPlaced());
+        Assertions.assertNull(c.getBEL());
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestModule.java
+++ b/test/src/com/xilinx/rapidwright/design/TestModule.java
@@ -23,11 +23,11 @@
 
 package com.xilinx.rapidwright.design;
 
+import com.xilinx.rapidwright.device.Device;
+import com.xilinx.rapidwright.device.Tile;
+import com.xilinx.rapidwright.examples.AddSubGenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import com.xilinx.rapidwright.device.Device;
-import com.xilinx.rapidwright.examples.AddSubGenerator;
 
 public class TestModule {
 
@@ -55,5 +55,18 @@ public class TestModule {
 
         Assertions.assertTrue(slrAdder.isValidPlacement(slrAdder.getAnchor(), top));
         Assertions.assertFalse(slrAdder.isValidPlacement(noSLRAdder.getAnchor(), top));
+    }
+
+    @Test
+    public void testCorrespondingSLLTile() {
+        Device v80 = Device.getDevice("xcv80");
+
+        Tile templateTile = v80.getTile("SLL_X23Y886");
+        Tile originalAnchor = v80.getTile("CLE_W_CORE_X22Y886");
+        Tile newAnchorTile = v80.getTile("CLE_W_CORE_X23Y900");
+        Tile newTile = Module.getCorrespondingTile(templateTile, newAnchorTile, originalAnchor);
+
+        Assertions.assertNotNull(newTile);
+        Assertions.assertEquals("SLL_1_X23Y900", newTile.getName());
     }
 }

--- a/test/src/com/xilinx/rapidwright/design/TestModule.java
+++ b/test/src/com/xilinx/rapidwright/design/TestModule.java
@@ -58,9 +58,10 @@ public class TestModule {
     }
 
     @Test
-    public void testCorrespondingSLLTile() {
+    public void testGetCorrespondingTile() {
         Device v80 = Device.getDevice("xcv80");
 
+        // Testing for SLL to SLL_1 special case because they have the same tile type but overlapping X,Y grids
         Tile templateTile = v80.getTile("SLL_X23Y886");
         Tile originalAnchor = v80.getTile("CLE_W_CORE_X22Y886");
         Tile newAnchorTile = v80.getTile("CLE_W_CORE_X23Y900");


### PR DESCRIPTION
Some Versal devices contain both SLL and SLL_1 tile name roots, even though both name roots have the same tile type (SLL). These different tile name roots have overlapping coordinates, so there can be an SLL tile and an SLL_1 tile with the same X, Y coordinates. This is a test for a change  to the rapidwright-api that allows SLL tiles to be relocated to SLL_1 tiles and vice versa, creating more opportunities for module relocation.