### PR TITLE
Remove unnecessary reporting in NOC json

### DIFF
--- a/src/com/xilinx/rapidwright/design/noc/NOCClient.java
+++ b/src/com/xilinx/rapidwright/design/noc/NOCClient.java
@@ -26,8 +26,10 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.json.JSONObject;
 
@@ -55,6 +57,7 @@ public class NOCClient implements Serializable {
     private Map<String, String> simMetaData;
 
     private static final ArrayList<String> unsupportedFields = new ArrayList<String>();
+    private static final Set<String> warnedUnsupportedFields = new HashSet<>();
 
     static {
         unsupportedFields.add("SysAddress");
@@ -64,7 +67,6 @@ public class NOCClient implements Serializable {
         unsupportedFields.add("NumWriteOutstanding");
         unsupportedFields.add("ReadRateLimiter");
         unsupportedFields.add("WriteRateLimiter");
-        //unsupportedFields.add("InterleaveSize");
     };
 
     /**
@@ -130,8 +132,6 @@ public class NOCClient implements Serializable {
                 simMetaData.put(key, value);
             }
         }
-
-        checkUnsupportedFields(json);
     }
 
     /**
@@ -141,8 +141,10 @@ public class NOCClient implements Serializable {
      */
     public void checkUnsupportedFields(JSONObject json) {
         for (String s : unsupportedFields) {
-            if (json.has(s))
-                System.out.println("Unsupported field " + s + " encountered in " + name);
+            if (json.has(s) && warnedUnsupportedFields.add(s)) {
+                System.out.println("WARNING: Unsupported NOC field '" + s +
+                    "' encountered (e.g., client " + name + "); field will be ignored.");
+            }
         }
     }
 

--- a/src/com/xilinx/rapidwright/design/noc/NOCConnection.java
+++ b/src/com/xilinx/rapidwright/design/noc/NOCConnection.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -60,6 +61,7 @@ public class NOCConnection implements Serializable {
 
 
     private static final ArrayList<String> unsupportedFields = new ArrayList<String>();
+    private static final Set<String> warnedUnsupportedFields = new HashSet<>();
     static {
         unsupportedFields.add("WriteBurstSize");
         unsupportedFields.add("ReadBurstSize");
@@ -122,10 +124,6 @@ public class NOCConnection implements Serializable {
         if (json.has(NOCJSONUtil.JSON_FIELD_EXCLUSIVE_GROUP)) {
             exclusiveGroup = json.getString(NOCJSONUtil.JSON_FIELD_EXCLUSIVE_GROUP);
         }
-
-        //= json.getString("ReadTC"); //Redundant: NOC Master
-        //= json.getString("WriteTC"); //Redundant: NOC Master
-        checkUnsupportedFields(json);
     }
 
     /**
@@ -135,9 +133,11 @@ public class NOCConnection implements Serializable {
      */
     public void checkUnsupportedFields(JSONObject json) {
         for (String s : unsupportedFields) {
-            if (json.has(s))
-                System.out.println("Unsupported field " + s +
-                    " encountered in Path " + source + " -> " + dest);
+            if (json.has(s) && warnedUnsupportedFields.add(s)) {
+                System.out.println("WARNING: Unsupported NOC field '" + s +
+                    "' encountered (e.g., Path " + source + " -> " + dest +
+                    "); field will be ignored.");
+            }
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/Xilinx/RapidWright/issues/1372.

No longer reports unsupported fields by default when loading DCPs.  This checking is not necessary and is reserved for debug scenarios.