### PR TITLE
Add null-safety guards in design/EDIF utilities

### DIFF
--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -4820,9 +4820,8 @@ public class DesignTools {
     public static void updateVersalXPHYPinsForDMC(Design design) {
         // Check for XPHY BEL pin remapping needs (DMC remappings)
         for (Cell cell : design.getCells()) {
-            if (cell.getType() == null)
-                continue;
-            if (!cell.getType().equals("XPHY"))
+            String type = cell.getType();
+            if (cell.getType() == null || !cell.getType().equals("XPHY"))
                 continue;
             for (EDIFHierPortInst portInst : cell.getEDIFHierCellInst().getHierPortInsts()) {
                 if (portInst.isInput()) {

--- a/src/com/xilinx/rapidwright/design/DesignTools.java
+++ b/src/com/xilinx/rapidwright/design/DesignTools.java
@@ -3536,6 +3536,9 @@ public class DesignTools {
                 }
 
                 String cellType = cell.getType();
+                if (cellType == null) {
+                    continue;
+                }
                 if (cellType.equals("AND2B1L") || cellType.equals("OR2L")) {
                     // pass
                 } else if (cell.isFFRoutethruCell()) {
@@ -4817,6 +4820,8 @@ public class DesignTools {
     public static void updateVersalXPHYPinsForDMC(Design design) {
         // Check for XPHY BEL pin remapping needs (DMC remappings)
         for (Cell cell : design.getCells()) {
+            if (cell.getType() == null)
+                continue;
             if (!cell.getType().equals("XPHY"))
                 continue;
             for (EDIFHierPortInst portInst : cell.getEDIFHierCellInst().getHierPortInsts()) {

--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -543,6 +543,10 @@ public class NetTools {
                 EDIFHierNet parentNet = d.getNetlist().getParentNet(hierNet);
                 Net net = d.getNet(parentNet.getHierarchicalNetName());
 
+                if (net == null) {
+                    continue;
+                }
+
                 boolean leavesPBlock = false;
                 for (PIP pip : net.getPIPs()) {
                     if (!pBlock.containsTile(pip.getTile())) {

--- a/src/com/xilinx/rapidwright/design/blocks/PBlockRange.java
+++ b/src/com/xilinx/rapidwright/design/blocks/PBlockRange.java
@@ -222,9 +222,9 @@ public class PBlockRange {
         // We may need to expand column to include outward facing CLB/DSP/BRAM to INT tiles
         if (isSiteRange()) {
             Tile t = getLowerLeftSite().getIntTile();
-            if (t.getColumn() < colMin) colMin = t.getColumn();
+            if (t != null && t.getColumn() < colMin) colMin = t.getColumn();
             t = getUpperRightSite().getIntTile();
-            if (t.getColumn() > colMax) colMax = t.getColumn();
+            if (t != null && t.getColumn() > colMax) colMax = t.getColumn();
         }
 
         for (int col=colMin; col <= colMax; col++) {

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -260,6 +260,13 @@ public class EDIFCellInst extends EDIFPropertyObject {
             if (port == null || port.getWidth() != origPort.getWidth()) {
                 port = cellType.getPort(origPort.getName());
             }
+            if (port == null) {
+                throw new RuntimeException("ERROR: Cannot remap port '" + origPort.getName()
+                        + "' from old cell type '" + origPort.getParentCell().getName()
+                        + "' to new cell type '" + cellType.getName()
+                        + "' on instance '" + getName()
+                        + "'. Port not found on new cell type.");
+            }
             portInst.setPort(port);
         }
     }


### PR DESCRIPTION
A collection of fixes to nullptr issues I ran into

- DesignTools: skip cells with a null type in the routethru-handling loop and in updateVersalXPHYPinsForDMC
- NetTools: skip nets that resolve to null when checking pblock escape
- PBlockRange: guard against a null INT tile when expanding columns
- EDIFCellInst.remapCell: throw a descriptive error when a port is missing on the new cell type instead of NPEing on the next line