### PR TITLE
[EDIFNetlist] Mem Optimizations - Trim PortInsts & Property Map Storage

### DIFF
--- a/src/com/xilinx/rapidwright/edif/BinaryEDIFWriter.java
+++ b/src/com/xilinx/rapidwright/edif/BinaryEDIFWriter.java
@@ -159,15 +159,15 @@ public class BinaryEDIFWriter {
      * @see BinaryEDIFReader#readEDIFObject(EDIFPropertyObject, Input, String[])
      */
     private static void writeEDIFObject(EDIFPropertyObject o, Output os, Map<String,Integer> stringMap) {
-        boolean hasProperties = o.getPropertiesMap().size() > 0;
+        boolean hasProperties = o.getPropertyCount() > 0;
         writeEDIFName(o, os, stringMap, hasProperties);
         if (hasProperties) {
-            if (o.getPropertiesMap().size() > 0x0000ffff) {
+            if (o.getPropertyCount() > 0x0000ffff) {
                 throw new RuntimeException("ERROR: EDIF object exceeded number of encoded "
                         + "properties on object '" + o.getName() + "'");
             }
 
-            os.writeInt(o.getPropertiesMap().size());
+            os.writeInt(o.getPropertyCount());
 
             for (Entry<String, EDIFPropertyValue> e : o.getPropertiesMap().entrySet()) {
                 int ownerFlag = e.getValue().getOwner() != null ? EDIF_HAS_OWNER : 0;

--- a/src/com/xilinx/rapidwright/edif/EDIFCell.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCell.java
@@ -672,7 +672,7 @@ public class EDIFCell extends EDIFPropertyObject {
             }
             os.write(EXPORT_CONST_CONTENTS_END); // Contents end
         }
-        if (getPropertiesMap().size() > 0) {
+        if (getPropertyCount() > 0) {
             os.write('\n');
             exportEDIFProperties(os, EXPORT_CONST_PROP_INDENT, cache, stable);
         }
@@ -762,6 +762,25 @@ public class EDIFCell extends EDIFPropertyObject {
         for (EDIFCellInst inst : getCellInsts()) {
             EDIFPortInstList list = inst.getEDIFPortInstList();
             if (list != null) list.reSortList();
+        }
+    }
+
+    /**
+     * Trims the backing capacity of all {@link EDIFPortInstList} objects on the
+     * nets and cell instances of this cell down to their current size. The lists
+     * are built via incremental {@link java.util.ArrayList} insertion (which
+     * leaves unused capacity slack), so calling this after a netlist is fully
+     * loaded reclaims that slack. This is purely a memory optimization and does
+     * not change the contents of any list.
+     */
+    public void trimEDIFPortInstLists() {
+        for (EDIFNet net : getNets()) {
+            EDIFPortInstList list = net.getEDIFPortInstList();
+            if (list != null) list.trimToSize();
+        }
+        for (EDIFCellInst inst : getCellInsts()) {
+            EDIFPortInstList list = inst.getEDIFPortInstList();
+            if (list != null) list.trimToSize();
         }
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFCellInst.java
@@ -302,7 +302,7 @@ public class EDIFCellInst extends EDIFPropertyObject {
         os.write(cache.getLegalEDIFName(cellType.getName()));
         os.write(EXPORT_CONST_LIBRARYREF);
         os.write(cache.getLegalEDIFName(cellType.getLibrary().getName()));
-        if (getPropertiesMap().size() > 0) {
+        if (getPropertyCount() > 0) {
             os.write(EXPORT_CONST_CLOSE_WITH_PROPS);
             exportEDIFProperties(os,EXPORT_CONST_PROP_INDENT, cache, stable);
             os.write(EXPORT_CONST_CLOSE);

--- a/src/com/xilinx/rapidwright/edif/EDIFNet.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNet.java
@@ -465,7 +465,7 @@ public class EDIFNet extends EDIFPropertyObject {
             p.writeEDIFExport(os, EXPORT_CONST_PORT_INDENT, cache);
         }
         os.write(EXPORT_CONST_JOINED_END); // joined end
-        if (getPropertiesMap().size() > 0) {
+        if (getPropertyCount() > 0) {
             os.write('\n');
             exportEDIFProperties(os, EXPORT_CONST_PROP_INDENT, cache, stable);
         }

--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -792,6 +792,22 @@ public class EDIFNetlist extends EDIFName {
     }
 
     /**
+     * Trims the backing capacity of every {@link EDIFPortInstList} in the netlist
+     * down to its current size (see {@link EDIFCell#trimEDIFPortInstLists()}).
+     * Port instance lists are built via incremental {@link java.util.ArrayList}
+     * insertion during parsing, which leaves unused capacity slack; calling this
+     * once after a netlist is fully loaded reclaims that slack. This is purely a
+     * memory optimization and does not change the netlist contents.
+     */
+    public void trimEDIFPortInstLists() {
+        for (EDIFLibrary lib : getLibraries()) {
+            for (EDIFCell cell : lib.getCells()) {
+                cell.trimEDIFPortInstLists();
+            }
+        }
+    }
+
+    /**
      * Get Libraries in export order so that any cell instance appearing in a library will only
      * refer to cells in its own library or previous libraries in the list.  This is a pre-requisite
      * for export to a file.

--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -141,6 +141,10 @@ public class EDIFParser extends AbstractEDIFParserWorker implements AutoCloseabl
             }
         }
 
+        // Port instance lists are built via incremental ArrayList insertion, which
+        // leaves unused capacity slack. Trim it now that parsing is complete.
+        currNetlist.trimEDIFPortInstLists();
+
         return currNetlist;
     }
 

--- a/src/com/xilinx/rapidwright/edif/EDIFPort.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPort.java
@@ -300,7 +300,7 @@ public class EDIFPort extends EDIFPropertyObject {
         os.write(EXPORT_CONST_DIRECTION_START);
         os.write(direction.toByteArray());
         os.write(')');
-        if (getPropertiesMap().size() > 0) {
+        if (getPropertyCount() > 0) {
             os.write('\n');
             exportEDIFProperties(os, EXPORT_CONST_CHILD_INDENT, cache, stable);
             os.write(EXPORT_CONST_INDENT);

--- a/src/com/xilinx/rapidwright/edif/EDIFPropertyMap.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPropertyMap.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A lightweight, live {@link Map} view over an {@link EDIFPropertyObject}'s
+ * inlined property storage.
+ *
+ * To minimize per-object memory, EDIF property storage lives directly inside the
+ * {@link EDIFPropertyObject} (see {@link EDIFPropertyObject#getRawPropertyData()})
+ * rather than in a dedicated map object.  This class provides the {@link Map}
+ * interface over that storage on demand: {@link EDIFPropertyObject#getPropertiesMap()}
+ * returns one of these views (a small, short-lived object that holds only a
+ * reference back to its owner).  All operations read and write through to the
+ * owner, so the view always reflects the current properties and mutations affect
+ * the underlying object.
+ *
+ * This view is not thread-safe (neither is the underlying storage); a single
+ * EDIF object's properties are only ever mutated by one thread during parsing.
+ */
+public class EDIFPropertyMap implements Map<String, EDIFPropertyValue> {
+
+    private static final Object[] EMPTY = new Object[0];
+
+    private final EDIFPropertyObject owner;
+
+    EDIFPropertyMap(EDIFPropertyObject owner) {
+        this.owner = owner;
+    }
+
+    /** @return true if this view is backed by the given object. */
+    boolean isViewOf(EDIFPropertyObject o) {
+        return owner == o;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static HashMap<String, EDIFPropertyValue> asMap(Object d) {
+        return (HashMap<String, EDIFPropertyValue>) d;
+    }
+
+    /** Returns the owner's compact array, or {@link #EMPTY} if not in compact mode. */
+    private Object[] compactOrEmpty() {
+        Object d = owner.getRawPropertyData();
+        return (d instanceof Object[]) ? (Object[]) d : EMPTY;
+    }
+
+    @Override
+    public int size() {
+        return owner.getPropertyCount();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return owner.getPropertyCount() == 0;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return (key instanceof String) && owner.getProperty((String) key) != null;
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        Object d = owner.getRawPropertyData();
+        if (d == null) {
+            return false;
+        }
+        if (d instanceof HashMap) {
+            return asMap(d).containsValue(value);
+        }
+        Object[] a = (Object[]) d;
+        for (int i = 1; i < a.length; i += 2) {
+            if (Objects.equals(value, a[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public EDIFPropertyValue get(Object key) {
+        return (key instanceof String) ? owner.getProperty((String) key) : null;
+    }
+
+    @Override
+    public EDIFPropertyValue put(String key, EDIFPropertyValue value) {
+        return owner.addProperty(key, value);
+    }
+
+    @Override
+    public EDIFPropertyValue remove(Object key) {
+        return (key instanceof String) ? owner.removeProperty((String) key) : null;
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends EDIFPropertyValue> m) {
+        for (Map.Entry<? extends String, ? extends EDIFPropertyValue> e : m.entrySet()) {
+            owner.addProperty(e.getKey(), e.getValue());
+        }
+    }
+
+    @Override
+    public void clear() {
+        owner.clearProperties();
+    }
+
+    // The collection views below intentionally do NOT decide between the compact
+    // and promoted (HashMap) representations when they are created. That decision
+    // is deferred to each iterator() call, so a view obtained while compact stays
+    // consistent (size and iteration agree) if the backing is later promoted to a
+    // HashMap by an intervening insertion.
+
+    @Override
+    public Set<String> keySet() {
+        return new AbstractSet<String>() {
+            @Override
+            public Iterator<String> iterator() {
+                Object d = owner.getRawPropertyData();
+                if (d instanceof HashMap) {
+                    return asMap(d).keySet().iterator();
+                }
+                return new BaseIterator<String>() {
+                    @Override
+                    String elementAt(Object[] a, int idx) {
+                        return (String) a[idx];
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return EDIFPropertyMap.this.size();
+            }
+
+            @Override
+            public boolean contains(Object o) {
+                return containsKey(o);
+            }
+        };
+    }
+
+    @Override
+    public Collection<EDIFPropertyValue> values() {
+        return new AbstractCollection<EDIFPropertyValue>() {
+            @Override
+            public Iterator<EDIFPropertyValue> iterator() {
+                Object d = owner.getRawPropertyData();
+                if (d instanceof HashMap) {
+                    return asMap(d).values().iterator();
+                }
+                return new BaseIterator<EDIFPropertyValue>() {
+                    @Override
+                    EDIFPropertyValue elementAt(Object[] a, int idx) {
+                        return (EDIFPropertyValue) a[idx + 1];
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return EDIFPropertyMap.this.size();
+            }
+        };
+    }
+
+    @Override
+    public Set<Map.Entry<String, EDIFPropertyValue>> entrySet() {
+        return new AbstractSet<Map.Entry<String, EDIFPropertyValue>>() {
+            @Override
+            public Iterator<Map.Entry<String, EDIFPropertyValue>> iterator() {
+                Object d = owner.getRawPropertyData();
+                if (d instanceof HashMap) {
+                    return asMap(d).entrySet().iterator();
+                }
+                return new BaseIterator<Map.Entry<String, EDIFPropertyValue>>() {
+                    @Override
+                    Map.Entry<String, EDIFPropertyValue> elementAt(Object[] a, int idx) {
+                        return new MapEntry((String) a[idx]);
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return EDIFPropertyMap.this.size();
+            }
+        };
+    }
+
+    /**
+     * A live view of a single entry. {@code setValue} writes through to the
+     * owning {@link EDIFPropertyObject}.
+     */
+    private class MapEntry implements Map.Entry<String, EDIFPropertyValue> {
+        private final String key;
+
+        MapEntry(String key) {
+            this.key = key;
+        }
+
+        @Override
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public EDIFPropertyValue getValue() {
+            return owner.getProperty(key);
+        }
+
+        @Override
+        public EDIFPropertyValue setValue(EDIFPropertyValue value) {
+            return owner.addProperty(key, value);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Map.Entry)) {
+                return false;
+            }
+            Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+            return Objects.equals(key, e.getKey()) && Objects.equals(getValue(), e.getValue());
+        }
+
+        @Override
+        public int hashCode() {
+            EDIFPropertyValue v = getValue();
+            return (key == null ? 0 : key.hashCode()) ^ (v == null ? 0 : v.hashCode());
+        }
+
+        @Override
+        public String toString() {
+            return key + "=" + getValue();
+        }
+    }
+
+    /**
+     * Iterator over the owner's compact array representation. Fail-fast without a
+     * modification counter: it captures the backing array at creation, and any
+     * structural modification replaces the owner's backing (with a new array, or
+     * a HashMap on promotion), which is detected by reference identity.
+     */
+    private abstract class BaseIterator<E> implements Iterator<E> {
+        private Object[] snapshot = compactOrEmpty();
+        private int cursor = 0;
+
+        abstract E elementAt(Object[] a, int idx);
+
+        private void checkForComodification() {
+            // compactOrEmpty() normalizes the empty (null) state to EMPTY so an
+            // empty map's iterator does not spuriously report comodification.
+            if (compactOrEmpty() != snapshot) {
+                throw new ConcurrentModificationException();
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return cursor < snapshot.length;
+        }
+
+        @Override
+        public E next() {
+            checkForComodification();
+            if (cursor >= snapshot.length) {
+                throw new NoSuchElementException();
+            }
+            E e = elementAt(snapshot, cursor);
+            cursor += 2;
+            return e;
+        }
+
+        @Override
+        public void remove() {
+            if (cursor == 0) {
+                throw new IllegalStateException();
+            }
+            checkForComodification();
+            int idx = cursor - 2;
+            owner.removeProperty((String) snapshot[idx]);
+            // Our own remove replaced the owner's backing array; resync the snapshot.
+            snapshot = compactOrEmpty();
+            cursor = idx;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof Map)) {
+            return false;
+        }
+        Map<?, ?> m = (Map<?, ?>) o;
+        if (m.size() != size()) {
+            return false;
+        }
+        Object d = owner.getRawPropertyData();
+        if (d instanceof HashMap) {
+            return asMap(d).equals(m);
+        }
+        Object[] a = (d instanceof Object[]) ? (Object[]) d : EMPTY;
+        for (int i = 0; i < a.length; i += 2) {
+            if (!Objects.equals(a[i + 1], m.get(a[i]))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        // Matches the AbstractMap/Map contract (sum of entry hash codes).
+        Object d = owner.getRawPropertyData();
+        if (d instanceof HashMap) {
+            return asMap(d).hashCode();
+        }
+        int h = 0;
+        Object[] a = (d instanceof Object[]) ? (Object[]) d : EMPTY;
+        for (int i = 0; i < a.length; i += 2) {
+            int keyHash = a[i] == null ? 0 : a[i].hashCode();
+            int valHash = a[i + 1] == null ? 0 : a[i + 1].hashCode();
+            h += keyHash ^ valHash;
+        }
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        Object d = owner.getRawPropertyData();
+        if (d instanceof HashMap) {
+            return asMap(d).toString();
+        }
+        Object[] a = (d instanceof Object[]) ? (Object[]) d : EMPTY;
+        if (a.length == 0) {
+            return "{}";
+        }
+        StringBuilder sb = new StringBuilder("{");
+        for (int i = 0; i < a.length; i += 2) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(a[i]).append('=').append(a[i + 1]);
+        }
+        return sb.append('}').toString();
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/EDIFPropertyMap.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPropertyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, AMD Research and Advanced Development.

--- a/src/com/xilinx/rapidwright/edif/EDIFPropertyObject.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFPropertyObject.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 /**
  * All EDIF netlist objects that can possess properties inherit from this
@@ -41,7 +42,37 @@ import java.util.Map.Entry;
  */
 public class EDIFPropertyObject extends EDIFName {
 
-    private Map<String,EDIFPropertyValue> properties;
+    /**
+     * Maximum number of entries kept in the compact array representation before
+     * the backing store is promoted to a {@link HashMap}. Chosen comfortably
+     * above the typical EDIF object property count (the overwhelming majority
+     * have fewer than 8) so promotion only affects rare large-property objects
+     * (e.g. transceiver primitives), while bounding the worst-case linear-scan
+     * length.
+     */
+    static final int PROMOTE_THRESHOLD = 16;
+
+    /**
+     * Inlined property storage. Rather than holding a separate map object per
+     * netlist object (which would cost an extra object header + reference for
+     * every property-bearing object), the properties are stored directly in this
+     * single field, which is one of:
+     * <ul>
+     *   <li>{@code null} - no properties;</li>
+     *   <li>an {@code Object[]} of alternating key/value entries
+     *       ({@code [k0, v0, k1, v1, ...]}) - the memory-compact representation
+     *       used for small property sets (lookup is a linear scan); or</li>
+     *   <li>a {@code HashMap<String,EDIFPropertyValue>} - used once the entry
+     *       count exceeds {@link #PROMOTE_THRESHOLD}, restoring amortized O(1)
+     *       access for the rare large-property objects.</li>
+     * </ul>
+     * {@link #getPropertiesMap()} exposes a lightweight {@link EDIFPropertyMap}
+     * view over this field that implements the full {@link Map} contract.
+     *
+     * This storage is not thread-safe (neither was the previous map); a single
+     * EDIF object's properties are only ever mutated by one thread during parsing.
+     */
+    private Object propertyData;
 
     public EDIFPropertyObject(String name) {
         super(name);
@@ -49,11 +80,16 @@ public class EDIFPropertyObject extends EDIFName {
 
     public EDIFPropertyObject(EDIFPropertyObject obj) {
         super(obj);
-        properties = obj.createDuplicatePropertiesMap();
+        copyPropertiesFrom(obj);
     }
 
     protected EDIFPropertyObject() {
 
+    }
+
+    @SuppressWarnings("unchecked")
+    private static HashMap<String, EDIFPropertyValue> asMap(Object d) {
+        return (HashMap<String, EDIFPropertyValue>) d;
     }
 
     /**
@@ -127,8 +163,27 @@ public class EDIFPropertyObject extends EDIFName {
      * @return The old property value or null if none existed
      */
     public EDIFPropertyValue removeProperty(String key) {
-        if (properties == null) return null;
-        return properties.remove(key);
+        Object d = propertyData;
+        if (d == null) return null;
+        if (d instanceof HashMap) {
+            return asMap(d).remove(key);
+        }
+        Object[] a = (Object[]) d;
+        for (int i = 0; i < a.length; i += 2) {
+            if (a[i].equals(key)) {
+                EDIFPropertyValue old = (EDIFPropertyValue) a[i + 1];
+                if (a.length == 2) {
+                    propertyData = null;
+                } else {
+                    Object[] n = new Object[a.length - 2];
+                    System.arraycopy(a, 0, n, 0, i);
+                    System.arraycopy(a, i + 2, n, i, a.length - i - 2);
+                    propertyData = n;
+                }
+                return old;
+            }
+        }
+        return null;
     }
 
     /**
@@ -138,44 +193,168 @@ public class EDIFPropertyObject extends EDIFName {
      * @return Old property value for the provided key
      */
     public EDIFPropertyValue addProperty(String key, EDIFPropertyValue value) {
-        if (properties == null) properties = getNewMap();
-        return properties.put(key, value);
+        Objects.requireNonNull(key, "EDIF property key cannot be null");
+        Object d = propertyData;
+        if (d == null) {
+            propertyData = new Object[] { key, value };
+            return null;
+        }
+        if (d instanceof HashMap) {
+            return asMap(d).put(key, value);
+        }
+        Object[] a = (Object[]) d;
+        for (int i = 0; i < a.length; i += 2) {
+            if (a[i].equals(key)) {
+                EDIFPropertyValue old = (EDIFPropertyValue) a[i + 1];
+                a[i + 1] = value;
+                return old;
+            }
+        }
+        // New key. Promote to a HashMap first if we would exceed the compact threshold.
+        if ((a.length >> 1) >= PROMOTE_THRESHOLD) {
+            HashMap<String, EDIFPropertyValue> m = new HashMap<>(a.length);
+            for (int i = 0; i < a.length; i += 2) {
+                m.put((String) a[i], (EDIFPropertyValue) a[i + 1]);
+            }
+            m.put(key, value);
+            propertyData = m;
+            return null;
+        }
+        Object[] n = new Object[a.length + 2];
+        System.arraycopy(a, 0, n, 0, a.length);
+        n[a.length] = key;
+        n[a.length + 1] = value;
+        propertyData = n;
+        return null;
     }
 
     public EDIFPropertyValue getProperty(String key) {
-        if (properties == null) return null;
-        return properties.get(key);
+        Object d = propertyData;
+        if (d == null) return null;
+        if (d instanceof HashMap) {
+            return asMap(d).get(key);
+        }
+        Object[] a = (Object[]) d;
+        for (int i = 0; i < a.length; i += 2) {
+            if (a[i].equals(key)) {
+                return (EDIFPropertyValue) a[i + 1];
+            }
+        }
+        return null;
     }
 
     /**
-     * Creates a completely new copy of the map
-     * @return
+     * Gets the number of properties on this object without materializing a map.
+     * @return The number of properties.
+     */
+    public int getPropertyCount() {
+        Object d = propertyData;
+        if (d == null) return 0;
+        if (d instanceof HashMap) return asMap(d).size();
+        return ((Object[]) d).length >> 1;
+    }
+
+    /**
+     * Package-private raw accessor used by the {@link EDIFPropertyMap} view. The
+     * returned object is {@code null}, an {@code Object[]} of alternating
+     * key/value entries, or a {@code HashMap}.
+     */
+    protected Object getRawPropertyData() {
+        return propertyData;
+    }
+
+    /**
+     * Package-private bulk clear used by the {@link EDIFPropertyMap} view.
+     */
+    protected void clearProperties() {
+        propertyData = null;
+    }
+
+    /**
+     * Creates a completely new copy of the properties (with copied values).
+     * @return A new map of the properties, or null if this object has none.
      */
     public Map<String, EDIFPropertyValue> createDuplicatePropertiesMap() {
-        if (properties == null) return null;
-        Map<String, EDIFPropertyValue> newMap = new HashMap<>();
-        for (Entry<String, EDIFPropertyValue> e : properties.entrySet()) {
-            newMap.put(e.getKey(), new EDIFPropertyValue(e.getValue()));
+        Object d = propertyData;
+        if (d == null) return null;
+        Map<String, EDIFPropertyValue> newMap = new HashMap<>(getPropertyCount() * 2);
+        if (d instanceof HashMap) {
+            for (Entry<String, EDIFPropertyValue> e : asMap(d).entrySet()) {
+                newMap.put(e.getKey(), new EDIFPropertyValue(e.getValue()));
+            }
+        } else {
+            Object[] a = (Object[]) d;
+            for (int i = 0; i < a.length; i += 2) {
+                newMap.put((String) a[i], new EDIFPropertyValue((EDIFPropertyValue) a[i + 1]));
+            }
         }
         return newMap;
     }
 
-    /**
-     * Get all properties in native format
-     */
-    public Map<String, EDIFPropertyValue> getPropertiesMap() {
-        if (properties == null) {
-            return Collections.emptyMap();
+    private void copyPropertiesFrom(EDIFPropertyObject obj) {
+        Object d = obj.propertyData;
+        if (d == null) return;
+        if (d instanceof HashMap) {
+            for (Entry<String, EDIFPropertyValue> e : asMap(d).entrySet()) {
+                addProperty(e.getKey(), new EDIFPropertyValue(e.getValue()));
+            }
+        } else {
+            Object[] a = (Object[]) d;
+            for (int i = 0; i < a.length; i += 2) {
+                addProperty((String) a[i], new EDIFPropertyValue((EDIFPropertyValue) a[i + 1]));
+            }
         }
-        return properties;
     }
 
     /**
-     * Set all properties
+     * Get all properties in native format.  Returns a live {@link Map} view over
+     * this object's inlined property storage (mutations write through). An empty,
+     * immutable map is returned when this object has no properties.
+     */
+    public Map<String, EDIFPropertyValue> getPropertiesMap() {
+        if (propertyData == null) {
+            return Collections.emptyMap();
+        }
+        return new EDIFPropertyMap(this);
+    }
+
+    /**
+     * Set all properties.  The entries of the provided map are copied into this
+     * object's inlined storage (the map reference itself is not retained).
+     *
+     * <p>The provided map is read in full <i>before</i> this object's existing
+     * storage is replaced, so it is safe to pass this object's own live
+     * {@link #getPropertiesMap()} view (it is detected and treated as a no-op).
+     *
      * @param properties the properties to set
      */
     public void setPropertiesMap(Map<String, EDIFPropertyValue> properties) {
-        this.properties = properties;
+        // Passing this object's own live view is a no-op (the data is already ours).
+        if (properties instanceof EDIFPropertyMap && ((EDIFPropertyMap) properties).isViewOf(this)) {
+            return;
+        }
+        if (properties == null || properties.isEmpty()) {
+            propertyData = null;
+            return;
+        }
+        // Build the new backing from the source first; only then replace our own
+        // storage. This keeps the operation correct even if 'properties' aliases
+        // this object's current data (e.g. another live view of this object).
+        int n = properties.size();
+        if (n > PROMOTE_THRESHOLD) {
+            HashMap<String, EDIFPropertyValue> m = new HashMap<>(n * 2);
+            m.putAll(properties);
+            propertyData = m;
+        } else {
+            Object[] a = new Object[n * 2];
+            int i = 0;
+            for (Entry<String, EDIFPropertyValue> e : properties.entrySet()) {
+                a[i++] = e.getKey();
+                a[i++] = e.getValue();
+            }
+            // Defensive against a source whose size() and entrySet() disagree.
+            propertyData = (i == a.length) ? a : java.util.Arrays.copyOf(a, i);
+        }
     }
 
     public static final byte[] EXPORT_CONST_PROP_START = "(property ".getBytes(StandardCharsets.UTF_8);
@@ -184,8 +363,8 @@ public class EDIFPropertyObject extends EDIFName {
     public static final byte[] EXPORT_CONST_PROP_END = ")\n".getBytes(StandardCharsets.UTF_8);
 
     public void exportEDIFProperties(OutputStream os, byte[] indent, EDIFWriteLegalNameCache<?> cache, boolean stable) throws IOException{
-        if (properties == null) return;
-        for (Entry<String, EDIFPropertyValue> e : EDIFTools.sortIfStable(properties, stable)) {
+        if (propertyData == null) return;
+        for (Entry<String, EDIFPropertyValue> e : EDIFTools.sortIfStable(getPropertiesMap(), stable)) {
             try {
                 os.write(indent);
                 os.write(EXPORT_CONST_PROP_START);

--- a/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
@@ -280,6 +280,14 @@ public class ParallelEDIFParser implements AutoCloseable{
                         }
                     }
                 });
+        t.stop().start("Trim PortInst Lists");
+        // Port instance lists are built via incremental ArrayList insertion, which
+        // leaves unused capacity slack. Trim it now that all insertions are done.
+        List<EDIFCell> allCells = new ArrayList<>();
+        for (EDIFLibrary lib : netlist.getLibraries()) {
+            allCells.addAll(lib.getCells());
+        }
+        ParallelismTools.invokeAllRunnable(allCells, EDIFCell::trimEDIFPortInstLists);
         t.stop();
     }
 

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPortInstListTrim.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPortInstListTrim.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+
+/**
+ * Validates optimization "C": trimming the backing capacity of every
+ * {@link EDIFPortInstList} after a netlist is fully loaded.
+ *
+ * <p>The capacity of a {@link java.util.ArrayList} is not exposed through any
+ * public API, so the capacity-specific assertions read it via reflection. Under
+ * the Java Platform Module System this requires {@code java.base/java.util} to
+ * be open; when it is not (the default), those assertions are skipped via JUnit
+ * {@link Assumptions} while the behavioral assertions (which need no reflection)
+ * always run.</p>
+ */
+public class TestEDIFPortInstListTrim {
+
+    private static final Field ELEMENT_DATA;
+    private static final boolean CAN_READ_CAPACITY;
+    static {
+        Field f = null;
+        boolean ok = false;
+        try {
+            f = ArrayList.class.getDeclaredField("elementData");
+            ok = f.trySetAccessible();
+        } catch (Throwable t) {
+            ok = false;
+        }
+        ELEMENT_DATA = f;
+        CAN_READ_CAPACITY = ok;
+    }
+
+    private static int capacityOf(ArrayList<?> list) {
+        try {
+            return ((Object[]) ELEMENT_DATA.get(list)).length;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testTrimPreservesContentsAndLookups() {
+        // Build a list with deliberate capacity slack (ArrayList grows to >size)
+        EDIFPortInstList list = new EDIFPortInstList();
+        List<EDIFPortInst> expected = new ArrayList<>();
+        TestEDIFPortInstList helper = new TestEDIFPortInstList();
+        for (int i = 0; i < 5; i++) {
+            EDIFPortInst pi = helper.makeEDIFPortInst("inst" + i + "/I");
+            list.add(pi);
+            expected.add(pi);
+        }
+        List<EDIFPortInst> before = new ArrayList<>(list);
+
+        list.trimToSize();
+
+        // Contents and order unchanged
+        Assertions.assertEquals(before, new ArrayList<>(list));
+        // Sorted lookup still works for every element
+        for (EDIFPortInst pi : expected) {
+            Assertions.assertSame(pi, list.get(pi.getCellInst(), pi.getName()));
+        }
+
+        // Capacity assertion (only where ArrayList internals are accessible)
+        if (CAN_READ_CAPACITY) {
+            Assertions.assertEquals(list.size(), capacityOf(list),
+                    "After trimToSize, capacity should equal size");
+        }
+    }
+
+    @Test
+    public void testCapacityHadSlackBeforeTrim() {
+        Assumptions.assumeTrue(CAN_READ_CAPACITY,
+                "Skipped: java.base/java.util not open for reflection");
+        EDIFPortInstList list = new EDIFPortInstList();
+        TestEDIFPortInstList helper = new TestEDIFPortInstList();
+        for (int i = 0; i < 5; i++) {
+            list.add(helper.makeEDIFPortInst("inst" + i + "/I"));
+        }
+        Assertions.assertTrue(capacityOf(list) > list.size(),
+                "Expected ArrayList to carry capacity slack before trimming");
+        list.trimToSize();
+        Assertions.assertEquals(list.size(), capacityOf(list));
+    }
+
+    @Test
+    public void testNetlistTrimIsIdempotentAndPreservesConnectivity() {
+        EDIFNetlist netlist = EDIFTools.createNewNetlist("trimTest");
+        EDIFCell top = netlist.getTopCell();
+        EDIFCell leaf = new EDIFCell(netlist.getWorkLibrary(), "leaf");
+        EDIFPort in = leaf.createPort("I", EDIFDirection.INPUT, 1);
+        EDIFPort out = leaf.createPort("O", EDIFDirection.OUTPUT, 1);
+
+        List<EDIFCellInst> insts = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            insts.add(leaf.createCellInst("u" + i, top));
+        }
+        EDIFNet net = top.createNet("n");
+        for (EDIFCellInst inst : insts) {
+            net.createPortInst(in, inst);
+        }
+        int netSize = net.getPortInsts().size();
+        Assertions.assertEquals(insts.size(), netSize);
+
+        netlist.trimEDIFPortInstLists();
+
+        // Connectivity preserved
+        Assertions.assertEquals(netSize, net.getPortInsts().size());
+        for (EDIFCellInst inst : insts) {
+            Assertions.assertNotNull(net.getPortInst(inst, "I"));
+            Assertions.assertNotNull(inst.getPortInst("I"));
+        }
+        if (CAN_READ_CAPACITY) {
+            EDIFPortInstList netList = net.getEDIFPortInstList();
+            Assertions.assertEquals(netList.size(), capacityOf(netList));
+        }
+
+        // Idempotent: a second trim changes nothing observable
+        netlist.trimEDIFPortInstLists();
+        Assertions.assertEquals(netSize, net.getPortInsts().size());
+
+        // After trim we can still add and look up new port insts
+        net.createPortInst(out, insts.get(0));
+        Assertions.assertNotNull(net.getPortInst(insts.get(0), "O"));
+    }
+
+    @Test
+    public void testParserProducesTrimmedLists(@TempDir Path dir) {
+        Assumptions.assumeTrue(CAN_READ_CAPACITY,
+                "Skipped: java.base/java.util not open for reflection");
+        // Validate the pure EDIF parse path: export a netlist and read it back.
+        // (Design.loadDCP additionally expands macros AFTER parsing, which creates
+        // new untrimmed lists; optimization C targets the parse itself, which is
+        // also what EDIFTools.readEdifFile exercises.)
+        Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
+        Path edf = dir.resolve("parsed.edf");
+        design.getNetlist().exportEDIF(edf.toString());
+        EDIFNetlist netlist = EDIFTools.readEdifFile(edf);
+
+        int listsChecked = 0;
+        int nonTrivial = 0;
+        for (EDIFLibrary lib : netlist.getLibraries()) {
+            for (EDIFCell cell : lib.getCells()) {
+                for (EDIFNet net : cell.getNets()) {
+                    EDIFPortInstList l = net.getEDIFPortInstList();
+                    if (l == null) continue;
+                    Assertions.assertEquals(l.size(), capacityOf(l),
+                            "Net port inst list not trimmed: " + cell.getName() + "/" + net.getName());
+                    listsChecked++;
+                    if (l.size() > 1) nonTrivial++;
+                }
+                for (EDIFCellInst inst : cell.getCellInsts()) {
+                    EDIFPortInstList l = inst.getEDIFPortInstList();
+                    if (l == null) continue;
+                    Assertions.assertEquals(l.size(), capacityOf(l),
+                            "Inst port inst list not trimmed: " + cell.getName() + "/" + inst.getName());
+                    listsChecked++;
+                    if (l.size() > 1) nonTrivial++;
+                }
+            }
+        }
+        Assertions.assertTrue(listsChecked > 100, "Expected to check many lists, only saw " + listsChecked);
+        Assertions.assertTrue(nonTrivial > 0, "Expected some multi-element lists");
+    }
+
+    @Test
+    public void testRoundTripUnaffectedByTrim(@TempDir Path dir) {
+        // Trimming must not alter the exported EDIF
+        Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
+        EDIFNetlist netlist = design.getNetlist();
+        Path out1 = dir.resolve("trim1.edf");
+        Path out2 = dir.resolve("trim2.edf");
+        netlist.exportEDIF(out1.toString());
+        netlist.trimEDIFPortInstLists();
+        netlist.exportEDIF(out2.toString());
+        Assertions.assertEquals(readAll(out1), readAll(out2));
+    }
+
+    private static String readAll(Path p) {
+        try {
+            return new String(java.nio.file.Files.readAllBytes(p));
+        } catch (java.io.IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPortInstListTrim.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPortInstListTrim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, AMD Research and Advanced Development.

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Author: Chris Lavin, AMD Research and Advanced Development.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Random;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates {@link EDIFPropertyMap}, the memory-compact property map used by
+ * {@link EDIFPropertyObject} (optimization "A").
+ */
+public class TestEDIFPropertyMap {
+
+    private static EDIFPropertyValue v(String s) {
+        return new EDIFPropertyValue(s, EDIFValueType.STRING);
+    }
+
+    /**
+     * Creates a fresh, always-mutable {@link EDIFPropertyMap} view backed by a
+     * new {@link EDIFPropertyObject}. (The view is the public type returned by
+     * {@link EDIFPropertyObject#getPropertiesMap()}; this exercises it directly.)
+     */
+    private static EDIFPropertyMap newMap() {
+        return new EDIFPropertyMap(new EDIFPropertyObject("test"));
+    }
+
+    private static EDIFPropertyMap newMap(Map<String, EDIFPropertyValue> src) {
+        EDIFPropertyMap m = newMap();
+        m.putAll(src);
+        return m;
+    }
+
+    @Test
+    public void testBasicOperations() {
+        EDIFPropertyMap m = newMap();
+        Assertions.assertTrue(m.isEmpty());
+        Assertions.assertEquals(0, m.size());
+        Assertions.assertNull(m.get("missing"));
+        Assertions.assertFalse(m.containsKey("missing"));
+
+        Assertions.assertNull(m.put("a", v("1")));
+        Assertions.assertNull(m.put("b", v("2")));
+        Assertions.assertNull(m.put("c", v("3")));
+        Assertions.assertEquals(3, m.size());
+        Assertions.assertFalse(m.isEmpty());
+
+        Assertions.assertEquals("1", m.get("a").getValue());
+        Assertions.assertEquals("2", m.get("b").getValue());
+        Assertions.assertEquals("3", m.get("c").getValue());
+        Assertions.assertTrue(m.containsKey("a"));
+        Assertions.assertTrue(m.containsValue(v("2")));
+        Assertions.assertFalse(m.containsValue(v("nope")));
+
+        // Overwrite returns previous value and does not grow
+        EDIFPropertyValue old = m.put("b", v("22"));
+        Assertions.assertEquals("2", old.getValue());
+        Assertions.assertEquals("22", m.get("b").getValue());
+        Assertions.assertEquals(3, m.size());
+
+        // Remove
+        Assertions.assertEquals("1", m.remove("a").getValue());
+        Assertions.assertNull(m.remove("a"));
+        Assertions.assertEquals(2, m.size());
+        Assertions.assertFalse(m.containsKey("a"));
+        Assertions.assertEquals("22", m.get("b").getValue());
+        Assertions.assertEquals("3", m.get("c").getValue());
+
+        m.clear();
+        Assertions.assertTrue(m.isEmpty());
+        Assertions.assertEquals(0, m.size());
+    }
+
+    @Test
+    public void testNullHandling() {
+        EDIFPropertyMap m = newMap();
+        Assertions.assertNull(m.get(null));
+        Assertions.assertFalse(m.containsKey(null));
+        Assertions.assertNull(m.remove(null));
+        Assertions.assertThrows(NullPointerException.class, () -> m.put(null, v("x")));
+    }
+
+    @Test
+    public void testViews() {
+        EDIFPropertyMap m = newMap();
+        m.put("a", v("1"));
+        m.put("b", v("2"));
+        m.put("c", v("3"));
+
+        Assertions.assertEquals(3, m.keySet().size());
+        Assertions.assertTrue(m.keySet().contains("a"));
+        Assertions.assertTrue(m.keySet().containsAll(List.of("a", "b", "c")));
+
+        Assertions.assertEquals(3, m.values().size());
+        List<String> values = new ArrayList<>();
+        for (EDIFPropertyValue val : m.values()) {
+            values.add(val.getValue());
+        }
+        Assertions.assertTrue(values.containsAll(List.of("1", "2", "3")));
+
+        // entrySet iteration
+        Map<String, String> seen = new HashMap<>();
+        for (Map.Entry<String, EDIFPropertyValue> e : m.entrySet()) {
+            seen.put(e.getKey(), e.getValue().getValue());
+        }
+        Assertions.assertEquals(Map.of("a", "1", "b", "2", "c", "3"), seen);
+    }
+
+    @Test
+    public void testEntrySetWriteThrough() {
+        EDIFPropertyMap m = newMap();
+        m.put("a", v("1"));
+        m.put("b", v("2"));
+        for (Map.Entry<String, EDIFPropertyValue> e : m.entrySet()) {
+            if (e.getKey().equals("a")) {
+                e.setValue(v("99"));
+            }
+        }
+        Assertions.assertEquals("99", m.get("a").getValue());
+        Assertions.assertEquals("2", m.get("b").getValue());
+    }
+
+    @Test
+    public void testIteratorRemove() {
+        EDIFPropertyMap m = newMap();
+        m.put("a", v("1"));
+        m.put("b", v("2"));
+        m.put("c", v("3"));
+        m.put("d", v("4"));
+
+        Iterator<String> it = m.keySet().iterator();
+        while (it.hasNext()) {
+            String k = it.next();
+            if (k.equals("b") || k.equals("d")) {
+                it.remove();
+            }
+        }
+        Assertions.assertEquals(2, m.size());
+        Assertions.assertTrue(m.containsKey("a"));
+        Assertions.assertTrue(m.containsKey("c"));
+        Assertions.assertFalse(m.containsKey("b"));
+        Assertions.assertFalse(m.containsKey("d"));
+    }
+
+    @Test
+    public void testConcurrentModification() {
+        EDIFPropertyMap m = newMap();
+        m.put("a", v("1"));
+        m.put("b", v("2"));
+        Iterator<String> it = m.keySet().iterator();
+        it.next();
+        m.put("c", v("3")); // structural modification
+        Assertions.assertThrows(ConcurrentModificationException.class, it::next);
+    }
+
+    @Test
+    public void testEmptyIterator() {
+        EDIFPropertyMap m = newMap();
+        Iterator<String> it = m.keySet().iterator();
+        Assertions.assertFalse(it.hasNext());
+        Assertions.assertThrows(NoSuchElementException.class, it::next);
+    }
+
+    @Test
+    public void testCopyConstructorAndEqualsHashCode() {
+        Map<String, EDIFPropertyValue> ref = new HashMap<>();
+        ref.put("x", v("10"));
+        ref.put("y", v("20"));
+
+        EDIFPropertyMap m = newMap(ref);
+        Assertions.assertEquals(2, m.size());
+        Assertions.assertEquals(ref, m);
+        Assertions.assertEquals(m, ref);
+        // Map.equals/hashCode contract: equal maps share hashCode
+        Assertions.assertEquals(ref.hashCode(), m.hashCode());
+
+        // A HashMap constructed from our map must round-trip
+        Map<String, EDIFPropertyValue> copy = new HashMap<>(m);
+        Assertions.assertEquals(m, copy);
+    }
+
+    @Test
+    public void testPutAll() {
+        EDIFPropertyMap m = newMap();
+        m.put("keep", v("0"));
+        Map<String, EDIFPropertyValue> src = new HashMap<>();
+        src.put("a", v("1"));
+        src.put("b", v("2"));
+        m.putAll(src);
+        Assertions.assertEquals(3, m.size());
+        Assertions.assertEquals("0", m.get("keep").getValue());
+        Assertions.assertEquals("1", m.get("a").getValue());
+        Assertions.assertEquals("2", m.get("b").getValue());
+    }
+
+    /**
+     * Collection views (keySet/values/entrySet) obtained while the backing is in
+     * its compact representation must remain consistent if the map is later
+     * promoted to a HashMap. In particular {@code size()} and iteration must
+     * agree; a stale view must not silently drop entries.
+     */
+    @Test
+    public void testCachedViewsSurvivePromotion() {
+        EDIFPropertyMap m = newMap();
+        m.put("k0", v("0")); // compact at this point
+
+        // Obtain the views while compact, then force promotion.
+        java.util.Set<String> keys = m.keySet();
+        java.util.Collection<EDIFPropertyValue> vals = m.values();
+        java.util.Set<Map.Entry<String, EDIFPropertyValue>> entries = m.entrySet();
+
+        int n = EDIFPropertyObject.PROMOTE_THRESHOLD + 5;
+        for (int i = 1; i < n; i++) {
+            m.put("k" + i, v(Integer.toString(i)));
+        }
+        // Sanity: we actually crossed into the promoted representation.
+        Assertions.assertTrue(m.size() > EDIFPropertyObject.PROMOTE_THRESHOLD);
+
+        // size() of the cached views reflects the promoted map...
+        Assertions.assertEquals(n, keys.size());
+        Assertions.assertEquals(n, vals.size());
+        Assertions.assertEquals(n, entries.size());
+
+        // ...and iteration agrees with size() (no dropped entries).
+        java.util.Set<String> iterated = new java.util.HashSet<>();
+        for (String k : keys) {
+            iterated.add(k);
+        }
+        Assertions.assertEquals(n, iterated.size());
+        for (int i = 0; i < n; i++) {
+            Assertions.assertTrue(iterated.contains("k" + i), "missing k" + i);
+        }
+
+        int valCount = 0;
+        for (EDIFPropertyValue ignored : vals) {
+            valCount++;
+        }
+        Assertions.assertEquals(n, valCount);
+
+        int entryCount = 0;
+        for (Map.Entry<String, EDIFPropertyValue> e : entries) {
+            Assertions.assertEquals(m.get(e.getKey()), e.getValue());
+            entryCount++;
+        }
+        Assertions.assertEquals(n, entryCount);
+    }
+
+    /**
+     * Verifies the transparent promotion from the compact array representation to
+     * a HashMap once the entry count crosses {@link EDIFPropertyObject#PROMOTE_THRESHOLD}.
+     * Behavior and contents must be identical across the boundary.
+     */
+    @Test
+    public void testPromotionAcrossThreshold() {
+        EDIFPropertyMap m = newMap();
+        HashMap<String, EDIFPropertyValue> ref = new HashMap<>();
+        int n = EDIFPropertyObject.PROMOTE_THRESHOLD + 5; // force promotion
+        for (int i = 0; i < n; i++) {
+            m.put("k" + i, v("v" + i));
+            ref.put("k" + i, v("v" + i));
+            Assertions.assertEquals(i + 1, m.size());
+            // Every entry inserted so far must still be retrievable
+            for (int j = 0; j <= i; j++) {
+                Assertions.assertEquals("v" + j, m.get("k" + j).getValue());
+            }
+        }
+        Assertions.assertEquals(ref, m);
+        Assertions.assertEquals(ref.keySet(), m.keySet());
+        Assertions.assertEquals(ref.hashCode(), m.hashCode());
+
+        // Overwrite (no size change) and removal still work after promotion
+        Assertions.assertEquals("v0", m.put("k0", v("changed")).getValue());
+        Assertions.assertEquals("changed", m.get("k0").getValue());
+        Assertions.assertEquals(n, m.size());
+        Assertions.assertEquals("changed", m.remove("k0").getValue());
+        Assertions.assertNull(m.get("k0"));
+        Assertions.assertEquals(n - 1, m.size());
+
+        // Iteration over the promoted map yields all remaining entries
+        int count = 0;
+        for (Map.Entry<String, EDIFPropertyValue> e : m.entrySet()) {
+            Assertions.assertEquals(m.get(e.getKey()), e.getValue());
+            count++;
+        }
+        Assertions.assertEquals(n - 1, count);
+    }
+
+    /**
+     * Exercises a map with several hundred entries (as seen on transceiver
+     * primitives) to ensure the promoted (HashMap-backed) path is correct.
+     */
+    @Test
+    public void testLargeMap() {
+        EDIFPropertyMap m = newMap();
+        HashMap<String, EDIFPropertyValue> ref = new HashMap<>();
+        for (int i = 0; i < 600; i++) {
+            m.put("p" + i, v(Integer.toString(i)));
+            ref.put("p" + i, v(Integer.toString(i)));
+        }
+        Assertions.assertEquals(600, m.size());
+        Assertions.assertEquals(ref, m);
+        for (int i = 0; i < 600; i++) {
+            Assertions.assertEquals(Integer.toString(i), m.get("p" + i).getValue());
+        }
+        // copy constructor of a large map stays consistent
+        EDIFPropertyMap copy = newMap(m);
+        Assertions.assertEquals(m, copy);
+        Assertions.assertEquals(600, copy.size());
+    }
+
+    /**
+     * Differential fuzz test: apply the same random sequence of operations to an
+     * {@link EDIFPropertyMap} and a reference {@link HashMap} and assert that the
+     * two remain equivalent throughout. The key space (24) exceeds
+     * {@link EDIFPropertyObject#PROMOTE_THRESHOLD}, so this also exercises promotion.
+     */
+    @Test
+    public void testRandomizedAgainstHashMap() {
+        Random rand = new Random(0xC0FFEE);
+        EDIFPropertyMap m = newMap();
+        HashMap<String, EDIFPropertyValue> ref = new HashMap<>();
+
+        String[] keys = new String[24];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = "k" + i;
+        }
+
+        for (int iter = 0; iter < 20000; iter++) {
+            String key = keys[rand.nextInt(keys.length)];
+            int op = rand.nextInt(10);
+            if (op < 6) {
+                EDIFPropertyValue val = v("val" + rand.nextInt(100));
+                Assertions.assertEquals(ref.put(key, val), m.put(key, val));
+            } else if (op < 8) {
+                Assertions.assertEquals(ref.remove(key), m.remove(key));
+            } else if (op == 8) {
+                Assertions.assertEquals(ref.get(key), m.get(key));
+                Assertions.assertEquals(ref.containsKey(key), m.containsKey(key));
+            } else {
+                Assertions.assertEquals(ref.size(), m.size());
+            }
+            Assertions.assertEquals(ref.size(), m.size());
+        }
+
+        // Final structural equivalence
+        Assertions.assertEquals(ref, m);
+        Assertions.assertEquals(m, ref);
+        Assertions.assertEquals(ref.keySet(), m.keySet());
+        Assertions.assertEquals(ref.hashCode(), m.hashCode());
+        for (String k : keys) {
+            Assertions.assertEquals(ref.get(k), m.get(k));
+        }
+    }
+}

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Author: Chris Lavin, AMD Research and Advanced Development.

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyObject.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyObject.java
@@ -22,9 +22,14 @@
 
 package com.xilinx.rapidwright.edif;
 
+import java.nio.file.Path;
+import java.util.Map;
+
 import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestEDIFPropertyObject {
     @Test
@@ -37,5 +42,131 @@ public class TestEDIFPropertyObject {
 
         obufds.addProperty("IOSTANDARD", "LVDS");
         Assertions.assertEquals("LVDS", obufds.getIOStandard().getValue());
+    }
+
+    /**
+     * Test properties backed by the memory-compact
+     * {@link EDIFPropertyMap} rather than a {@link java.util.HashMap}.
+     */
+    @Test
+    public void testPropertiesUseCompactMap() {
+        EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+        EDIFCellInst inst = netlist.getTopCell().createChildCellInst("u0",
+                Design.getPrimitivesLibrary().getCell("FDRE"));
+
+        // No properties yet -> empty (immutable) map
+        Assertions.assertTrue(inst.getPropertiesMap().isEmpty());
+
+        inst.addProperty("INIT", "1'b0");
+        inst.addProperty("IS_C_INVERTED", "1'b0");
+
+        Map<String, EDIFPropertyValue> map = inst.getPropertiesMap();
+        Assertions.assertTrue(map instanceof EDIFPropertyMap,
+                "Expected EDIFPropertyMap backing, got " + map.getClass());
+        Assertions.assertEquals(2, map.size());
+        Assertions.assertEquals("1'b0", inst.getProperty("INIT").getValue());
+
+        // Behaves like a Map for all standard operations
+        Assertions.assertTrue(map.containsKey("INIT"));
+        Assertions.assertEquals(2, map.keySet().size());
+        Assertions.assertEquals(2, map.entrySet().size());
+
+        // Removal works through the object API
+        Assertions.assertEquals("1'b0", inst.removeProperty("INIT").getValue());
+        Assertions.assertNull(inst.getProperty("INIT"));
+        Assertions.assertEquals(1, inst.getPropertiesMap().size());
+    }
+
+    /**
+     * The map returned by getPropertiesMap() is a live view over the object's
+     * inlined storage: mutations made through the object are visible through a
+     * previously-obtained map, and vice versa.
+     */
+    @Test
+    public void testPropertiesMapIsLiveView() {
+        EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+        EDIFCellInst inst = netlist.getTopCell().createChildCellInst("u0",
+                Design.getPrimitivesLibrary().getCell("FDRE"));
+        inst.addProperty("A", "1");
+
+        Map<String, EDIFPropertyValue> view = inst.getPropertiesMap();
+        Assertions.assertEquals(1, view.size());
+
+        // Mutation through the object is reflected in the previously-obtained view
+        inst.addProperty("B", "2");
+        Assertions.assertEquals(2, view.size());
+        Assertions.assertEquals("2", view.get("B").getValue());
+
+        // Mutation through the view is reflected on the object
+        view.put("C", new EDIFPropertyValue("3", EDIFValueType.STRING));
+        Assertions.assertEquals("3", inst.getProperty("C").getValue());
+
+        inst.removeProperty("A");
+        Assertions.assertFalse(view.containsKey("A"));
+        Assertions.assertEquals(2, view.size());
+    }
+
+    /**
+     * setPropertiesMap() must not lose data when handed this object's own live
+     * getPropertiesMap() view (it reads the source before replacing storage).
+     */
+    @Test
+    public void testSetPropertiesMapWithOwnLiveView() {
+        EDIFNetlist netlist = EDIFTools.createNewNetlist("test");
+        EDIFCellInst inst = netlist.getTopCell().createChildCellInst("u0",
+                Design.getPrimitivesLibrary().getCell("FDRE"));
+        inst.addProperty("A", "1");
+        inst.addProperty("B", "2");
+
+        // Passing the object's own live view must preserve all properties.
+        Map<String, EDIFPropertyValue> ownView = inst.getPropertiesMap();
+        inst.setPropertiesMap(ownView);
+        Assertions.assertEquals(2, inst.getPropertyCount());
+        Assertions.assertEquals("1", inst.getProperty("A").getValue());
+        Assertions.assertEquals("2", inst.getProperty("B").getValue());
+
+        // Passing another object's live view copies it (and does not alias).
+        EDIFCellInst other = netlist.getTopCell().createChildCellInst("u1",
+                Design.getPrimitivesLibrary().getCell("FDRE"));
+        other.setPropertiesMap(inst.getPropertiesMap());
+        Assertions.assertEquals(2, other.getPropertyCount());
+        // Mutating the source afterwards must not affect the copy.
+        inst.addProperty("C", "3");
+        Assertions.assertEquals(2, other.getPropertyCount());
+        Assertions.assertNull(other.getProperty("C"));
+
+        // Setting an empty map clears.
+        inst.setPropertiesMap(new java.util.HashMap<>());
+        Assertions.assertEquals(0, inst.getPropertyCount());
+    }
+
+    /**
+     * Properties must survive an EDIF read/write round-trip
+     * unchanged when stored in the compact map.
+     */
+    @Test
+    public void testPropertiesSurviveRoundTrip(@TempDir Path dir) {
+        Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
+        EDIFNetlist netlist = design.getNetlist();
+
+        java.nio.file.Path out = dir.resolve("roundtrip.edf");
+        netlist.exportEDIF(out.toString());
+        EDIFNetlist reloaded = EDIFTools.readEdifFile(out);
+
+        // Spot-check that every cell instance in the top cell preserved its
+        // property set across the round trip.
+        EDIFCell top = netlist.getTopCell();
+        EDIFCell topReloaded = reloaded.getTopCell();
+        for (EDIFCellInst inst : top.getCellInsts()) {
+            EDIFCellInst other = topReloaded.getCellInst(inst.getName());
+            Assertions.assertNotNull(other, "Missing inst after round trip: " + inst.getName());
+            Map<String, EDIFPropertyValue> a = inst.getPropertiesMap();
+            Map<String, EDIFPropertyValue> b = other.getPropertiesMap();
+            Assertions.assertEquals(a.keySet(), b.keySet(), "Property keys differ for " + inst.getName());
+            for (String key : a.keySet()) {
+                Assertions.assertEquals(a.get(key).getValue(), b.get(key).getValue(),
+                        "Property value differs for " + inst.getName() + "." + key);
+            }
+        }
     }
 }


### PR DESCRIPTION
Loading very large netlists (from large EDIF files) consumes a lot of heap memory.  This PR aims to reduce the memory needed to represent the logical netlist while maintaining high performance and agility in manipulation of the netlist.  

This PR implements two main optimizations:
1. After EDIF parse, this will call the `.trim()` method on all `EDIFPortInstList` objects.  This removes any extra slack space used in the lists as many designs.  This does incur a cost of runtime in that any modifications to these lists will require a re-sizing of the array on first addition to the list.
2. There are several objects that can store properties and using a HashMap for each object was memory inefficient.  This PR implements a new hybrid approach in that a private object can store either an `Object[]` for up to 16 properties or switch to a `HashMap` for objects with greater than 16 properties.  Over 99.99% of objects have 8 properties or less so only rarely (such as transceiver objects) get promoted.  These changes were added to `EDIFPropertyObject` such that the map data lives directly in the object to avoid creating additional objects.  For live map access, upon API request, a new `EDIFPropertyMap` can be created backed by the `EDIFPropertyObject` data to allow a live view of the properties.  

A few EDIF netlists were surveyed and measured before/after these changes using a 64GB virtual machine with 8 cores (uncontrolled environment, so runtime values are noisy):

| EDIF File Size | Property objects | Mem base | Mem opt | Δ Mem | Load base | Load opt | Export base | Export opt |
|---|--:|--:|--:|--:|--:|--:|--:|--:|
| 0.63 GB | 0.62 M | 639 MB | 540 MB | −15.4 % | 8.3 s | 8.4 s | 7.0 s | 6.7 s |
| 5.28 GB | 7.92 M | 6198 MB | 5002 MB | −19.3 % | 46.0 s | 36.8 s | 46.9 s | 42.0 s |
| 5.95 GB | 15.13 M | 7632 MB | 5870 MB | −23.1 % | 54.6 s | 60.9 s | 62.6 s | 54.4 s |

Based on these results, this PR can reduce total memory usage of the `EDIFNetlist` by up to 23% (nearly 2GBs of RAM for a 6GB EDIF).  Export runtime is also marginally improved whereas load runtime behavior is mixed.  