### PR TITLE
Correctly handle NOC clock pins when routing

### DIFF
--- a/src/com/xilinx/rapidwright/router/VersalClockRouting.java
+++ b/src/com/xilinx/rapidwright/router/VersalClockRouting.java
@@ -588,14 +588,14 @@ public class VersalClockRouting {
             }
             NodeWithPrev sink = new NodeWithPrev(p.getConnectedNode());
             ClockRegion cr = p.getTile().getClockRegion();
-            boolean isPSSink = Utils.isPS(p.getSiteInst());
+            boolean crossCRSink = Utils.isPS(p.getSiteInst()) || Utils.isNOC(p.getSiteInst());
             q.clear();
             q.add(sink);
 
             while (!q.isEmpty()) {
                 NodeWithPrev curr = q.poll();
                 for (Node uphill : curr.getAllUphillNodes()) {
-                    if (!isPSSink && !uphill.getTile().getClockRegion().equals(cr)) {
+                    if (!crossCRSink && !uphill.getTile().getClockRegion().equals(cr)) {
                         continue;
                     }
                     IntentCode uphillIntentCode = uphill.getIntentCode();

--- a/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
+++ b/src/com/xilinx/rapidwright/rwroute/GlobalSignalRouting.java
@@ -449,11 +449,19 @@ public class GlobalSignalRouting {
             if (pin.isOutPin()) continue;
             Tile t = pin.getTile();
             ClockRegion cr = t.getClockRegion();
-            if (Utils.isIOB(pin.getSiteInst())) {
+            SiteInst si = pin.getSiteInst();
+            if (Utils.isIOB(si)) {
                 offFabricClkSinks.add(pin);
-            } else if (Utils.isPS(pin.getSiteInst())) {
+            } else if (Utils.isPS(si)) {
                 // PS clock input will be driven by East CR neighbor
                 clockRegions.add(cr.getNeighborClockRegion(0, 1));
+            } else if (Utils.isNOC(si)) {
+                // NOC sites might also need to look at neighbors for LCB 
+                clockRegions.add(cr);
+                for (int dx : new int[] {1, -1}) {
+                    ClockRegion neighbor = cr.getNeighborClockRegion(0, dx);
+                    if (neighbor != null) clockRegions.add(neighbor);
+                }
             } else {
                 clockRegions.add(cr);
             }

--- a/src/com/xilinx/rapidwright/util/Utils.java
+++ b/src/com/xilinx/rapidwright/util/Utils.java
@@ -75,6 +75,8 @@ public class Utils{
 
     public static Set<SiteTypeEnum> psTypes;
 
+    public static Set<SiteTypeEnum> nocTypes;
+
     /**
      * Returns a SiteTypeEnum enum based on the given string. If such
      * an enum does not exist, it will return null.
@@ -188,6 +190,10 @@ public class Utils{
         return psTypes.contains(type);
     }
 
+    public static boolean isNOCSiteType(SiteTypeEnum type) {
+        return nocTypes.contains(type);
+    }
+
     public static Set<TileTypeEnum> getIntTileTypes() {
         return interconnects;
     }
@@ -232,6 +238,10 @@ public class Utils{
         return psTypes;
     }
 
+    public static Set<SiteTypeEnum> getNOCTypes() {
+        return nocTypes;
+    }
+
     public static boolean isSLICE(SiteInst s) {
         return sliceTypes.contains(s.getSiteTypeEnum());
     }
@@ -266,6 +276,14 @@ public class Utils{
 
     public static boolean isPS(SiteTypeEnum s) {
         return psTypes.contains(s);
+    }
+
+    public static boolean isNOC(SiteInst s) {
+        return nocTypes.contains(s.getSiteTypeEnum());
+    }
+
+    public static boolean isNOC(SiteTypeEnum s) {
+        return nocTypes.contains(s);
     }
 
     static{
@@ -458,6 +476,24 @@ public class Utils{
         psTypes.add(SiteTypeEnum.PS8);
         psTypes.add(SiteTypeEnum.PS9);
         psTypes.add(SiteTypeEnum.PS11);
+
+        nocTypes = EnumSet.of(
+            SiteTypeEnum.NOC_HBM_BLI_SCAN,
+            SiteTypeEnum.NOC_NCRB,
+            SiteTypeEnum.NOC_NCRB_SSIT,
+            SiteTypeEnum.NOC_NIDB,
+            SiteTypeEnum.NOC_NMU128,
+            SiteTypeEnum.NOC_NMU512,
+            SiteTypeEnum.NOC_NMU_HBM2E,
+            SiteTypeEnum.NOC_NPP_RPTR,
+            SiteTypeEnum.NOC_NPS4,
+            SiteTypeEnum.NOC_NPS5555,
+            SiteTypeEnum.NOC_NPS6,
+            SiteTypeEnum.NOC_NPS7575,
+            SiteTypeEnum.NOC_NPS_VNOC,
+            SiteTypeEnum.NOC_NSU128,
+            SiteTypeEnum.NOC_NSU512
+        );
     }
 
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestGlobalSignalRouting.java
@@ -426,6 +426,38 @@ public class TestGlobalSignalRouting {
     }
 
     @Test
+    public void testVersalNocClockRouting() {
+        // Test for NOC clock routing compatibility as LCBs might be in neighboring CRs
+        Design design = new Design("versal_noc_clk", "xcv80-lsva4737-2MHP-e-S");
+        EDIFCell top = design.getTopEDIFCell();
+
+        Net clk = design.createNet("clk");
+        Net clkIn = design.createNet("clkIn");
+        Net vcc = design.getVccNet();
+
+        clkIn.getLogicalNet().createPortInst(top.createPort(clkIn.getName(), EDIFDirection.INPUT, 1));
+        Cell bufgce = createBUFGCE(design, top, "bufgceInst", design.getDevice().getSite("BUFGCE_X2Y0"));
+        clkIn.connect(bufgce, "I");
+        clk.connect(bufgce, "O");
+        vcc.connect(bufgce, "CE");
+
+        Site nocSite = design.getDevice().getSite("NOC_NSU512_X3Y18");
+        Cell nsu = design.createAndPlaceCell("nsu", Unisim.NOC_NSU512, nocSite.getName() + "/NSU");
+        clk.connect(nsu, "CLK");
+
+        design.routeSites();
+        design.setAutoIOBuffers(false);
+        design.setDesignOutOfContext(true);
+
+        GlobalSignalRouting.symmetricClkRouting(clk, design.getDevice(),
+                (n) -> NodeStatus.AVAILABLE, null);
+
+        SitePinInst nocClkPin = nsu.getSiteInst().getSitePinInst("CLK");
+        Assertions.assertNotNull(nocClkPin, "NOC CLK SitePinInst should exist");
+        Assertions.assertFalse(clk.getPIPs().isEmpty(), "Clock net should have PIPs after routing");
+    }
+
+    @Test
     public void testVersalVDistrClockRouting() {
         Design d = genTestDesignForVersalClockRouting();
 


### PR DESCRIPTION
This is a potential fix for the second issue described in #1364.

NOC site types have clock pins that can be fed from neighboring clock region columns and must be handled in a similar way to PS sites.  This identifies when a NOC instance clock pin is being routed to and includes neighboring CRs accordingly.  
