### PR TITLE
[Params] Adds parameters to control how readable EDIF is extracted when DCP is loaded

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -33,9 +33,9 @@
 	<classpathentry kind="lib" path="jars/kryo-5.2.1.jar"/>
 	<classpathentry kind="lib" path="jars/minlog-1.3.1.jar"/>
 	<classpathentry kind="lib" path="jars/jython-standalone-2.7.2.jar"/>
-	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2025.2.2-rc4.jar">
+	<classpathentry kind="lib" path="jars/rapidwright-api-lib-2025.2.2-rc5.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2025.2.2-rc4-javadoc.jar!/"/>
+			<attribute name="javadoc_location" value="jar:platform:/resource/RapidWright/jars/rapidwright-api-lib-2025.2.2-rc5-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="jars/jgrapht-core-1.3.0.jar"/>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RAPIDWRIGHT_VERSION: v2025.2.2-rc4-beta
+  RAPIDWRIGHT_VERSION: v2025.2.2-rc5-beta
 
 
 jobs:

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -561,27 +561,38 @@ public class RouteNodeGraph {
 
     private Net preserve(Tile tile, int wireIndex, Net net) {
         // Assumes that tile/wireIndex describes the base wire on the node
-        // No need to synchronize access to 'nets' since collisions are not expected
         int tileAddress = tile.getUniqueAddress();
-        Net[] nets;
         while (true) {
-            nets = preservedMap.get(tileAddress);
-            if (nets != null && wireIndex < nets.length) {
-                break;
+            Net[] nets = preservedMap.get(tileAddress);
+            if (nets == null) {
+                Net[] newNets = new Net[wireIndex + 1];
+                if (preservedMap.compareAndSet(tileAddress, null, newNets)) {
+                    nets = newNets;
+                } else {
+                    continue;
+                }
             }
 
-            Net[] newNets = nets == null ? new Net[wireIndex + 1] : Arrays.copyOf(nets, wireIndex + 1);
-            if (preservedMap.compareAndSet(tileAddress, nets, newNets)) {
-                nets = newNets;
-                break;
+            synchronized (nets) {
+                if (preservedMap.get(tileAddress) != nets) {
+                    continue;
+                }
+                if (wireIndex >= nets.length) {
+                    Net[] newNets = Arrays.copyOf(nets, wireIndex + 1);
+                    if (preservedMap.compareAndSet(tileAddress, nets, newNets)) {
+                        continue;
+                    } else {
+                        continue;
+                    }
+                }
+                Net oldNet = nets[wireIndex];
+                // Do not clobber the old value
+                if (oldNet == null) {
+                    nets[wireIndex] = net;
+                }
+                return oldNet;
             }
         }
-        Net oldNet = nets[wireIndex];
-        // Do not clobber the old value
-        if (oldNet == null) {
-            nets[wireIndex] = net;
-        }
-        return oldNet;
     }
 
     public void preserve(Net net, List<SitePinInst> pins) {
@@ -669,11 +680,23 @@ public class RouteNodeGraph {
 
     private boolean unpreserve(Tile tile, int wireIndex) {
         // Assumes that tile/wireIndex describes the base wire on its node
-        Net[] nets = preservedMap.get(tile.getUniqueAddress());
-        if (nets == null || wireIndex >= nets.length || nets[wireIndex] == null)
-            return false;
-        nets[wireIndex] = null;
-        return true;
+        int tileAddress = tile.getUniqueAddress();
+        while (true) {
+            Net[] nets = preservedMap.get(tileAddress);
+            if (nets == null || wireIndex >= nets.length) {
+                return false;
+            }
+            synchronized (nets) {
+                if (preservedMap.get(tileAddress) != nets) {
+                    continue;
+                }
+                if (nets[wireIndex] == null) {
+                    return false;
+                }
+                nets[wireIndex] = null;
+                return true;
+            }
+        }
     }
 
     public boolean isPreserved(Node node) {

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BiConsumer;
@@ -126,6 +127,9 @@ public class RouteNodeGraph {
     /** Flag for whether design targets the Versal series */
     protected final boolean isVersal;
 
+    /** Map of the TileTypeEnum to the highest base wire index */
+    protected final Map<TileTypeEnum, Integer> highestBaseWireIndex;
+
     protected final static int MAX_OCCUPANCY = 256;
     protected final float[] presentCongestionCosts;
 
@@ -150,6 +154,7 @@ public class RouteNodeGraph {
         preservedMapSize = new AtomicInteger();
         asyncPreserveOutstanding = new CountUpDownLatch();
         createRnodeTime = 0;
+        highestBaseWireIndex = new ConcurrentHashMap<>();
 
         Device device = design.getDevice();
         intYToSLRIndex = new int[device.getRows()];
@@ -551,6 +556,29 @@ public class RouteNodeGraph {
     public void initialize() {
     }
 
+    /*
+     * Return the highest base wire index across all Nodes in this tile
+     */
+    protected int getHighestBaseWireIndex(Tile tile, int startWireIndex) {
+        return highestBaseWireIndex.computeIfAbsent(tile.getTileTypeEnum(), (e) -> {
+            final boolean isSLLType = e == TileTypeEnum.SLL; // Versal only
+            // Check all wires in tile to find the index of the last base wire
+            int lastBaseWire = startWireIndex;
+            for (int i = lastBaseWire + 1; i < tile.getWireCount(); i++) {
+                Node node = Node.getNode(tile, i);
+                if (node == null) {
+                    continue;
+                }
+                if ((node.getTile() == tile && node.getWireIndex() == i) ||
+                        // Count Versal SLLs even if they're not based in this tile, since they are bidir
+                        (isSLLType && node.getTile().getTileTypeEnum() == e && node.getIntentCode() == IntentCode.NODE_SLL_DATA)) {
+                    lastBaseWire = i;
+                }
+            }
+            return lastBaseWire + 1;
+        });
+    }
+
     protected Net preserve(Node node, Net net) {
         Net oldNet = preserve(node.getTile(), node.getWireIndex(), net);
         if (oldNet == null) {
@@ -561,38 +589,23 @@ public class RouteNodeGraph {
 
     private Net preserve(Tile tile, int wireIndex, Net net) {
         // Assumes that tile/wireIndex describes the base wire on the node
+        // No need to synchronize access to 'nets' since collisions are not expected
         int tileAddress = tile.getUniqueAddress();
-        while (true) {
-            Net[] nets = preservedMap.get(tileAddress);
-            if (nets == null) {
-                Net[] newNets = new Net[wireIndex + 1];
-                if (preservedMap.compareAndSet(tileAddress, null, newNets)) {
-                    nets = newNets;
-                } else {
-                    continue;
-                }
-            }
-
-            synchronized (nets) {
-                if (preservedMap.get(tileAddress) != nets) {
-                    continue;
-                }
-                if (wireIndex >= nets.length) {
-                    Net[] newNets = Arrays.copyOf(nets, wireIndex + 1);
-                    if (preservedMap.compareAndSet(tileAddress, nets, newNets)) {
-                        continue;
-                    } else {
-                        continue;
-                    }
-                }
-                Net oldNet = nets[wireIndex];
-                // Do not clobber the old value
-                if (oldNet == null) {
-                    nets[wireIndex] = net;
-                }
-                return oldNet;
+        Net[] nets = preservedMap.get(tileAddress);
+        if (nets == null) {
+            int baseWireCount = getHighestBaseWireIndex(tile, wireIndex);
+            nets = new Net[baseWireCount];
+            if (!preservedMap.compareAndSet(tileAddress, null, nets)) {
+                // Another thread must have beat us to a compareAndSet, use that result
+                nets = preservedMap.get(tileAddress);
             }
         }
+        Net oldNet = nets[wireIndex];
+        // Do not clobber the old value
+        if (oldNet == null) {
+            nets[wireIndex] = net;
+        }
+        return oldNet;
     }
 
     public void preserve(Net net, List<SitePinInst> pins) {
@@ -680,30 +693,18 @@ public class RouteNodeGraph {
 
     private boolean unpreserve(Tile tile, int wireIndex) {
         // Assumes that tile/wireIndex describes the base wire on its node
-        int tileAddress = tile.getUniqueAddress();
-        while (true) {
-            Net[] nets = preservedMap.get(tileAddress);
-            if (nets == null || wireIndex >= nets.length) {
-                return false;
-            }
-            synchronized (nets) {
-                if (preservedMap.get(tileAddress) != nets) {
-                    continue;
-                }
-                if (nets[wireIndex] == null) {
-                    return false;
-                }
-                nets[wireIndex] = null;
-                return true;
-            }
-        }
+        Net[] nets = preservedMap.get(tile.getUniqueAddress());
+        if (nets == null || nets[wireIndex] == null)
+            return false;
+        nets[wireIndex] = null;
+        return true;
     }
 
     public boolean isPreserved(Node node) {
         Tile tile = node.getTile();
         int wireIndex = node.getWireIndex();
         Net[] nets = preservedMap.get(tile.getUniqueAddress());
-        return nets != null && wireIndex < nets.length && nets[wireIndex] != null;
+        return nets != null && nets[wireIndex] != null;
     }
 
     private static final Set<TileTypeEnum> allowedTileEnums;
@@ -828,7 +829,7 @@ public class RouteNodeGraph {
     private Net getPreservedNet(Tile tile, int wireIndex) {
         // Assumes that tile/wireIndex describes the base wire on its node
         Net[] nets = preservedMap.get(tile.getUniqueAddress());
-        return nets != null && wireIndex < nets.length ? nets[wireIndex] : null;
+        return nets != null ? nets[wireIndex] : null;
     }
 
     public RouteNode getNode(Node node) {
@@ -840,7 +841,7 @@ public class RouteNodeGraph {
     private RouteNode getNode(Tile tile, int wireIndex) {
         // Assumes that tile/wireIndex describes the base wire on its node
         RouteNode[] rnodes = nodesMap[tile.getUniqueAddress()];
-        return rnodes != null && wireIndex < rnodes.length ? rnodes[wireIndex] : null;
+        return rnodes != null ? rnodes[wireIndex] : null;
     }
 
     public Iterable<RouteNode> getRnodes() {
@@ -924,8 +925,9 @@ public class RouteNodeGraph {
         int wireIndex = node.getWireIndex();
         int tileAddress = tile.getUniqueAddress();
         RouteNode[] rnodes = nodesMap[tileAddress];
-        if (rnodes == null || wireIndex >= rnodes.length) {
-            rnodes = rnodes == null ? new RouteNode[wireIndex + 1] : Arrays.copyOf(rnodes, wireIndex + 1);
+        if (rnodes == null) {
+            int baseWireCount = getHighestBaseWireIndex(tile, wireIndex);
+            rnodes = new RouteNode[baseWireCount];
             nodesMap[tileAddress] = rnodes;
         }
         RouteNode rnode = rnodes[wireIndex];

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -34,7 +34,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BiConsumer;
@@ -127,9 +126,6 @@ public class RouteNodeGraph {
     /** Flag for whether design targets the Versal series */
     protected final boolean isVersal;
 
-    /** Map of the TileTypeEnum to the highest base wire index */
-    protected final Map<TileTypeEnum, Integer> highestBaseWireIndex;
-
     protected final static int MAX_OCCUPANCY = 256;
     protected final float[] presentCongestionCosts;
 
@@ -154,7 +150,6 @@ public class RouteNodeGraph {
         preservedMapSize = new AtomicInteger();
         asyncPreserveOutstanding = new CountUpDownLatch();
         createRnodeTime = 0;
-        highestBaseWireIndex = new ConcurrentHashMap<>();
 
         Device device = design.getDevice();
         intYToSLRIndex = new int[device.getRows()];
@@ -556,29 +551,6 @@ public class RouteNodeGraph {
     public void initialize() {
     }
 
-    /*
-     * Return the highest base wire index across all Nodes in this tile
-     */
-    protected int getHighestBaseWireIndex(Tile tile, int startWireIndex) {
-        return highestBaseWireIndex.computeIfAbsent(tile.getTileTypeEnum(), (e) -> {
-            final boolean isSLLType = e == TileTypeEnum.SLL; // Versal only
-            // Check all wires in tile to find the index of the last base wire
-            int lastBaseWire = startWireIndex;
-            for (int i = lastBaseWire + 1; i < tile.getWireCount(); i++) {
-                Node node = Node.getNode(tile, i);
-                if (node == null) {
-                    continue;
-                }
-                if ((node.getTile() == tile && node.getWireIndex() == i) ||
-                        // Count Versal SLLs even if they're not based in this tile, since they are bidir
-                        (isSLLType && node.getTile().getTileTypeEnum() == e && node.getIntentCode() == IntentCode.NODE_SLL_DATA)) {
-                    lastBaseWire = i;
-                }
-            }
-            return lastBaseWire + 1;
-        });
-    }
-
     protected Net preserve(Node node, Net net) {
         Net oldNet = preserve(node.getTile(), node.getWireIndex(), net);
         if (oldNet == null) {
@@ -591,13 +563,17 @@ public class RouteNodeGraph {
         // Assumes that tile/wireIndex describes the base wire on the node
         // No need to synchronize access to 'nets' since collisions are not expected
         int tileAddress = tile.getUniqueAddress();
-        Net[] nets = preservedMap.get(tileAddress);
-        if (nets == null) {
-            int baseWireCount = getHighestBaseWireIndex(tile, wireIndex);
-            nets = new Net[baseWireCount];
-            if (!preservedMap.compareAndSet(tileAddress, null, nets)) {
-                // Another thread must have beat us to a compareAndSet, use that result
-                nets = preservedMap.get(tileAddress);
+        Net[] nets;
+        while (true) {
+            nets = preservedMap.get(tileAddress);
+            if (nets != null && wireIndex < nets.length) {
+                break;
+            }
+
+            Net[] newNets = nets == null ? new Net[wireIndex + 1] : Arrays.copyOf(nets, wireIndex + 1);
+            if (preservedMap.compareAndSet(tileAddress, nets, newNets)) {
+                nets = newNets;
+                break;
             }
         }
         Net oldNet = nets[wireIndex];
@@ -694,7 +670,7 @@ public class RouteNodeGraph {
     private boolean unpreserve(Tile tile, int wireIndex) {
         // Assumes that tile/wireIndex describes the base wire on its node
         Net[] nets = preservedMap.get(tile.getUniqueAddress());
-        if (nets == null || nets[wireIndex] == null)
+        if (nets == null || wireIndex >= nets.length || nets[wireIndex] == null)
             return false;
         nets[wireIndex] = null;
         return true;
@@ -704,7 +680,7 @@ public class RouteNodeGraph {
         Tile tile = node.getTile();
         int wireIndex = node.getWireIndex();
         Net[] nets = preservedMap.get(tile.getUniqueAddress());
-        return nets != null && nets[wireIndex] != null;
+        return nets != null && wireIndex < nets.length && nets[wireIndex] != null;
     }
 
     private static final Set<TileTypeEnum> allowedTileEnums;
@@ -829,7 +805,7 @@ public class RouteNodeGraph {
     private Net getPreservedNet(Tile tile, int wireIndex) {
         // Assumes that tile/wireIndex describes the base wire on its node
         Net[] nets = preservedMap.get(tile.getUniqueAddress());
-        return nets != null ? nets[wireIndex] : null;
+        return nets != null && wireIndex < nets.length ? nets[wireIndex] : null;
     }
 
     public RouteNode getNode(Node node) {
@@ -841,7 +817,7 @@ public class RouteNodeGraph {
     private RouteNode getNode(Tile tile, int wireIndex) {
         // Assumes that tile/wireIndex describes the base wire on its node
         RouteNode[] rnodes = nodesMap[tile.getUniqueAddress()];
-        return rnodes != null ? rnodes[wireIndex] : null;
+        return rnodes != null && wireIndex < rnodes.length ? rnodes[wireIndex] : null;
     }
 
     public Iterable<RouteNode> getRnodes() {
@@ -925,9 +901,8 @@ public class RouteNodeGraph {
         int wireIndex = node.getWireIndex();
         int tileAddress = tile.getUniqueAddress();
         RouteNode[] rnodes = nodesMap[tileAddress];
-        if (rnodes == null) {
-            int baseWireCount = getHighestBaseWireIndex(tile, wireIndex);
-            rnodes = new RouteNode[baseWireCount];
+        if (rnodes == null || wireIndex >= rnodes.length) {
+            rnodes = rnodes == null ? new RouteNode[wireIndex + 1] : Arrays.copyOf(rnodes, wireIndex + 1);
             nodesMap[tileAddress] = rnodes;
         }
         RouteNode rnode = rnodes[wireIndex];

--- a/src/com/xilinx/rapidwright/util/Job.java
+++ b/src/com/xilinx/rapidwright/util/Job.java
@@ -57,6 +57,8 @@ public abstract class Job {
 
     public static final String DEFAULT_COMMAND_LOG_FILE = DEFAULT_COMMAND_NAME + DEFAULT_LOG_EXTENSION;
 
+    public static final int DEFAULT_LOG_LINES = 80;
+
     public abstract long launchJob();
 
     public abstract JobState getJobState();
@@ -151,7 +153,7 @@ public abstract class Job {
         String logFileName = getLogFilename();
         if (new File(logFileName).exists()) {
             ArrayList<String> lines = FileTools.getLinesFromTextFile(logFileName);
-            int start = lines.size() >= 8 ? lines.size()-8 : 0;
+            int start = lines.size() >= DEFAULT_LOG_LINES ? lines.size()-DEFAULT_LOG_LINES : 0;
             return Optional.of(IntStream.range(start, lines.size()).mapToObj(lines::get).collect(Collectors.toList()));
         }
         return Optional.empty();

--- a/src/com/xilinx/rapidwright/util/Params.java
+++ b/src/com/xilinx/rapidwright/util/Params.java
@@ -41,6 +41,14 @@ public class Params {
     public static String RW_COPY_EDNS_ON_DCP_WRITE_NAME = "RW_COPY_EDNS_ON_DCP_WRITE";
 
     /**
+     * Directory where RapidWright should temporarily extract readable EDIF files
+     * embedded inside DCPs before parsing. This can be set either as an environment
+     * variable or JVM system property. If unset, RapidWright will try the DCP's
+     * directory first and then the JVM temp directory.
+     */
+    public static String RW_DCP_EDIF_TEMP_DIR_NAME = "RW_DCP_EDIF_TEMP_DIR";
+
+    /**
      * Flag to have RapidWright decompress gzipped EDIF files to disk prior to
      * parsing. This is a tradeoff where pre-decompression improves runtime over the
      * default method which is to decompress in memory. The disadvantage is that
@@ -77,6 +85,12 @@ public class Params {
      * to the same directory where the DCP is being written to.
      */
     public static boolean RW_COPY_EDNS_ON_DCP_WRITE = isParamSet(RW_COPY_EDNS_ON_DCP_WRITE_NAME);
+
+    /**
+     * Directory where RapidWright should temporarily extract readable EDIF files
+     * embedded inside DCPs before parsing, or null if unset.
+     */
+    public static String RW_DCP_EDIF_TEMP_DIR = getParamValue(RW_DCP_EDIF_TEMP_DIR_NAME);
 
     /**
      * Checks if the named RapidWright parameter is set via an environment variable

--- a/src/com/xilinx/rapidwright/util/Params.java
+++ b/src/com/xilinx/rapidwright/util/Params.java
@@ -49,6 +49,13 @@ public class Params {
     public static String RW_DCP_EDIF_TEMP_DIR_NAME = "RW_DCP_EDIF_TEMP_DIR";
 
     /**
+     * Minimum uncompressed EDIF size in bytes where RapidWright should extract a
+     * readable EDIF embedded inside a DCP before parsing. If unset or negative,
+     * RapidWright uses the parallel EDIF parser's thread-count heuristic.
+     */
+    public static String RW_DCP_EDIF_EXTRACT_THRESHOLD_BYTES_NAME = "RW_DCP_EDIF_EXTRACT_THRESHOLD_BYTES";
+
+    /**
      * Flag to have RapidWright decompress gzipped EDIF files to disk prior to
      * parsing. This is a tradeoff where pre-decompression improves runtime over the
      * default method which is to decompress in memory. The disadvantage is that
@@ -91,6 +98,14 @@ public class Params {
      * embedded inside DCPs before parsing, or null if unset.
      */
     public static String RW_DCP_EDIF_TEMP_DIR = getParamValue(RW_DCP_EDIF_TEMP_DIR_NAME);
+
+    /**
+     * Minimum uncompressed EDIF size in bytes where RapidWright should extract a
+     * readable EDIF embedded inside a DCP before parsing. A negative value means
+     * the threshold was not set explicitly.
+     */
+    public static long RW_DCP_EDIF_EXTRACT_THRESHOLD_BYTES =
+            getParamOrDefaultLongSetting(RW_DCP_EDIF_EXTRACT_THRESHOLD_BYTES_NAME, -1L);
 
     /**
      * Checks if the named RapidWright parameter is set via an environment variable
@@ -141,6 +156,27 @@ public class Params {
     }
 
     /**
+     * Gets the long value of the provided parameter name.
+     *
+     * @param key Name of the system parameter to get.
+     * @return The set long value of the parameter, or null if none was set. If
+     *         the property is set to a value that is not a parsable long, a
+     *         warning message is produced and returns null.
+     */
+    public static Long getParamLongValue(String key) {
+        String envValue = getParamValue(key);
+        if (envValue != null) {
+            try {
+                return Long.parseLong(envValue);
+            } catch (NumberFormatException e) {
+                System.err.println("WARNING: Couldn't interpret the value '" + envValue
+                        + "' from the parameter '" + key + "' as a long.");
+            }
+        }
+        return null;
+    }
+
+    /**
      * Gets the string value of the provided parameter name.
      * 
      * @param key Name of the system parameter to get.
@@ -165,6 +201,20 @@ public class Params {
      */
     public static int getParamOrDefaultIntSetting(String key, int defaultValue) {
         Integer setValue = getParamIntValue(key);
+        return setValue == null ? defaultValue : setValue;
+    }
+
+    /**
+     * Checks the parameter value of the provided key. If it is set, it returns the
+     * set value. Otherwise it will return the default value.
+     *
+     * @param key          Name of the system parameter to check.
+     * @param defaultValue The default value to return if the parameter is not set.
+     * @return The system parameter value if is set, otherwise it returns
+     *         defaultValue.
+     */
+    public static long getParamOrDefaultLongSetting(String key, long defaultValue) {
+        Long setValue = getParamLongValue(key);
         return setValue == null ? defaultValue : setValue;
     }
 


### PR DESCRIPTION
When large netlist designs are saved in a DCP and the EDIF file inside is readable, there is a significant slow down issue.  When this DCP is later read by RapidWright the parallel EDIF parser is prevented from being run because the netlist is inside the DCP and the parallel parser needs an extracted version of the EDIF to operate and the default behavior is to fall back to the old serial parser.  When designs are very large, this causes a significant slowdown.

To work around this issue, this PR detects large readable EDIFs that would invoke the parallel parser and extracts them beforehand to enable the parallel parser to work.  The threshold can be set by a param (`Params.RW_DCP_EDIF_EXTRACT_THRESHOLD_BYTES`) while the default behavior is to call `ParallelEDIFParser.calcThreads()` and check when more than one thread would be used.

The directory where the EDIF is extracted to can be set by `Params.RW_DCP_EDIF_TEMP_DIR`.  Otherwise, RapidWright will attempt to extract it to the same directory as the DCP.  If that fails, it will attempt to extract it to `/tmp` or equivalent.  The extracted EDIF is deleted once the netlist has been fully parsed into memory.  