### PR TITLE
[EDIFNetlist] NetlistValidator - A tool for checking output EDIF for inconsistencies before they are found on Vivado import

### DIFF
--- a/src/com/xilinx/rapidwright/MainEntrypoint.java
+++ b/src/com/xilinx/rapidwright/MainEntrypoint.java
@@ -58,6 +58,7 @@ import com.xilinx.rapidwright.edif.EDIFParser;
 import com.xilinx.rapidwright.edif.EDIFPropertyValue;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.edif.compare.EDIFNetlistComparator;
+import com.xilinx.rapidwright.edif.validate.NetlistValidator;
 import com.xilinx.rapidwright.examples.AddSubGenerator;
 import com.xilinx.rapidwright.examples.CopyMMCMCell;
 import com.xilinx.rapidwright.examples.CountRoutedNets;
@@ -189,6 +190,7 @@ public class MainEntrypoint {
         addFunction("MultGenerator", MultGenerator::main);
         addFunction("NetlistBrowser", NetlistBrowser::main);
         addFunction("NetlistClockDetection", NetlistClockDetection::main);
+        addFunction("NetlistValidator", NetlistValidator::main);
         addFunction("PartPrinter", PartPrinter::main);
         addFunction("PartTileBrowser", PartTileBrowser::main);
         addFunction("PartialCUFR", PartialCUFR::main);

--- a/src/com/xilinx/rapidwright/edif/validate/IssueCode.java
+++ b/src/com/xilinx/rapidwright/edif/validate/IssueCode.java
@@ -62,6 +62,11 @@ public enum IssueCode {
     PORT_NONPOSITIVE_WIDTH(Severity.ERROR),
     PORT_WIDTH_MISMATCH(Severity.ERROR),
     PORT_NULL_DIRECTION(Severity.ERROR),
+    // A top-level single-bit port whose name ends with ']' (e.g. port[0]) that is
+    // not protected with the EDIFTools.VIVADO_PRESERVE_PORT_INTERFACE ("[]") prefix.
+    // Vivado will incorrectly merge such ports into a bus, breaking interface
+    // matching against a black box. See EDIFTools.ensurePreservedInterfaceVivado().
+    PORT_VIVADO_BUS_GROUPING(Severity.WARNING),
 
     // F. Net
     NET_PARENT_BROKEN(Severity.ERROR),

--- a/src/com/xilinx/rapidwright/edif/validate/IssueCode.java
+++ b/src/com/xilinx/rapidwright/edif/validate/IssueCode.java
@@ -1,0 +1,104 @@
+/*
+ *
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.validate;
+
+/**
+ * Stable identifiers for each class of inconsistency the
+ * {@link NetlistValidator} detects. The default {@link Severity} travels
+ * with the code but can be escalated (e.g. warnings-as-errors) by the caller.
+ */
+public enum IssueCode {
+    // A. Netlist / Design / top-level
+    NULL_DESIGN(Severity.ERROR),
+    NULL_TOP_CELL(Severity.ERROR),
+    TOP_CELL_NOT_IN_NETLIST(Severity.ERROR),
+    TOP_CELL_IN_PRIMITIVES_LIB(Severity.ERROR),
+    TOP_INST_STALE(Severity.WARNING),
+    MISSING_PART_PROPERTY(Severity.WARNING),
+
+    // B. Library
+    LIBRARY_NETLIST_BACKPTR_BROKEN(Severity.ERROR),
+    LIBRARY_KEY_MISMATCH(Severity.ERROR),
+    CELL_LIBRARY_BACKPTR_BROKEN(Severity.ERROR),
+    CELL_IN_MULTIPLE_LIBRARIES(Severity.ERROR),
+    CIRCULAR_LIBRARY_DEP(Severity.ERROR),
+
+    // C. Cell
+    CELL_MAP_KEY_MISMATCH(Severity.ERROR),
+    PORT_MAP_KEY_MISMATCH(Severity.ERROR),
+    INTERNAL_PORTMAP_STALE(Severity.ERROR),
+    INTERNAL_PORTMAP_MISSING(Severity.WARNING),
+    EMPTY_OBJECT_NAME(Severity.ERROR),
+
+    // D. CellInst
+    CELLINST_PARENT_BROKEN(Severity.ERROR),
+    CELLINST_NULL_CELLTYPE(Severity.ERROR),
+    INST_DANGLING_CELLTYPE(Severity.ERROR),
+    VIEWREF_MISMATCH(Severity.WARNING),
+    BLACKBOX_HAS_CONTENTS(Severity.WARNING),
+    INSTANTIATION_COUNT_DRIFT(Severity.INFO),
+
+    // E. Port
+    PORT_PARENT_BROKEN(Severity.ERROR),
+    PORT_MALFORMED_BUS_NAME(Severity.ERROR),
+    PORT_NONPOSITIVE_WIDTH(Severity.ERROR),
+    PORT_WIDTH_MISMATCH(Severity.ERROR),
+    PORT_NULL_DIRECTION(Severity.ERROR),
+
+    // F. Net
+    NET_PARENT_BROKEN(Severity.ERROR),
+    NET_MULTI_DRIVER(Severity.ERROR),
+    // A net that only appears multi-driven because of a Vivado "lopt"
+    // logic-optimization output pin; a benign post-optimization artifact.
+    NET_MULTI_DRIVER_LOPT(Severity.INFO),
+    // Undriven-with-sinks is legal and common in OOC / black-box / emulation
+    // netlists, so it is informational rather than a warning.
+    NET_UNDRIVEN(Severity.INFO),
+    NET_EMPTY(Severity.INFO),
+    NET_NAME_LEGALIZATION_COLLISION(Severity.ERROR),
+
+    // G. PortInst
+    PORTINST_PARENTNET_BROKEN(Severity.ERROR),
+    PORTINST_DUAL_MEMBERSHIP_BROKEN(Severity.ERROR),
+    PORTINST_NULL_PORT(Severity.ERROR),
+    PORTINST_PORT_WRONG_CELL(Severity.ERROR),
+    PORTINST_INDEX_MISMATCH(Severity.ERROR),
+    PORTINST_NAME_DESYNC(Severity.ERROR),
+    PORTINST_DUPLICATE_ON_NET(Severity.ERROR),
+    PORT_BIT_MULTIPLY_CONNECTED(Severity.ERROR),
+
+    // H. Name legalization (sibling-scope collisions)
+    NAME_LEGALIZATION_COLLISION(Severity.ERROR),
+
+    // I. Hierarchy
+    CYCLIC_HIERARCHY(Severity.ERROR),
+    UNREACHABLE_CELL(Severity.INFO);
+
+    private final Severity defaultSeverity;
+
+    IssueCode(Severity defaultSeverity) {
+        this.defaultSeverity = defaultSeverity;
+    }
+
+    public Severity getDefaultSeverity() {
+        return defaultSeverity;
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/validate/NetlistValidator.java
+++ b/src/com/xilinx/rapidwright/edif/validate/NetlistValidator.java
@@ -162,6 +162,33 @@ public class NetlistValidator {
             add(IssueCode.MISSING_PART_PROPERTY, loc(netlist),
                     "No PART property found on the design; Vivado requires a part");
         }
+        checkVivadoBusGrouping(top);
+    }
+
+    /**
+     * Flags top-level single-bit ports that Vivado would incorrectly group into a
+     * bus on read-back (e.g. {@code port[0]}, {@code port[1]} merged into
+     * {@code port[1:0]}), which breaks interface matching against a black box. The
+     * remedy is {@link EDIFTools#ensurePreservedInterfaceVivado(EDIFNetlist)},
+     * which prepends {@link EDIFTools#VIVADO_PRESERVE_PORT_INTERFACE} ("[]") to
+     * these names. This uses the exact predicate of that method, so a netlist that
+     * has already been preserved reports nothing.
+     *
+     * @param top The top cell whose interface ports are checked.
+     */
+    private void checkVivadoBusGrouping(EDIFCell top) {
+        for (EDIFPort p : top.getPorts()) {
+            String name = p.getName();
+            if (!p.isBus()
+                    && !name.startsWith(EDIFTools.VIVADO_PRESERVE_PORT_INTERFACE)
+                    && name.endsWith("]")) {
+                add(IssueCode.PORT_VIVADO_BUS_GROUPING, portLoc(top, p),
+                        "Top-level single-bit port '" + name + "' would be merged into a bus by "
+                                + "Vivado on read-back, breaking interface matching; prefix it with '"
+                                + EDIFTools.VIVADO_PRESERVE_PORT_INTERFACE
+                                + "' (EDIFTools.ensurePreservedInterfaceVivado())");
+            }
+        }
     }
 
     /* ------------------------------------------------------------------ *

--- a/src/com/xilinx/rapidwright/edif/validate/NetlistValidator.java
+++ b/src/com/xilinx/rapidwright/edif/validate/NetlistValidator.java
@@ -1,0 +1,741 @@
+/*
+ *
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.validate;
+
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFDesign;
+import com.xilinx.rapidwright.edif.EDIFDirection;
+import com.xilinx.rapidwright.edif.EDIFLibrary;
+import com.xilinx.rapidwright.edif.EDIFName;
+import com.xilinx.rapidwright.edif.EDIFNet;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPort;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import com.xilinx.rapidwright.tests.CodePerfTracker;
+
+/**
+ * Comprehensively traverses an {@link EDIFNetlist} object graph and reports any
+ * structural inconsistencies or EDIF-export-safety problems that could otherwise
+ * write out as valid-looking EDIF but fail or silently corrupt when read into
+ * Vivado.
+ *
+ * <p>This validator focuses on the in-memory object graph and EDIF export
+ * semantics; it does not perform device- or Unisim-aware checks (primitive pin
+ * legality, required properties, etc.).</p>
+ *
+ * <p>The validator never throws on an inconsistency it is designed to detect;
+ * instead it accumulates {@link ValidationIssue} objects into an
+ * {@link ValidationReport}. It is designed to run on very large netlists:
+ * the heavy per-cell pass only ever builds maps scoped to a single cell, and the
+ * report caps the number of stored issues per code.</p>
+ */
+public class NetlistValidator {
+
+    /** If false, skips sibling-scope EDIF name-legalization collision checks. */
+    public boolean checkNameLegalization = true;
+
+    /**
+     * If true, verifies that each cell's cached non-hierarchical instantiation
+     * count matches the actual number of instantiations found during traversal.
+     */
+    public boolean checkInstantiationCounts = true;
+
+    /** Codes the caller has chosen to suppress entirely. */
+    public Set<IssueCode> disabledCodes = new HashSet<>();
+
+    /** Per-code cap on retained issues (overflow is still counted). */
+    public int maxIssuesPerCode = ValidationReport.DEFAULT_MAX_ISSUES_PER_CODE;
+
+    private ValidationReport report;
+
+    /** Identity set of every cell owned by a library of the netlist under test. */
+    private Set<EDIFCell> netlistCells;
+
+    /** Actual instantiation counts observed during the per-cell pass. */
+    private Map<EDIFCell, Integer> observedInstCounts;
+
+    /**
+     * Validates the provided netlist and returns a report of all issues found.
+     *
+     * @param netlist The netlist to validate.
+     * @return The populated validation report.
+     */
+    public ValidationReport validate(EDIFNetlist netlist) {
+        report = new ValidationReport(maxIssuesPerCode);
+        netlistCells = null;
+        observedInstCounts = checkInstantiationCounts ? new IdentityHashMap<>() : null;
+
+        buildCellIndex(netlist);
+        checkTopAndDesign(netlist);
+        checkLibraries(netlist);
+        for (EDIFLibrary lib : netlist.getLibraries()) {
+            for (EDIFCell cell : lib.getCells()) {
+                checkCell(cell);
+            }
+        }
+        checkInstantiationCountDrift();
+        checkHierarchyAndReachability(netlist);
+
+        return report;
+    }
+
+    private void add(IssueCode code, String location, String message) {
+        if (disabledCodes.contains(code)) {
+            return;
+        }
+        report.add(code, location, message);
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Index construction
+     * ------------------------------------------------------------------ */
+
+    private void buildCellIndex(EDIFNetlist netlist) {
+        netlistCells = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (EDIFLibrary lib : netlist.getLibraries()) {
+            for (EDIFCell cell : lib.getCells()) {
+                netlistCells.add(cell);
+            }
+        }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Pass 0: top / design / part
+     * ------------------------------------------------------------------ */
+
+    private void checkTopAndDesign(EDIFNetlist netlist) {
+        EDIFDesign design = netlist.getDesign();
+        if (design == null) {
+            add(IssueCode.NULL_DESIGN, loc(netlist), "Netlist has no EDIFDesign set");
+            return;
+        }
+        EDIFCell top = design.getTopCell();
+        if (top == null) {
+            add(IssueCode.NULL_TOP_CELL, loc(netlist), "EDIFDesign has no top cell set");
+            return;
+        }
+        if (netlistCells != null && !netlistCells.contains(top)) {
+            add(IssueCode.TOP_CELL_NOT_IN_NETLIST, cellLoc(top),
+                    "Top cell is not contained in any library of this netlist");
+        }
+        EDIFLibrary topLib = top.getLibrary();
+        if (topLib != null && topLib.isHDIPrimitivesLibrary()) {
+            add(IssueCode.TOP_CELL_IN_PRIMITIVES_LIB, cellLoc(top),
+                    "Top cell resides in the hdi_primitives library");
+        }
+        String part = EDIFTools.getPartName(netlist);
+        if (part == null || part.isEmpty()) {
+            add(IssueCode.MISSING_PART_PROPERTY, loc(netlist),
+                    "No PART property found on the design; Vivado requires a part");
+        }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Pass: library wiring
+     * ------------------------------------------------------------------ */
+
+    private void checkLibraries(EDIFNetlist netlist) {
+        // Track cells seen across libraries to detect shared/duplicated cell objects.
+        Map<EDIFCell, EDIFLibrary> cellOwner = new IdentityHashMap<>();
+        for (Map.Entry<String, EDIFLibrary> e : netlist.getLibrariesMap().entrySet()) {
+            EDIFLibrary lib = e.getValue();
+            if (lib.getNetlist() != netlist) {
+                add(IssueCode.LIBRARY_NETLIST_BACKPTR_BROKEN, libLoc(lib),
+                        "Library's netlist back-pointer does not refer to the netlist being validated");
+            }
+            for (Map.Entry<String, EDIFCell> ce : lib.getCellMap().entrySet()) {
+                EDIFCell cell = ce.getValue();
+                if (!ce.getKey().equals(cell.getName())) {
+                    add(IssueCode.CELL_MAP_KEY_MISMATCH, cellLoc(cell),
+                            "Library cell-map key '" + ce.getKey() + "' != cell name '"
+                                    + cell.getName() + "'");
+                }
+                if (cell.getLibrary() != lib) {
+                    add(IssueCode.CELL_LIBRARY_BACKPTR_BROKEN, cellLoc(cell),
+                            "Cell's library back-pointer does not refer to its containing library");
+                }
+                EDIFLibrary prev = cellOwner.put(cell, lib);
+                if (prev != null) {
+                    add(IssueCode.CELL_IN_MULTIPLE_LIBRARIES, cellLoc(cell),
+                            "Cell object is shared by libraries '" + prev.getName() + "' and '"
+                                    + lib.getName() + "'");
+                }
+            }
+        }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Pass 1: per-cell local checks (scale-conscious; maps scoped to cell)
+     * ------------------------------------------------------------------ */
+
+    private void checkCell(EDIFCell cell) {
+        // Maps scoped to this cell only.
+        Map<String, String> legalCellNames = checkNameLegalization ? new HashMap<>() : null;
+
+        // Ports. Port name legalization collisions are intentionally not checked:
+        // bus-vs-single-bit root-name collisions are resolved by the EDIF writer's
+        // bus-collision rename ("_BUS_" suffix, see EDIFPort.getBusEDIFRename), and
+        // the cell port map already forbids same-key duplicates, so emitted port
+        // names are always distinct.
+        for (Map.Entry<String, EDIFPort> pe : cell.getPortMap().entrySet()) {
+            checkPort(cell, pe.getKey(), pe.getValue());
+        }
+
+        // Cell instances
+        for (EDIFCellInst inst : cell.getCellInsts()) {
+            checkCellInst(cell, inst);
+            if (legalCellNames != null) {
+                checkLegalCollision(legalCellNames, inst.getName(), cellLoc(cell),
+                        IssueCode.NAME_LEGALIZATION_COLLISION, "instance");
+            }
+            if (observedInstCounts != null && inst.getCellType() != null) {
+                observedInstCounts.merge(inst.getCellType(), 1, Integer::sum);
+            }
+        }
+
+        // Nets + the per-cell connectivity invariants (#39, #45)
+        // portInstNetMap: portInst identity -> the net it was found on
+        Map<EDIFPortInst, EDIFNet> portInstNetMap = new IdentityHashMap<>();
+        // connectedBit: (cellInst, portInstName) -> net, to detect a port bit on two nets
+        Map<String, EDIFNet> connectedBit = new HashMap<>();
+        Map<String, String> legalNetNames = checkNameLegalization ? new HashMap<>() : null;
+
+        for (EDIFNet net : cell.getNets()) {
+            checkNet(cell, net, portInstNetMap, connectedBit);
+            if (legalNetNames != null) {
+                checkLegalCollision(legalNetNames, net.getName(), cellLoc(cell),
+                        IssueCode.NET_NAME_LEGALIZATION_COLLISION, "net");
+            }
+        }
+
+        // Verify every portInst on every cellInst is also present on exactly one net.
+        for (EDIFCellInst inst : cell.getCellInsts()) {
+            for (EDIFPortInst pi : inst.getPortInsts()) {
+                if (!portInstNetMap.containsKey(pi)) {
+                    add(IssueCode.PORTINST_DUAL_MEMBERSHIP_BROKEN, portInstLoc(cell, pi),
+                            "PortInst is on cell instance '" + inst.getName()
+                                    + "' but not present on any net in the parent cell");
+                }
+            }
+        }
+
+        checkInternalPortMap(cell);
+    }
+
+    private void checkPort(EDIFCell cell, String mapKey, EDIFPort port) {
+        if (isEmpty(port.getName())) {
+            add(IssueCode.EMPTY_OBJECT_NAME, cellLoc(cell), "Cell has a port with an empty name");
+        }
+        if (port.getParentCell() != cell) {
+            add(IssueCode.PORT_PARENT_BROKEN, portLoc(cell, port),
+                    "Port's parent-cell back-pointer is broken");
+        }
+        if (port.getDirection() == null) {
+            add(IssueCode.PORT_NULL_DIRECTION, portLoc(cell, port), "Port has null direction");
+        }
+        if (port.getWidth() <= 0) {
+            add(IssueCode.PORT_NONPOSITIVE_WIDTH, portLoc(cell, port),
+                    "Port has non-positive width " + port.getWidth());
+        }
+        // Expected map key: bussed ports keyed by busName(true) (ends with '['),
+        // single-bit ports keyed by full name.
+        String expectedKey = port.isBus() ? port.getBusName(true) : port.getName();
+        if (!expectedKey.equals(mapKey)) {
+            add(IssueCode.PORT_MAP_KEY_MISMATCH, portLoc(cell, port),
+                    "Port map key '" + mapKey + "' != expected key '" + expectedKey + "'");
+        }
+        // Bus name / width consistency
+        if (port.isBus()) {
+            try {
+                Integer left = port.getLeft();
+                Integer right = port.getRight();
+                if (left == null || right == null) {
+                    add(IssueCode.PORT_MALFORMED_BUS_NAME, portLoc(cell, port),
+                            "Bus port name is missing a valid [hi:lo] range");
+                } else {
+                    int implied = Math.abs(left - right) + 1;
+                    if (implied != port.getWidth()) {
+                        add(IssueCode.PORT_WIDTH_MISMATCH, portLoc(cell, port),
+                                "Port width " + port.getWidth() + " != range-implied width "
+                                        + implied + " from '" + port.getName() + "'");
+                    }
+                }
+            } catch (NumberFormatException ex) {
+                add(IssueCode.PORT_MALFORMED_BUS_NAME, portLoc(cell, port),
+                        "Bus port name has a non-numeric index range: '" + port.getName() + "'");
+            }
+        }
+    }
+
+    private void checkCellInst(EDIFCell cell, EDIFCellInst inst) {
+        if (isEmpty(inst.getName())) {
+            add(IssueCode.EMPTY_OBJECT_NAME, cellLoc(cell), "Cell has an instance with an empty name");
+        }
+        if (inst.getParentCell() != cell) {
+            add(IssueCode.CELLINST_PARENT_BROKEN, instLoc(cell, inst),
+                    "Instance's parent-cell back-pointer is broken");
+        }
+        EDIFCell type = inst.getCellType();
+        if (type == null) {
+            add(IssueCode.CELLINST_NULL_CELLTYPE, instLoc(cell, inst), "Instance has null cell type");
+            return;
+        }
+        if (netlistCells != null && !netlistCells.contains(type)) {
+            add(IssueCode.INST_DANGLING_CELLTYPE, instLoc(cell, inst),
+                    "Instance references cell type '" + type.getName()
+                            + "' that is not contained in any library of this netlist");
+        }
+        EDIFName viewref = inst.getViewref();
+        if (viewref != null && !viewref.getName().equals(type.getView())) {
+            add(IssueCode.VIEWREF_MISMATCH, instLoc(cell, inst),
+                    "Instance viewref '" + viewref.getName() + "' != cell type view '"
+                            + type.getView() + "'");
+        }
+        if (inst.isBlackBox() && type.hasContents()) {
+            add(IssueCode.BLACKBOX_HAS_CONTENTS, instLoc(cell, inst),
+                    "Instance is marked as a black box but its cell type still has contents");
+        }
+    }
+
+    private void checkNet(EDIFCell cell, EDIFNet net, Map<EDIFPortInst, EDIFNet> portInstNetMap,
+            Map<String, EDIFNet> connectedBit) {
+        if (isEmpty(net.getName())) {
+            add(IssueCode.EMPTY_OBJECT_NAME, cellLoc(cell), "Cell has a net with an empty name");
+        }
+        if (net.getParentCell() != cell) {
+            add(IssueCode.NET_PARENT_BROKEN, netLoc(cell, net),
+                    "Net's parent-cell back-pointer is broken");
+        }
+
+        int realSources = 0;
+        int loptSources = 0;
+        int sinks = 0;
+        Set<String> seenOnThisNet = new HashSet<>();
+        for (EDIFPortInst pi : net.getPortInsts()) {
+            // PortInst back-pointer to this net
+            if (pi.getNet() != net) {
+                add(IssueCode.PORTINST_PARENTNET_BROKEN, portInstLoc(cell, pi),
+                        "PortInst's parent-net back-pointer does not refer to the net containing it");
+            }
+            // duplicate on this net
+            String dedupKey = (pi.getCellInst() == null ? "" : pi.getCellInst().getName())
+                    + "/" + pi.getName();
+            if (!seenOnThisNet.add(dedupKey)) {
+                add(IssueCode.PORTINST_DUPLICATE_ON_NET, portInstLoc(cell, pi),
+                        "PortInst '" + dedupKey + "' appears more than once on net '"
+                                + net.getName() + "'");
+            }
+            // membership bookkeeping for dual-membership check
+            EDIFNet prevNet = portInstNetMap.put(pi, net);
+            if (prevNet != null && prevNet != net) {
+                add(IssueCode.PORTINST_DUAL_MEMBERSHIP_BROKEN, portInstLoc(cell, pi),
+                        "Same PortInst object appears on multiple nets");
+            }
+
+            checkPortInst(cell, net, pi);
+
+            // External (instance) port insts must belong to the cellInst's list.
+            EDIFCellInst inst = pi.getCellInst();
+            if (inst != null) {
+                if (inst.getPortInst(pi.getName()) != pi) {
+                    add(IssueCode.PORTINST_DUAL_MEMBERSHIP_BROKEN, portInstLoc(cell, pi),
+                            "PortInst is on net '" + net.getName()
+                                    + "' but not registered on its cell instance '"
+                                    + inst.getName() + "'");
+                }
+                // A given physical port bit must be connected by only one net.
+                EDIFNet bitPrev = connectedBit.put(dedupKey, net);
+                if (bitPrev != null && bitPrev != net) {
+                    add(IssueCode.PORT_BIT_MULTIPLY_CONNECTED, portInstLoc(cell, pi),
+                            "Port bit '" + dedupKey + "' is connected by both net '"
+                                    + bitPrev.getName() + "' and net '" + net.getName() + "'");
+                }
+            }
+
+            // Source/sink tally for driver checks. Note INOUT pins are
+            // intentionally counted as neither source nor sink, so bidirectional
+            // pins never inflate the driver count. Vivado "lopt" logic-optimization
+            // output pins are counted separately so they don't masquerade as a
+            // genuine second driver (they are an artifact present in valid
+            // post-optimization netlists).
+            boolean isSource = (pi.isOutput() && !pi.isTopLevelPort())
+                    || (pi.isInput() && pi.isTopLevelPort());
+            boolean isSink = (pi.isInput() && !pi.isTopLevelPort())
+                    || (pi.isOutput() && pi.isTopLevelPort());
+            if (isSource) {
+                if (isLoptOutputPin(pi)) {
+                    loptSources++;
+                } else {
+                    realSources++;
+                }
+            }
+            if (isSink) {
+                sinks++;
+            }
+        }
+
+        int totalSources = realSources + loptSources;
+        if (net.getPortInsts().isEmpty()) {
+            add(IssueCode.NET_EMPTY, netLoc(cell, net), "Net has no port instances");
+        } else if (realSources > 1) {
+            add(IssueCode.NET_MULTI_DRIVER, netLoc(cell, net),
+                    "Net has " + realSources + " real drivers (sources)"
+                            + (loptSources > 0 ? " plus " + loptSources + " Vivado 'lopt' pin(s)" : ""));
+        } else if (totalSources > 1) {
+            // realSources <= 1 but an lopt output makes the net appear multi-driven;
+            // this is a benign Vivado optimization artifact, reported as INFO.
+            add(IssueCode.NET_MULTI_DRIVER_LOPT, netLoc(cell, net),
+                    "Net has " + totalSources + " drivers including " + loptSources
+                            + " Vivado 'lopt' optimization pin(s)");
+        } else if (totalSources == 0 && sinks > 0) {
+            add(IssueCode.NET_UNDRIVEN, netLoc(cell, net),
+                    "Net drives " + sinks + " sink(s) but has no source");
+        }
+    }
+
+    /**
+     * Identifies a Vivado "lopt" (logic optimization) output pin. These appear as
+     * extra output ports (named {@code lopt} or {@code lopt_<n>}) created by Vivado
+     * optimization and are not genuine independent drivers, so they are excluded
+     * from the real-driver count for {@link IssueCode#NET_MULTI_DRIVER}.
+     *
+     * @param pi The port instance to test.
+     * @return True if this is an output port named lopt / lopt_&lt;n&gt;.
+     */
+    private static boolean isLoptOutputPin(EDIFPortInst pi) {
+        if (pi.getPort() == null || pi.getDirection() != EDIFDirection.OUTPUT) {
+            return false;
+        }
+        String base = pi.getPort().getBusName();
+        if (!base.startsWith("lopt")) {
+            return false;
+        }
+        return base.equals("lopt") || base.matches("lopt_\\d+");
+    }
+
+    private void checkPortInst(EDIFCell cell, EDIFNet net, EDIFPortInst pi) {
+        EDIFPort port = pi.getPort();
+        if (port == null) {
+            add(IssueCode.PORTINST_NULL_PORT, portInstLoc(cell, pi), "PortInst has null port");
+            return;
+        }
+        EDIFCellInst inst = pi.getCellInst();
+        // The port must belong to the correct cell (internal) or cell type (external).
+        EDIFCell expectedCell = inst != null ? inst.getCellType() : net.getParentCell();
+        if (expectedCell != null && port.getParentCell() != expectedCell) {
+            add(IssueCode.PORTINST_PORT_WRONG_CELL, portInstLoc(cell, pi),
+                    "PortInst's port belongs to cell '"
+                            + (port.getParentCell() == null ? "null" : port.getParentCell().getName())
+                            + "' but should belong to '" + expectedCell.getName() + "'");
+        }
+        // Index vs bus consistency
+        if (port.isBus()) {
+            if (pi.getIndex() == -1) {
+                add(IssueCode.PORTINST_INDEX_MISMATCH, portInstLoc(cell, pi),
+                        "PortInst on bus port '" + port.getName() + "' has no index (-1)");
+            } else if (pi.getIndex() < 0 || pi.getIndex() >= port.getWidth()) {
+                add(IssueCode.PORTINST_INDEX_MISMATCH, portInstLoc(cell, pi),
+                        "PortInst index " + pi.getIndex() + " out of range [0," + port.getWidth()
+                                + ") for port '" + port.getName() + "'");
+            }
+        } else if (pi.getIndex() != -1) {
+            add(IssueCode.PORTINST_INDEX_MISMATCH, portInstLoc(cell, pi),
+                    "PortInst on single-bit port '" + port.getName() + "' has index "
+                            + pi.getIndex() + " (expected -1)");
+        }
+        // Name must be derivable from port + index
+        try {
+            String expectedName = pi.getPortInstNameFromPort();
+            if (!expectedName.equals(pi.getName())) {
+                add(IssueCode.PORTINST_NAME_DESYNC, portInstLoc(cell, pi),
+                        "PortInst name '" + pi.getName() + "' != name derived from port+index '"
+                                + expectedName + "'");
+            }
+        } catch (RuntimeException ex) {
+            add(IssueCode.PORTINST_NAME_DESYNC, portInstLoc(cell, pi),
+                    "PortInst name could not be derived from its port+index: " + ex.getMessage());
+        }
+    }
+
+    private void checkInternalPortMap(EDIFCell cell) {
+        Map<String, EDIFNet> internal = cell.getInternalNetMap();
+        if (internal.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, EDIFNet> e : internal.entrySet()) {
+            EDIFNet mapped = e.getValue();
+            if (mapped == null) {
+                continue;
+            }
+            if (cell.getNet(mapped.getName()) != mapped) {
+                add(IssueCode.INTERNAL_PORTMAP_STALE, cellLoc(cell),
+                        "internalPortMap entry '" + e.getKey()
+                                + "' points to net '" + mapped.getName()
+                                + "' that is not (or no longer) in this cell");
+            }
+        }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Pass 2: instantiation-count drift + hierarchy + reachability
+     * ------------------------------------------------------------------ */
+
+    private void checkInstantiationCountDrift() {
+        if (observedInstCounts == null) {
+            return;
+        }
+        for (EDIFCell cell : netlistCells) {
+            int observed = observedInstCounts.getOrDefault(cell, 0);
+            int cached = cell.getNonHierInstantiationCount();
+            if (observed != cached) {
+                add(IssueCode.INSTANTIATION_COUNT_DRIFT, cellLoc(cell),
+                        "Cached non-hierarchical instantiation count " + cached
+                                + " != observed " + observed);
+            }
+        }
+    }
+
+    private void checkHierarchyAndReachability(EDIFNetlist netlist) {
+        EDIFDesign design = netlist.getDesign();
+        EDIFCell top = design == null ? null : design.getTopCell();
+        if (top == null) {
+            return;
+        }
+        // DFS with WHITE/GRAY/BLACK coloring to detect cycles, reachable set as a side effect.
+        Map<EDIFCell, Integer> color = new IdentityHashMap<>();
+        Set<EDIFCell> reachable = Collections.newSetFromMap(new IdentityHashMap<>());
+        detectCycleDFS(top, color, reachable);
+
+        // Reachability: cells in work libraries not reachable from top are unused.
+        for (EDIFLibrary lib : netlist.getLibraries()) {
+            if (lib.isHDIPrimitivesLibrary()) {
+                continue;
+            }
+            for (EDIFCell cell : lib.getCells()) {
+                if (!reachable.contains(cell)) {
+                    add(IssueCode.UNREACHABLE_CELL, cellLoc(cell),
+                            "Cell is not reachable from the top cell (unused)");
+                }
+            }
+        }
+    }
+
+    /**
+     * Iterative DFS cycle detection over the cell -> child-cell-type graph.
+     * Reports CYCLIC_HIERARCHY when a cell is found on the current DFS path.
+     *
+     * @return true if any cycle was found.
+     */
+    private boolean detectCycleDFS(EDIFCell root, Map<EDIFCell, Integer> color, Set<EDIFCell> reachable) {
+        final int WHITE = 0, GRAY = 1, BLACK = 2;
+        boolean found = false;
+        Deque<EDIFCell> path = new ArrayDeque<>();
+        Deque<Iterator<EDIFCellInst>> iters = new ArrayDeque<>();
+
+        color.put(root, GRAY);
+        reachable.add(root);
+        path.push(root);
+        iters.push(root.getCellInsts().iterator());
+
+        while (!path.isEmpty()) {
+            Iterator<EDIFCellInst> it = iters.peek();
+            if (it.hasNext()) {
+                EDIFCellInst inst = it.next();
+                EDIFCell child = inst.getCellType();
+                if (child == null) {
+                    continue;
+                }
+                int c = color.getOrDefault(child, WHITE);
+                if (c == GRAY) {
+                    add(IssueCode.CYCLIC_HIERARCHY, cellLoc(child),
+                            "Cell participates in a cyclic instantiation (instantiated under itself)");
+                    found = true;
+                } else if (c == WHITE) {
+                    color.put(child, GRAY);
+                    reachable.add(child);
+                    path.push(child);
+                    iters.push(child.getCellInsts().iterator());
+                }
+            } else {
+                color.put(path.pop(), BLACK);
+                iters.pop();
+            }
+        }
+        return found;
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Name-legalization collision helper
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Detects sibling names that would be emitted as the same EDIF name. The EDIF
+     * writer uniquifies <em>renamed</em> names against each other with a "_HDI_"
+     * suffix, so two names that both require legalization never actually collide.
+     * The remaining real hazard is an already-legal name being shadowed by another
+     * name whose legalized form equals it (the legal name is emitted verbatim and
+     * is not tracked for uniquification). Therefore a collision is only reported
+     * when at least one of the two colliding names is already EDIF-legal.
+     */
+    private void checkLegalCollision(Map<String, String> seen, String rawName, String location,
+            IssueCode code, String kind) {
+        if (isEmpty(rawName)) {
+            return;
+        }
+        String legal = EDIFTools.makeNameEDIFCompatible(rawName);
+        String prevRaw = seen.putIfAbsent(legal, rawName);
+        if (prevRaw != null && !prevRaw.equals(rawName)) {
+            boolean currAlreadyLegal = rawName.equals(legal);
+            boolean prevAlreadyLegal = prevRaw.equals(legal);
+            if (currAlreadyLegal || prevAlreadyLegal) {
+                add(code, location, "Two " + kind + " names legalize to the same EDIF name '"
+                        + legal + "': '" + prevRaw + "' and '" + rawName + "'"
+                        + " (one is already EDIF-legal and would be shadowed)");
+            }
+        }
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Location string helpers
+     * ------------------------------------------------------------------ */
+
+    private static boolean isEmpty(String s) {
+        return s == null || s.isEmpty();
+    }
+
+    private static String loc(EDIFNetlist nl) {
+        return "netlist:" + nl.getName();
+    }
+
+    private static String libLoc(EDIFLibrary lib) {
+        return lib.getName();
+    }
+
+    private static String cellLoc(EDIFCell cell) {
+        EDIFLibrary lib = cell.getLibrary();
+        return (lib == null ? "?" : lib.getName()) + "/" + cell.getName();
+    }
+
+    private static String portLoc(EDIFCell cell, EDIFPort port) {
+        return cellLoc(cell) + ".port:" + port.getName();
+    }
+
+    private static String instLoc(EDIFCell cell, EDIFCellInst inst) {
+        return cellLoc(cell) + "/" + inst.getName();
+    }
+
+    private static String netLoc(EDIFCell cell, EDIFNet net) {
+        return cellLoc(cell) + ":" + net.getName();
+    }
+
+    private static String portInstLoc(EDIFCell cell, EDIFPortInst pi) {
+        String instName = pi.getCellInst() == null ? "<top>" : pi.getCellInst().getName();
+        return cellLoc(cell) + "/" + instName + "." + pi.getName();
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  CLI
+     * ------------------------------------------------------------------ */
+
+    private static EDIFNetlist loadNetlist(String path, int maxThreads) {
+        String lower = path.toLowerCase();
+        if (lower.endsWith(".dcp")) {
+            return Design.readCheckpoint(path).getNetlist();
+        } else if (lower.endsWith(".bedf") || lower.endsWith(".bin")) {
+            return EDIFNetlist.readBinaryEDIF(Paths.get(path));
+        }
+        return EDIFTools.readEdifFile(Paths.get(path), maxThreads);
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("USAGE: NetlistValidator <input.edf|.dcp|.bedf> "
+                    + "[--report <out.txt>] [--no-namecheck] [--no-instcount] "
+                    + "[--max-per-code <N>] [--threads <N>] [--warnings-as-errors]");
+            System.exit(2);
+        }
+
+        String input = args[0];
+        Path reportFile = null;
+        boolean warningsAsErrors = false;
+        int maxThreads = Integer.MAX_VALUE;
+        NetlistValidator validator = new NetlistValidator();
+
+        for (int i = 1; i < args.length; i++) {
+            switch (args[i]) {
+                case "--report":
+                    reportFile = Paths.get(args[++i]);
+                    break;
+                case "--no-namecheck":
+                    validator.checkNameLegalization = false;
+                    break;
+                case "--no-instcount":
+                    validator.checkInstantiationCounts = false;
+                    break;
+                case "--max-per-code":
+                    validator.maxIssuesPerCode = Integer.parseInt(args[++i]);
+                    break;
+                case "--threads":
+                    maxThreads = Integer.parseInt(args[++i]);
+                    break;
+                case "--warnings-as-errors":
+                    warningsAsErrors = true;
+                    break;
+                default:
+                    System.err.println("WARNING: ignoring unknown argument '" + args[i] + "'");
+            }
+        }
+
+        CodePerfTracker t = new CodePerfTracker("Validate EDIF Netlist");
+        t.start("Load");
+        EDIFNetlist netlist = loadNetlist(input, maxThreads);
+        t.stop().start("Validate");
+        ValidationReport report = validator.validate(netlist);
+        t.stop();
+
+        PrintStream out = System.out;
+        report.print(out);
+        if (reportFile != null) {
+            report.writeReport(reportFile);
+            System.out.println("Report written to " + reportFile);
+        }
+        t.printSummary();
+
+        boolean failed = !report.isValid() || (warningsAsErrors && report.getWarningCount() > 0);
+        System.exit(failed ? 1 : 0);
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/validate/Severity.java
+++ b/src/com/xilinx/rapidwright/edif/validate/Severity.java
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.validate;
+
+/**
+ * Severity of an {@link ValidationIssue}.
+ */
+public enum Severity {
+    /** A definite inconsistency that will corrupt or fail on Vivado read-back. */
+    ERROR,
+    /** A likely problem or a construct that is legal only in narrow cases. */
+    WARNING,
+    /** Informational; usually harmless but often an artifact of a bug. */
+    INFO
+}

--- a/src/com/xilinx/rapidwright/edif/validate/ValidationIssue.java
+++ b/src/com/xilinx/rapidwright/edif/validate/ValidationIssue.java
@@ -1,0 +1,66 @@
+/*
+ *
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.validate;
+
+/**
+ * A single inconsistency found by {@link NetlistValidator}. Issues are
+ * immutable and carry a stable {@link IssueCode}, a {@link Severity}, a
+ * human-readable location string and a descriptive message.
+ */
+public class ValidationIssue {
+
+    private final Severity severity;
+    private final IssueCode code;
+    private final String location;
+    private final String message;
+
+    public ValidationIssue(Severity severity, IssueCode code, String location, String message) {
+        this.severity = severity;
+        this.code = code;
+        this.location = location;
+        this.message = message;
+    }
+
+    public ValidationIssue(IssueCode code, String location, String message) {
+        this(code.getDefaultSeverity(), code, location, message);
+    }
+
+    public Severity getSeverity() {
+        return severity;
+    }
+
+    public IssueCode getCode() {
+        return code;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + severity + "] " + code + " " + location + " — " + message;
+    }
+}

--- a/src/com/xilinx/rapidwright/edif/validate/ValidationReport.java
+++ b/src/com/xilinx/rapidwright/edif/validate/ValidationReport.java
@@ -1,0 +1,183 @@
+/*
+ *
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.validate;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Collects the {@link ValidationIssue} objects produced by
+ * {@link NetlistValidator}. To stay bounded on very large netlists, only the
+ * first {@code maxIssuesPerCode} issues of each {@link IssueCode} are retained;
+ * subsequent issues of that code are counted but not stored.
+ */
+public class ValidationReport {
+
+    /** Default cap on retained issues per code (overflow is still counted). */
+    public static final int DEFAULT_MAX_ISSUES_PER_CODE = 100;
+
+    private final List<ValidationIssue> issues = new ArrayList<>();
+    private final EnumMap<IssueCode, Integer> totalCounts = new EnumMap<>(IssueCode.class);
+    private final EnumMap<Severity, Integer> severityCounts = new EnumMap<>(Severity.class);
+
+    private final int maxIssuesPerCode;
+
+    public ValidationReport() {
+        this(DEFAULT_MAX_ISSUES_PER_CODE);
+    }
+
+    public ValidationReport(int maxIssuesPerCode) {
+        this.maxIssuesPerCode = maxIssuesPerCode <= 0 ? Integer.MAX_VALUE : maxIssuesPerCode;
+    }
+
+    /**
+     * Adds an issue to the report. Storage of the issue object is capped per code,
+     * but the total and severity counters always reflect every reported issue.
+     *
+     * @param issue The issue to record.
+     */
+    public synchronized void add(ValidationIssue issue) {
+        int priorForCode = totalCounts.getOrDefault(issue.getCode(), 0);
+        totalCounts.put(issue.getCode(), priorForCode + 1);
+        severityCounts.merge(issue.getSeverity(), 1, Integer::sum);
+        if (priorForCode < maxIssuesPerCode) {
+            issues.add(issue);
+        }
+    }
+
+    /**
+     * Convenience helper that constructs and adds an issue using a code's default
+     * severity.
+     */
+    public void add(IssueCode code, String location, String message) {
+        add(new ValidationIssue(code, location, message));
+    }
+
+    /**
+     * @return The retained (capped) list of issues, in discovery order.
+     */
+    public List<ValidationIssue> getIssues() {
+        return Collections.unmodifiableList(issues);
+    }
+
+    /**
+     * @return The total number of issues reported for the given code, including
+     *         those dropped by the per-code cap.
+     */
+    public int getCount(IssueCode code) {
+        return totalCounts.getOrDefault(code, 0);
+    }
+
+    public int getCount(Severity severity) {
+        return severityCounts.getOrDefault(severity, 0);
+    }
+
+    public int getErrorCount() {
+        return getCount(Severity.ERROR);
+    }
+
+    public int getWarningCount() {
+        return getCount(Severity.WARNING);
+    }
+
+    public int getInfoCount() {
+        return getCount(Severity.INFO);
+    }
+
+    public int getTotalIssueCount() {
+        int total = 0;
+        for (int v : severityCounts.values()) {
+            total += v;
+        }
+        return total;
+    }
+
+    /**
+     * @return True if no ERROR-severity issues were reported.
+     */
+    public boolean isValid() {
+        return getErrorCount() == 0;
+    }
+
+    public Map<IssueCode, Integer> getTotalCounts() {
+        return Collections.unmodifiableMap(totalCounts);
+    }
+
+    /**
+     * Prints the full list of retained issues followed by a summary to the given
+     * stream.
+     *
+     * @param ps The stream to print to.
+     */
+    public void print(PrintStream ps) {
+        for (ValidationIssue issue : issues) {
+            ps.println(issue.toString());
+        }
+        printSummary(ps);
+    }
+
+    /**
+     * Prints just the per-code and per-severity summary to the given stream.
+     *
+     * @param ps The stream to print to.
+     */
+    public void printSummary(PrintStream ps) {
+        ps.println("===== EDIF Netlist Validation Summary =====");
+        if (totalCounts.isEmpty()) {
+            ps.println("No issues found.");
+        } else {
+            for (Map.Entry<IssueCode, Integer> e : totalCounts.entrySet()) {
+                int stored = Math.min(e.getValue(), maxIssuesPerCode);
+                String capNote = e.getValue() > stored
+                        ? " (showing " + stored + " of " + e.getValue() + ")" : "";
+                ps.println("  " + e.getKey().getDefaultSeverity() + "  " + e.getKey()
+                        + ": " + e.getValue() + capNote);
+            }
+        }
+        ps.println("-------------------------------------------");
+        ps.println("  ERRORS:   " + getErrorCount());
+        ps.println("  WARNINGS: " + getWarningCount());
+        ps.println("  INFO:     " + getInfoCount());
+        ps.println("  Netlist is " + (isValid() ? "VALID (no errors)" : "INVALID"));
+        ps.println("===========================================");
+    }
+
+    /**
+     * Writes the full report (issues + summary) to a file.
+     *
+     * @param reportFile Destination path.
+     */
+    public void writeReport(Path reportFile) {
+        try (PrintStream ps = new PrintStream(Files.newOutputStream(reportFile))) {
+            print(ps);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/test/src/com/xilinx/rapidwright/edif/validate/TestNetlistValidator.java
+++ b/test/src/com/xilinx/rapidwright/edif/validate/TestNetlistValidator.java
@@ -203,6 +203,30 @@ class TestNetlistValidator {
     }
 
     @Test
+    void testVivadoBusGroupingFlaggedAndFixed() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        // Single-bit top-level ports named like bus members -> Vivado would merge them.
+        top.createPort("sel[0]", EDIFDirection.INPUT, 1);
+        top.createPort("sel[1]", EDIFDirection.INPUT, 1);
+        Assertions.assertEquals(2, validate(n).getCount(IssueCode.PORT_VIVADO_BUS_GROUPING),
+                "unpreserved indexed single-bit top ports must be flagged");
+
+        // After applying the RapidWright remedy, nothing should be flagged.
+        EDIFTools.ensurePreservedInterfaceVivado(n);
+        Assertions.assertEquals(0, validate(n).getCount(IssueCode.PORT_VIVADO_BUS_GROUPING),
+                "ports preserved with the '[]' prefix must not be flagged");
+    }
+
+    @Test
+    void testRealBusPortNotFlaggedForBusGrouping() {
+        EDIFNetlist n = buildMinimalNetlist();
+        // A genuinely declared bus must not be flagged.
+        getTop(n).createPort("data[3:0]", EDIFDirection.INPUT, 4);
+        Assertions.assertEquals(0, validate(n).getCount(IssueCode.PORT_VIVADO_BUS_GROUPING));
+    }
+
+    @Test
     void testNetUndriven() {
         EDIFNetlist n = buildMinimalNetlist();
         EDIFCell top = getTop(n);

--- a/test/src/com/xilinx/rapidwright/edif/validate/TestNetlistValidator.java
+++ b/test/src/com/xilinx/rapidwright/edif/validate/TestNetlistValidator.java
@@ -1,0 +1,382 @@
+/*
+ *
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.xilinx.rapidwright.edif.validate;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.edif.EDIFCell;
+import com.xilinx.rapidwright.edif.EDIFCellInst;
+import com.xilinx.rapidwright.edif.EDIFDesign;
+import com.xilinx.rapidwright.edif.EDIFDirection;
+import com.xilinx.rapidwright.edif.EDIFLibrary;
+import com.xilinx.rapidwright.edif.EDIFName;
+import com.xilinx.rapidwright.edif.EDIFNet;
+import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.edif.EDIFPort;
+import com.xilinx.rapidwright.edif.EDIFPortInst;
+import com.xilinx.rapidwright.edif.EDIFTools;
+import com.xilinx.rapidwright.support.RapidWrightDCP;
+
+/**
+ * Unit tests for {@link NetlistValidator}. Most tests build a minimal,
+ * self-contained netlist (no device/Unisim data needed), then inject exactly one
+ * fault using back-door setters and assert that the corresponding
+ * {@link IssueCode} is reported.
+ */
+class TestNetlistValidator {
+
+    /**
+     * Builds a minimal but fully consistent netlist:
+     *
+     * <pre>
+     *   hdi_primitives: BUF(I:in, O:out)   [leaf primitive]
+     *   work: top(in -&gt; bufInst.I, bufInst.O -&gt; out)
+     * </pre>
+     */
+    private static EDIFNetlist buildMinimalNetlist() {
+        EDIFNetlist netlist = new EDIFNetlist("top");
+        EDIFLibrary primLib = netlist.addLibrary(
+                new EDIFLibrary(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME));
+        EDIFLibrary workLib = netlist.addLibrary(
+                new EDIFLibrary(EDIFTools.EDIF_LIBRARY_WORK_NAME));
+
+        // Leaf primitive cell BUF
+        EDIFCell buf = new EDIFCell(primLib, "BUF");
+        buf.createPort("I", EDIFDirection.INPUT, 1);
+        buf.createPort("O", EDIFDirection.OUTPUT, 1);
+
+        // Top cell
+        EDIFCell top = new EDIFCell(workLib, "top");
+        EDIFDesign design = new EDIFDesign("top");
+        design.setTopCell(top);
+        netlist.setDesign(design);
+        // Avoid the (harmless) MISSING_PART_PROPERTY warning in clean tests.
+        design.addProperty("PART", "xcku040-ffva1156-2-e");
+
+        EDIFPort inPort = top.createPort("in", EDIFDirection.INPUT, 1);
+        EDIFPort outPort = top.createPort("out", EDIFDirection.OUTPUT, 1);
+
+        EDIFCellInst bufInst = new EDIFCellInst("bufInst", buf, top);
+
+        EDIFNet nIn = top.createNet("n_in");
+        nIn.createPortInst(inPort);
+        nIn.createPortInst("I", bufInst);
+
+        EDIFNet nOut = top.createNet("n_out");
+        nOut.createPortInst("O", bufInst);
+        nOut.createPortInst(outPort);
+
+        return netlist;
+    }
+
+    private static EDIFCell getTop(EDIFNetlist n) {
+        return n.getDesign().getTopCell();
+    }
+
+    private static ValidationReport validate(EDIFNetlist n) {
+        return new NetlistValidator().validate(n);
+    }
+
+    // ---------------------------------------------------------------- //
+    //  Positive controls
+    // ---------------------------------------------------------------- //
+
+    @Test
+    void testCleanMinimalNetlistPasses() {
+        EDIFNetlist n = buildMinimalNetlist();
+        ValidationReport report = validate(n);
+        Assertions.assertTrue(report.isValid(),
+                "Clean netlist should have no errors, got: " + report.getIssues());
+        Assertions.assertEquals(0, report.getErrorCount());
+    }
+
+    @Test
+    void testCleanNetlistRoundTripsThroughEDIF(@org.junit.jupiter.api.io.TempDir java.nio.file.Path dir) {
+        EDIFNetlist n = buildMinimalNetlist();
+        java.nio.file.Path edf = dir.resolve("min.edf");
+        n.exportEDIF(edf);
+        EDIFNetlist reloaded = EDIFTools.readEdifFile(edf);
+        ValidationReport report = validate(reloaded);
+        Assertions.assertTrue(report.isValid(),
+                "Round-tripped netlist should be valid, got: " + report.getIssues());
+    }
+
+    @Test
+    void testRealDcpNetlistHasNoStructuralErrors() {
+        Design design = RapidWrightDCP.loadDCP("picoblaze_ooc_X10Y235.dcp");
+        ValidationReport report = validate(design.getNetlist());
+        // A well-formed Vivado netlist must not contain structural errors.
+        Assertions.assertEquals(0, report.getErrorCount(),
+                "Real DCP netlist reported errors: " + report.getIssues());
+    }
+
+    // ---------------------------------------------------------------- //
+    //  Fault injection — one targeted test per representative IssueCode
+    // ---------------------------------------------------------------- //
+
+    @Test
+    void testNullDesign() {
+        EDIFNetlist n = buildMinimalNetlist();
+        n.setDesign(null);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.NULL_DESIGN) > 0);
+    }
+
+    @Test
+    void testNetMultiDriver() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        // Add a second driver to n_in: re-add the buf output as another source.
+        EDIFNet nIn = top.getNet("n_in");
+        EDIFCellInst buf = top.getCellInst("bufInst");
+        // Create a second buf instance and connect its output as a second source.
+        EDIFCellInst buf2 = new EDIFCellInst("bufInst2", buf.getCellType(), top);
+        nIn.createPortInst("O", buf2);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.NET_MULTI_DRIVER) > 0);
+    }
+
+    /**
+     * Builds a primitive with a normal output "O" plus a Vivado "lopt"
+     * optimization output, and adds it to the netlist's primitives library.
+     */
+    private static EDIFCell makeOptCell(EDIFNetlist n) {
+        EDIFLibrary prim = n.getLibrary(EDIFTools.EDIF_LIBRARY_HDI_PRIMITIVES_NAME);
+        EDIFCell opt = new EDIFCell(prim, "OPTCELL");
+        opt.createPort("I", EDIFDirection.INPUT, 1);
+        opt.createPort("O", EDIFDirection.OUTPUT, 1);
+        opt.createPort("lopt", EDIFDirection.OUTPUT, 1);
+        return opt;
+    }
+
+    @Test
+    void testLoptSecondDriverIsInfoNotError() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        EDIFCell opt = makeOptCell(n);
+        EDIFCellInst oi = new EDIFCellInst("optInst", opt, top);
+        EDIFCellInst sink = new EDIFCellInst("sinkInst", opt, top);
+        // Net driven by a real output "O" and the artifact "lopt" output.
+        EDIFNet net = top.createNet("lopt_net");
+        net.createPortInst("O", oi);
+        net.createPortInst("lopt", oi);
+        net.createPortInst("I", sink);
+        ValidationReport r = validate(n);
+        Assertions.assertEquals(0, r.getCount(IssueCode.NET_MULTI_DRIVER),
+                "lopt second driver must not be a hard error");
+        Assertions.assertTrue(r.getCount(IssueCode.NET_MULTI_DRIVER_LOPT) > 0,
+                "lopt second driver should be reported as INFO");
+    }
+
+    @Test
+    void testTwoRealDriversStillErrorEvenWithLopt() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        EDIFCell opt = makeOptCell(n);
+        EDIFCellInst a = new EDIFCellInst("a", opt, top);
+        EDIFCellInst b = new EDIFCellInst("b", opt, top);
+        // Two genuine output drivers ("O" of a and b) plus an lopt -> still ERROR.
+        EDIFNet net = top.createNet("two_real_net");
+        net.createPortInst("O", a);
+        net.createPortInst("O", b);
+        net.createPortInst("lopt", a);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.NET_MULTI_DRIVER) > 0,
+                "two real drivers must remain a hard error even when an lopt pin is present");
+    }
+
+    @Test
+    void testNetUndriven() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        EDIFNet nIn = top.getNet("n_in");
+        // Remove the top-level input source, leaving only the sink (bufInst.I).
+        nIn.removePortInst(nIn.getPortInst(null, "in"));
+        Assertions.assertTrue(validate(n).getCount(IssueCode.NET_UNDRIVEN) > 0);
+    }
+
+    @Test
+    void testNetEmpty() {
+        EDIFNetlist n = buildMinimalNetlist();
+        getTop(n).createNet("danglingNet");
+        Assertions.assertTrue(validate(n).getCount(IssueCode.NET_EMPTY) > 0);
+    }
+
+    @Test
+    void testInstNullCellType() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCellInst buf = getTop(n).getCellInst("bufInst");
+        buf.setCellTypeRaw(null);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.CELLINST_NULL_CELLTYPE) > 0);
+    }
+
+    @Test
+    void testInstDanglingCellType() {
+        EDIFNetlist n = buildMinimalNetlist();
+        // Point the instance at a cell that is not in any library of this netlist.
+        EDIFCell orphan = new EDIFCell((EDIFLibrary) null, "ORPHAN");
+        getTop(n).getCellInst("bufInst").setCellTypeRaw(orphan);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.INST_DANGLING_CELLTYPE) > 0);
+    }
+
+    @Test
+    void testViewrefMismatch() {
+        EDIFNetlist n = buildMinimalNetlist();
+        getTop(n).getCellInst("bufInst").setViewref(new EDIFName("bogusView"));
+        Assertions.assertTrue(validate(n).getCount(IssueCode.VIEWREF_MISMATCH) > 0);
+    }
+
+    @Test
+    void testPortInstParentNetBroken() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        EDIFNet nIn = top.getNet("n_in");
+        EDIFNet nOut = top.getNet("n_out");
+        // Corrupt the parent-net back-pointer on one of n_in's port insts.
+        nIn.getPortInsts().get(0).setParentNet(nOut);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.PORTINST_PARENTNET_BROKEN) > 0);
+    }
+
+    @Test
+    void testPortInstIndexMismatch() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        // Set a bogus index on a single-bit port inst.
+        EDIFNet nOut = top.getNet("n_out");
+        EDIFPortInst pi = nOut.getPortInst(top.getCellInst("bufInst"), "O");
+        pi.setIndex(5);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.PORTINST_INDEX_MISMATCH) > 0);
+    }
+
+    @Test
+    void testNameLegalizationCollision() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        EDIFCell bufType = top.getCellInst("bufInst").getCellType();
+        // 'a_b' is already EDIF-legal; 'a.b' legalizes to 'a_b' and would shadow it.
+        new EDIFCellInst("a_b", bufType, top);
+        new EDIFCellInst("a.b", bufType, top);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.NAME_LEGALIZATION_COLLISION) > 0);
+    }
+
+    @Test
+    void testRenameVsRenameDoesNotCollide() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        EDIFCell bufType = top.getCellInst("bufInst").getCellType();
+        // Both legalize to 'a_b' but neither is already legal; the writer uniquifies
+        // them with a _HDI_ suffix, so this must NOT be reported.
+        new EDIFCellInst("a.b", bufType, top);
+        new EDIFCellInst("a/b", bufType, top);
+        Assertions.assertEquals(0, validate(n).getCount(IssueCode.NAME_LEGALIZATION_COLLISION));
+    }
+
+    @Test
+    void testCyclicHierarchy() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFLibrary work = n.getLibrary(EDIFTools.EDIF_LIBRARY_WORK_NAME);
+        EDIFCell top = getTop(n);
+        // Create A and B in work that instantiate each other; make top instantiate A.
+        EDIFCell a = new EDIFCell(work, "A");
+        EDIFCell b = new EDIFCell(work, "B");
+        new EDIFCellInst("bInst", b, a);
+        new EDIFCellInst("aInst", a, b);
+        new EDIFCellInst("aTop", a, top);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.CYCLIC_HIERARCHY) > 0);
+    }
+
+    @Test
+    void testInternalPortMapStale() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        // Add an internal port map entry pointing at a net not in the cell.
+        EDIFCell other = new EDIFCell(n.getLibrary(EDIFTools.EDIF_LIBRARY_WORK_NAME), "other");
+        EDIFNet stray = other.createNet("stray");
+        top.addInternalPortMapEntry("phantom", stray);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.INTERNAL_PORTMAP_STALE) > 0);
+    }
+
+    @Test
+    void testPortWidthMismatch() {
+        EDIFNetlist n = buildMinimalNetlist();
+        // Create a bus port whose declared width disagrees with its [hi:lo] range.
+        EDIFCell top = getTop(n);
+        EDIFPort bus = top.createPort("d[3:0]", EDIFDirection.INPUT, 2);
+        Assertions.assertNotNull(bus);
+        Assertions.assertTrue(validate(n).getCount(IssueCode.PORT_WIDTH_MISMATCH) > 0);
+    }
+
+    @Test
+    void testInstantiationCountDrift() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell buf = getTop(n).getCellInst("bufInst").getCellType();
+        // Artificially inflate the cached count.
+        buf.incrementNonHierInstantiationCount();
+        buf.incrementNonHierInstantiationCount();
+        Assertions.assertTrue(validate(n).getCount(IssueCode.INSTANTIATION_COUNT_DRIFT) > 0);
+    }
+
+    @Test
+    void testUnreachableCell() {
+        EDIFNetlist n = buildMinimalNetlist();
+        // Add an unused cell in the work library (not instantiated under top).
+        new EDIFCell(n.getLibrary(EDIFTools.EDIF_LIBRARY_WORK_NAME), "unused");
+        Assertions.assertTrue(validate(n).getCount(IssueCode.UNREACHABLE_CELL) > 0);
+    }
+
+    @Test
+    void testMissingPartProperty() {
+        EDIFNetlist n = buildMinimalNetlist();
+        n.getDesign().removeProperty("PART");
+        Assertions.assertTrue(validate(n).getCount(IssueCode.MISSING_PART_PROPERTY) > 0);
+    }
+
+    // ---------------------------------------------------------------- //
+    //  Report cap behavior
+    // ---------------------------------------------------------------- //
+
+    @Test
+    void testIssueCapAndOverflowCount() {
+        EDIFNetlist n = buildMinimalNetlist();
+        EDIFCell top = getTop(n);
+        // Inject many empty nets.
+        int total = 250;
+        for (int i = 0; i < total; i++) {
+            top.createNet("empty_" + i);
+        }
+        NetlistValidator v = new NetlistValidator();
+        v.maxIssuesPerCode = 50;
+        ValidationReport report = v.validate(n);
+        // Total count reflects all; stored issues for that code are capped.
+        Assertions.assertEquals(total, report.getCount(IssueCode.NET_EMPTY));
+        long storedEmpty = report.getIssues().stream()
+                .filter(iss -> iss.getCode() == IssueCode.NET_EMPTY).count();
+        Assertions.assertEquals(50, storedEmpty);
+    }
+
+    @Test
+    void testDisabledCodeSuppressed() {
+        EDIFNetlist n = buildMinimalNetlist();
+        getTop(n).createNet("danglingNet");
+        NetlistValidator v = new NetlistValidator();
+        v.disabledCodes.add(IssueCode.NET_EMPTY);
+        Assertions.assertEquals(0, v.validate(n).getCount(IssueCode.NET_EMPTY));
+    }
+}


### PR DESCRIPTION
Adds a new tool (`NetlistValidator`) and package (`com.xilinx.rapidwright.edif.validate`) that traverses an `EDIFNetlist` and reports structural inconsistencies and EDIF-export-issues that can write out as valid-looking EDIF but fail or silently corrupt when read back into Vivado. The goal is to catch any netlist corruption introduced during RapidWright development/manipulation before allowing Vivado to parse it and get a delayed result.

Should scale well as a single traversal with per-cell-scoped maps and per-code issue caps; validated a 6 GB EDIF / ~6M-net netlist in ~2 min.