### PR TITLE
Fix tests to be Java 8 compatible

### DIFF
--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPortInstListTrim.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPortInstListTrim.java
@@ -55,7 +55,8 @@ public class TestEDIFPortInstListTrim {
         boolean ok = false;
         try {
             f = ArrayList.class.getDeclaredField("elementData");
-            ok = f.trySetAccessible();
+            f.setAccessible(true);
+            ok = f.isAccessible();
         } catch (Throwable t) {
             ok = false;
         }

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java
@@ -23,6 +23,7 @@
 package com.xilinx.rapidwright.edif;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -117,21 +118,25 @@ public class TestEDIFPropertyMap {
 
         Assertions.assertEquals(3, m.keySet().size());
         Assertions.assertTrue(m.keySet().contains("a"));
-        Assertions.assertTrue(m.keySet().containsAll(List.of("a", "b", "c")));
+        Assertions.assertTrue(m.keySet().containsAll(Arrays.asList("a", "b", "c")));
 
         Assertions.assertEquals(3, m.values().size());
         List<String> values = new ArrayList<>();
         for (EDIFPropertyValue val : m.values()) {
             values.add(val.getValue());
         }
-        Assertions.assertTrue(values.containsAll(List.of("1", "2", "3")));
+        Assertions.assertTrue(values.containsAll(Arrays.asList("1", "2", "3")));
 
         // entrySet iteration
         Map<String, String> seen = new HashMap<>();
         for (Map.Entry<String, EDIFPropertyValue> e : m.entrySet()) {
             seen.put(e.getKey(), e.getValue().getValue());
         }
-        Assertions.assertEquals(Map.of("a", "1", "b", "2", "c", "3"), seen);
+        Map<String, String> expected = new HashMap<>();
+        expected.put("a", "1");
+        expected.put("b", "2");
+        expected.put("c", "3");
+        Assertions.assertEquals(expected, seen);
     }
 
     @Test


### PR DESCRIPTION
Without which:
```
./gradlew testJava
```

returns:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileTestJava'.
> Compilation failed; see the compiler output below.
  <<PATH>>/RapidWright/test/src/com/xilinx/rapidwright/edif/TestEDIFPortInstListTrim.java:58: error: cannot find symbol
              ok = f.trySetAccessible();
                    ^
    symbol:   method trySetAccessible()
    location: variable f of type java.lang.reflect.Field
  <<PATH>>/RapidWright/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java:120: error: cannot find symbol
          Assertions.assertTrue(m.keySet().containsAll(List.of("a", "b", "c")));
                                                           ^
    symbol:   method of(java.lang.String,java.lang.String,java.lang.String)
    location: interface java.util.List
  <<PATH>>/RapidWright/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java:127: error: cannot find symbol
          Assertions.assertTrue(values.containsAll(List.of("1", "2", "3")));
                                                       ^
    symbol:   method of(java.lang.String,java.lang.String,java.lang.String)
    location: interface java.util.List
  <<PATH>>/RapidWright/test/src/com/xilinx/rapidwright/edif/TestEDIFPropertyMap.java:134: error: cannot find symbol
          Assertions.assertEquals(Map.of("a", "1", "b", "2", "c", "3"), seen);
                                     ^
    symbol:   method of(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)
    location: interface java.util.Map
  4 errors
```