### PR TITLE
Add ConstraintTools.getClockNetsFromXDC

### DIFF
--- a/src/com/xilinx/rapidwright/design/xdc/ConstraintTools.java
+++ b/src/com/xilinx/rapidwright/design/xdc/ConstraintTools.java
@@ -22,8 +22,12 @@
 
 package com.xilinx.rapidwright.design.xdc;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.xilinx.rapidwright.design.ConstraintGroup;
 import com.xilinx.rapidwright.design.Design;
@@ -48,5 +52,17 @@ public class ConstraintTools {
         }
 
         return pblockMap;
+    }
+
+    public static List<String> getClockNetsFromXDC(Design d) {
+        Set<String> clockNets = new HashSet<>();
+
+        for (ConstraintGroup cg : ConstraintGroup.values()) {
+            XDCConstraints xdcConstraints = XDCParser.parseXDC(d.getDevice(), d.getXDCConstraints(cg), new RegularEdifCellLookup(d.getNetlist()));
+            xdcConstraints.getClockConstraints().forEach((k, v) -> {
+                clockNets.add(v.getPortName());
+            });
+        }
+        return new ArrayList<>(clockNets);
     }
 }

--- a/src/com/xilinx/rapidwright/design/xdc/ConstraintTools.java
+++ b/src/com/xilinx/rapidwright/design/xdc/ConstraintTools.java
@@ -54,12 +54,12 @@ public class ConstraintTools {
         return pblockMap;
     }
 
-    public static List<String> getClockNetsFromXDC(Design d) {
+    public static List<String> getClockNetPortNamesFromXDC(Design d) {
         Set<String> clockNets = new HashSet<>();
 
         for (ConstraintGroup cg : ConstraintGroup.values()) {
             XDCConstraints xdcConstraints = XDCParser.parseXDC(d.getDevice(), d.getXDCConstraints(cg), new RegularEdifCellLookup(d.getNetlist()));
-            xdcConstraints.getClockConstraints().forEach((k, v) -> {
+            xdcConstraints.getClockConstraints().values().forEach((v) -> {
                 clockNets.add(v.getPortName());
             });
         }


### PR DESCRIPTION
Adds a utility to collect the set of clock net (port) names declared via create_clock constraints across all XDC constraint groups of a design.