### PR TITLE
[RWRoute] On Versal, preserve node uphill of sink SPIs

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/Connection.java
+++ b/src/com/xilinx/rapidwright/rwroute/Connection.java
@@ -472,9 +472,9 @@ public class Connection implements Comparable<Connection>{
         s.append(", ");
         s.append(String.format("net fanout = %3s", netWrapper.getConnections().size()));
         s.append(", ");
-        s.append(String.format("source = %s", getSource().getName()));
+        s.append(String.format("source = %s", getSource().getSitePinName()));
         s.append(", ");
-        s.append("sink = " + getSink().getName());
+        s.append("sink = " + getSink().getSitePinName());
         s.append(", ");
         s.append(String.format("delay = %4d ", (short)(getTimingEdges() == null? 0:getTimingEdges().get(0).getNetDelay())));
         s.append(", ");

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -250,6 +250,10 @@ public class PartialRouter extends RWRoute {
             assert(sinkRnode.getType().isAnyExclusiveSink());
             preservedNet = routingGraph.getPreservedNet(sinkRnode);
             if (preservedNet != null && preservedNet != net) {
+                if (preservedNet.isStaticNet()) {
+                    System.err.println("ERROR: Unable to unpreserve " + preservedNet + " to allow " + connection.getSink().getSitePinName() + " to be reached. Expect unrouteable connection.");
+                    continue;
+                }
                 unpreserveNets.add(preservedNet);
             }
         }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -611,7 +611,16 @@ public class RouteNodeGraph {
     public void preserve(Net net, List<SitePinInst> pins) {
         boolean isStaticNet = net.isStaticNet();
         for (SitePinInst pin : pins) {
-            preserve(pin.getConnectedNode(), net);
+            Node spiNode = pin.getConnectedNode();
+            if (isVersal) {
+                // On Versal, spiNode gives the "*_PIN" node. Preserve the one and only
+                // node uphill of that, which is the "IMUX_*" or "BOUNCE_*"
+                List<Node> uphillNodes = spiNode.getAllUphillNodes();
+                assert(uphillNodes.size() == 1);
+                preserve(uphillNodes.get(0), net);
+            } else {
+                preserve(spiNode, net);
+            }
 
             if (isStaticNet && pin.isOutPin()) {
                 // When a LUT output is used as a static source, also preserve the other pin

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -611,16 +611,15 @@ public class RouteNodeGraph {
     public void preserve(Net net, List<SitePinInst> pins) {
         boolean isStaticNet = net.isStaticNet();
         for (SitePinInst pin : pins) {
-            Node spiNode = pin.getConnectedNode();
-            if (isVersal) {
+            Node preserveNode = pin.getConnectedNode();
+            if (isVersal && !pin.isOutPin()) {
                 // On Versal, spiNode gives the "*_PIN" node. Preserve the one and only
                 // node uphill of that, which is the "IMUX_*" or "BOUNCE_*"
-                List<Node> uphillNodes = spiNode.getAllUphillNodes();
+                List<Node> uphillNodes = preserveNode.getAllUphillNodes();
                 assert(uphillNodes.size() == 1);
-                preserve(uphillNodes.get(0), net);
-            } else {
-                preserve(spiNode, net);
+                preserveNode = uphillNodes.get(0);
             }
+            preserve(preserveNode, net);
 
             if (isStaticNet && pin.isOutPin()) {
                 // When a LUT output is used as a static source, also preserve the other pin

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -765,7 +765,7 @@ public class TestRWRoute {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testPartialRouteEnsureSinkRoutabilityStatic(boolean preserveInner) {
+    public void testPartialRouterEnsureSinkRoutabilityStatic(boolean preserveInner) {
         Design design = new Design("top", "xcv80");
 
         Net net = design.createNet("net");
@@ -785,9 +785,43 @@ public class TestRWRoute {
 
         List<SitePinInst> pinsToRoute = new ArrayList<>();
         pinsToRoute.add(dstSpi);
-        boolean softPreserve = false;
-        PartialRouter.routeDesignPartialNonTimingDriven(design, pinsToRoute, softPreserve);
+        PartialRouter.routeDesignPartialNonTimingDriven(design, pinsToRoute);
         Assertions.assertFalse(dstSpi.isRouted());
         Assertions.assertFalse(net.hasPIPs());
+    }
+
+    @Test
+    public void testPartialRouterPreservesOuterNode() {
+        Design design = new Design("top", "xcv80");
+
+        // This is the signal sink, the node(s) to which should not be claimed by static routing
+        Net signalNet = design.createNet("net");
+        SiteInst signalSi = design.createSiteInst("SLICE_X94Y621");
+        SitePinInst signalSpi = signalNet.createPin("DX", signalSi);
+
+        Device device = design.getDevice();
+        Net Z_NET = design.createNet(Net.Z_NET);
+
+        // Block these nodes so that there's only one path
+        // Z_NET.addPIP(device.getNode("INT_X29Y625/INT_NODE_IMUX_ATOM_119_INT_OUT1").getAllUphillPIPs().get(0)); // Force signal through this node
+        Z_NET.addPIP(device.getNode("INT_X29Y625/INT_NODE_IMUX_ATOM_122_INT_OUT0").getAllUphillPIPs().get(0));
+        Z_NET.addPIP(device.getNode("INT_X29Y625/INT_NODE_IMUX_ATOM_125_INT_OUT0").getAllUphillPIPs().get(0));
+        Z_NET.addPIP(device.getNode("INT_X29Y625/INT_NODE_IMUX_ATOM_53_INT_OUT1").getAllUphillPIPs().get(0));
+        Z_NET.addPIP(device.getNode("INT_X29Y625/INT_NODE_IMUX_ATOM_57_INT_OUT1").getAllUphillPIPs().get(0));
+        Z_NET.addPIP(device.getNode("INT_X29Y625/INT_NODE_IMUX_ATOM_60_INT_OUT0").getAllUphillPIPs().get(0));
+
+        Z_NET.addPIP(device.getNode("SLL_X29Y625/BNODE_OUTS_E0").getAllUphillPIPs().get(0));
+        // Z_NET.addPIP(device.getNode("INT_X29Y625/BOUNCE_W2").getAllUphillPIPs().get(0)); // Force signal through this node (which is signalSpi)
+        Z_NET.addPIP(device.getNode("INT_X28Y625/OUT_EE1_E_BEG12").getAllUphillPIPs().get(0));
+        Z_NET.addPIP(device.getNode("INT_X29Y626/OUT_SS4_W_BEG6").getAllUphillPIPs().get(0));
+        Z_NET.addPIP(device.getNode("INT_X29Y626/OUT_SS1_W_BEG12").getAllUphillPIPs().get(0));
+        Z_NET.addPIP(device.getNode("INT_X30Y625/OUT_WW2_W_BEG6").getAllUphillPIPs().get(0));
+
+        Net gndNet = design.getGndNet();
+        SiteInst gndSi = design.createSiteInst("SLICE_X95Y621");
+        SitePinInst gndSpi = gndNet.createPin("HX", gndSi);
+        PartialRouter.routeDesignPartialNonTimingDriven(design, Collections.singletonList(gndSpi));
+        Assertions.assertFalse(gndSpi.isRouted());
+        Assertions.assertFalse(gndNet.hasPIPs());
     }
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -762,4 +762,32 @@ public class TestRWRoute {
         }
         Assertions.assertEquals(expectRoutethru, routethruFound);
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPartialRouteEnsureSinkRoutabilityStatic(boolean preserveInner) {
+        Design design = new Design("top", "xcv80");
+
+        Net net = design.createNet("net");
+        SiteInst si = design.createSiteInst("SLICE_X95Y621");
+        SitePinInst srcSpi = net.createPin("A_O", si);
+        SitePinInst dstSpi = net.createPin("A_I", si);
+
+        Net gndNet = design.getGndNet();
+        Node preserveNode = dstSpi.getConnectedNode();
+        if (!preserveInner) {
+            List<Node> uphillNodes = preserveNode.getAllUphillNodes();
+            Assertions.assertEquals(1, uphillNodes.size());
+            preserveNode = uphillNodes.get(0);
+        }
+        List<PIP> uphillPIPs = preserveNode.getAllUphillPIPs();
+        gndNet.addPIP(uphillPIPs.get(0));
+
+        List<SitePinInst> pinsToRoute = new ArrayList<>();
+        pinsToRoute.add(dstSpi);
+        boolean softPreserve = false;
+        PartialRouter.routeDesignPartialNonTimingDriven(design, pinsToRoute, softPreserve);
+        Assertions.assertFalse(dstSpi.isRouted());
+        Assertions.assertFalse(net.hasPIPs());
+    }
 }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -786,6 +786,11 @@ public class TestRWRoute {
         List<SitePinInst> pinsToRoute = new ArrayList<>();
         pinsToRoute.add(dstSpi);
         PartialRouter.routeDesignPartialNonTimingDriven(design, pinsToRoute);
+
+        // Check that dstSpi does not get routed because its
+        // inner or outer node is preserved for the ground net.
+        // Check also that an assertion doesn't fire, but this test
+        // is not able to verify that an "ERROR" message gets emitted.
         Assertions.assertFalse(dstSpi.isRouted());
         Assertions.assertFalse(net.hasPIPs());
     }

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -773,6 +773,8 @@ public class TestRWRoute {
         SitePinInst srcSpi = net.createPin("A_O", si);
         SitePinInst dstSpi = net.createPin("A_I", si);
 
+        // Attach either the inner or outer connected node 
+        // of the dstSpi above to the gnd net
         Net gndNet = design.getGndNet();
         Node preserveNode = dstSpi.getConnectedNode();
         if (!preserveInner) {

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -821,6 +821,9 @@ public class TestRWRoute {
         SiteInst gndSi = design.createSiteInst("SLICE_X95Y621");
         SitePinInst gndSpi = gndNet.createPin("HX", gndSi);
         PartialRouter.routeDesignPartialNonTimingDriven(design, Collections.singletonList(gndSpi));
+
+        // Make sure the ground sink is not routed, since INT_X29Y625/BOUNCE_W2
+        // is now reserved for signalSpi
         Assertions.assertFalse(gndSpi.isRouted());
         Assertions.assertFalse(gndNet.hasPIPs());
     }


### PR DESCRIPTION
... uphill of `SitePinInst.getConnectedNode()` since this only gives the `*_PIN` node. We actually want to preserve its (one and only) uphill node instead -- `IMUX_*` or `BOUNCE_*`:

<img width="1297" height="842" alt="image" src="https://github.com/user-attachments/assets/1e8dd3b0-e9d1-457c-b763-c985ce6ecfc4" />

(tooltip is from hovering over the "inner" node which is the `*_PIN`)

Also:
- `Connection.toString()` to emit `<SiteName>.<PinName>` rather than just `<PinName>`
- `PartialRouter.ensureSinkRoutability()` to not `AssertionError` when asked to unpreserve a static net; print an ERROR out instead.