### PR TITLE
[Timing] Fixes for unrouted and post-routed designs

### DIFF
--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -562,4 +562,58 @@ public class NetTools {
         }
         return unroutedNets;
     }
+
+    /**
+     * Builds a map from each {@link Node} driven by a PIP of the given net onto the node driving it,
+     * so that the routing reaching any one node can be recovered by walking backwards from it (see
+     * {@link #getNodesToSink(SitePinInst)}). The direction of bidirectional PIPs is taken from
+     * {@link PIP#isReversed()}. Since a node has at most one entry, a multiply-driven node (which
+     * only an illegally routed net can have) retains just the driver of the last such PIP visited;
+     * use {@link #getNodeTrees(Net)} when all drivers matter. Nodes that the net's routing merely
+     * passes through without a PIP terminating on them (e.g. the source pin's node) are absent.
+     *
+     * The net's routing is assumed to be loop-free, so that following these drivers backwards from
+     * any node terminates.
+     *
+     * @param net The net to examine; it need not be fully routed.
+     * @return A map from driven node onto driving node, empty if the net has no PIPs.
+     */
+    public static Map<Node,Node> getNodeToDriver(Net net) {
+        Map<Node, Node> nodeToDriver = new HashMap<>();
+        for (PIP pip : net.getPIPs()) {
+            if (pip.isReversed()) {
+                nodeToDriver.put(pip.getStartNode(), pip.getEndNode());
+            } else {
+                nodeToDriver.put(pip.getEndNode(), pip.getStartNode());
+            }
+        }
+        return nodeToDriver;
+    }
+
+    /**
+     * Recovers the {@link Node} instances that route the net of the given sink pin as far as that
+     * pin, by walking backwards from it through the drivers given by
+     * {@link #getNodeToDriver(Net)}. Since that map is rebuilt on every call, prefer building it
+     * once and walking it directly when more than one sink of the same net is of interest.
+     *
+     * The walk stops at the first node that no PIP drives, which is not included in the result:
+     * for a fully routed sink that is the source pin's node, but for a partially routed one it is
+     * wherever its routing gives out, which this method does not distinguish. The net's routing is
+     * assumed to be loop-free; this walk does not terminate on one that is not.
+     *
+     * @param spi The sink {@link SitePinInst} to walk back from; it must belong to a net.
+     * @return The nodes reaching that pin, ordered sink-first and excluding the node the walk
+     *         stopped at, or an empty list if nothing drives the pin (e.g. an unrouted net).
+     */
+    public static List<Node> getNodesToSink(SitePinInst spi) {
+        Map<Node, Node> nodeToDriver = getNodeToDriver(spi.getNet());
+        Node sinkNode = spi.getConnectedNode();
+        // Walk backwards, stopping at the first node without a driver: either the source node of
+        // the net, or the sink itself when this connection has not been routed to
+        List<Node> nodes = new ArrayList<>();
+        for (Node node = sinkNode, driver; (driver = nodeToDriver.get(node)) != null; node = driver) {
+            nodes.add(node);
+        }
+        return nodes;
+    }
 }

--- a/src/com/xilinx/rapidwright/design/NetTools.java
+++ b/src/com/xilinx/rapidwright/design/NetTools.java
@@ -572,9 +572,6 @@ public class NetTools {
      * use {@link #getNodeTrees(Net)} when all drivers matter. Nodes that the net's routing merely
      * passes through without a PIP terminating on them (e.g. the source pin's node) are absent.
      *
-     * The net's routing is assumed to be loop-free, so that following these drivers backwards from
-     * any node terminates.
-     *
      * @param net The net to examine; it need not be fully routed.
      * @return A map from driven node onto driving node, empty if the net has no PIPs.
      */
@@ -606,6 +603,10 @@ public class NetTools {
      *         stopped at, or an empty list if nothing drives the pin (e.g. an unrouted net).
      */
     public static List<Node> getNodesToSink(SitePinInst spi) {
+        if (spi.isOutPin()) {
+            throw new RuntimeException("ERROR: " + spi + " is an output pin");
+        }
+
         Map<Node, Node> nodeToDriver = getNodeToDriver(spi.getNet());
         Node sinkNode = spi.getConnectedNode();
         // Walk backwards, stopping at the first node without a driver: either the source node of

--- a/src/com/xilinx/rapidwright/rwroute/CUFR.java
+++ b/src/com/xilinx/rapidwright/rwroute/CUFR.java
@@ -91,7 +91,7 @@ public class CUFR extends RWRoute {
     }
 
     public static class RouteNodeGraphCUFRTimingDriven extends RouteNodeGraphTimingDriven {
-        public RouteNodeGraphCUFRTimingDriven(Design design, RWRouteConfig config, DelayEstimatorBase delayEstimator) {
+        public RouteNodeGraphCUFRTimingDriven(Design design, RWRouteConfig config, DelayEstimatorBase<InterconnectInfo> delayEstimator) {
             super(design, config, delayEstimator);
         }
 
@@ -104,7 +104,7 @@ public class CUFR extends RWRoute {
     protected RouteNodeGraph createRouteNodeGraph() {
         if (config.isTimingDriven()) {
             /* An instantiated delay estimator that is used to calculate delay of routing resources */
-            DelayEstimatorBase estimator = new DelayEstimatorBase<>(design.getDevice(), new InterconnectInfo(), config.isUseUTurnNodes(), 0);
+            DelayEstimatorBase<InterconnectInfo> estimator = new DelayEstimatorBase<>(design.getDevice(), new InterconnectInfo(), config.isUseUTurnNodes(), 0);
             return new RouteNodeGraphCUFRTimingDriven(design, config, estimator);
         } else {
             return new RouteNodeGraphCUFR(design, config);

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -185,7 +185,8 @@ public class PartialRouter extends RWRoute {
     @Override
     protected TimingManager createTimingManager(ClkRouteTiming clkTiming, Collection<Net> timingNets) {
         final boolean isPartialRouting = true;
-        return new TimingManager(design, routerTimer, config, clkTiming, timingNets, isPartialRouting);
+        return new TimingManager(design, routerTimer, config, clkTiming, timingNets, isPartialRouting,
+                ((RouteNodeGraphTimingDriven) routingGraph).delayEstimator);
     }
 
     @Override

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -186,7 +186,7 @@ public class PartialRouter extends RWRoute {
     protected TimingManager createTimingManager(ClkRouteTiming clkTiming, Collection<Net> timingNets) {
         final boolean isPartialRouting = true;
         return new TimingManager(design, routerTimer, config, clkTiming, timingNets, isPartialRouting,
-                ((RouteNodeGraphTimingDriven) routingGraph).delayEstimator);
+                routingGraph.getDelayEstimator());
     }
 
     @Override

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -312,7 +312,8 @@ public class RWRoute {
 
     protected TimingManager createTimingManager(ClkRouteTiming clkTiming, Collection<Net> timingNets) {
         final boolean isPartialRouting = false;
-        return new TimingManager(design, routerTimer, config, clkTiming, timingNets, isPartialRouting);
+        return new TimingManager(design, routerTimer, config, clkTiming, timingNets, isPartialRouting,
+                ((RouteNodeGraphTimingDriven) routingGraph).delayEstimator);
     }
 
     /**
@@ -1423,7 +1424,7 @@ public class RWRoute {
                     continue;
                 }
                 totalINTNodes++;
-                int wl = RouteNode.getLength(node, routingGraph);
+                int wl = RouteNode.getLength(node);
                 totalWL += wl;
 
                 RouterHelper.addNodeTypeLengthToMap(node, wl, nodeTypeUsage, nodeTypeLength);
@@ -2303,7 +2304,7 @@ public class RWRoute {
 
     private void printTimingInfo() {
         if (!sortedIndirectConnections.isEmpty()) {
-            timingManager.getCriticalPathInfo(maxDelayAndTimingVertex, false, routingGraph);
+            timingManager.getCriticalPathInfo(maxDelayAndTimingVertex);
         }
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RWRoute.java
+++ b/src/com/xilinx/rapidwright/rwroute/RWRoute.java
@@ -313,7 +313,7 @@ public class RWRoute {
     protected TimingManager createTimingManager(ClkRouteTiming clkTiming, Collection<Net> timingNets) {
         final boolean isPartialRouting = false;
         return new TimingManager(design, routerTimer, config, clkTiming, timingNets, isPartialRouting,
-                ((RouteNodeGraphTimingDriven) routingGraph).delayEstimator);
+                routingGraph.getDelayEstimator());
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -344,8 +344,8 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
         return getOccupancy() > 0;
     }
 
-    public static short getLength(Node node, RouteNodeGraph routingGraph) {
-        return RouteNodeInfo.get(node, routingGraph).length;
+    public static short getLength(Node node) {
+        return RouteNodeInfo.get(node, null).length;
     }
 
     @Override

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -55,6 +55,7 @@ import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.TileTypeEnum;
 import com.xilinx.rapidwright.router.RouteThruHelper;
 import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
+import com.xilinx.rapidwright.timing.delayestimator.InterconnectInfo;
 import com.xilinx.rapidwright.util.CountUpDownLatch;
 import com.xilinx.rapidwright.util.ParallelismTools;
 import com.xilinx.rapidwright.util.Utils;
@@ -1249,7 +1250,7 @@ public class RouteNodeGraph {
      * Gets the delay estimator that this graph computes its node delays with.
      * @return That delay estimator, or null since this graph is not timing driven.
      */
-    public DelayEstimatorBase getDelayEstimator() {
+    public DelayEstimatorBase<InterconnectInfo> getDelayEstimator() {
         return null;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -54,6 +54,7 @@ import com.xilinx.rapidwright.device.Series;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.TileTypeEnum;
 import com.xilinx.rapidwright.router.RouteThruHelper;
+import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
 import com.xilinx.rapidwright.util.CountUpDownLatch;
 import com.xilinx.rapidwright.util.ParallelismTools;
 import com.xilinx.rapidwright.util.Utils;
@@ -1242,6 +1243,14 @@ public class RouteNodeGraph {
 
     public float getPresentCongestionCost(int occupancy) {
         return presentCongestionCosts[occupancy];
+    }
+
+    /**
+     * Gets the delay estimator that this graph computes its node delays with.
+     * @return That delay estimator, or null since this graph is not timing driven.
+     */
+    public DelayEstimatorBase getDelayEstimator() {
+        return null;
     }
 
     /**

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraphTimingDriven.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraphTimingDriven.java
@@ -96,6 +96,11 @@ public class RouteNodeGraphTimingDriven extends RouteNodeGraph {
     private final Set<Integer> excludeAboveRclk;
     private final Set<Integer> excludeBelowRclk;
 
+    @Override
+    public DelayEstimatorBase getDelayEstimator() {
+        return delayEstimator;
+    }
+
     protected static class RouteNodeTimingDriven extends RouteNode {
 
         /** The delay of this rnode computed based on the timing model */

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraphTimingDriven.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraphTimingDriven.java
@@ -29,6 +29,7 @@ import com.xilinx.rapidwright.device.Node;
 import com.xilinx.rapidwright.device.Tile;
 import com.xilinx.rapidwright.device.TileTypeEnum;
 import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
+import com.xilinx.rapidwright.timing.delayestimator.InterconnectInfo;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,7 +41,7 @@ import java.util.Set;
  */
 public class RouteNodeGraphTimingDriven extends RouteNodeGraph {
     /** The instantiated delayEstimator to compute delays */
-    protected final DelayEstimatorBase delayEstimator;
+    protected final DelayEstimatorBase<InterconnectInfo> delayEstimator;
     /** A flag to indicate if the routing resource exclusion should disable exclusion of nodes cross RCLK */
     protected final boolean maskNodesCrossRCLK;
 
@@ -72,7 +73,7 @@ public class RouteNodeGraphTimingDriven extends RouteNodeGraph {
 
     protected RouteNodeGraphTimingDriven(Design design,
                                          RWRouteConfig config,
-                                         DelayEstimatorBase delayEstimator) {
+                                         DelayEstimatorBase<InterconnectInfo> delayEstimator) {
         super(design, config);
         this.delayEstimator = delayEstimator;
         this.maskNodesCrossRCLK = config.isMaskNodesCrossRCLK();
@@ -97,7 +98,7 @@ public class RouteNodeGraphTimingDriven extends RouteNodeGraph {
     private final Set<Integer> excludeBelowRclk;
 
     @Override
-    public DelayEstimatorBase getDelayEstimator() {
+    public DelayEstimatorBase<InterconnectInfo> getDelayEstimator() {
         return delayEstimator;
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -73,16 +73,30 @@ public class RouteNodeInfo {
         RouteNodeType type = getType(node, routingGraph);
         short endTileXCoordinate = getEndTileXCoordinate(node, (short) endTile.getTileXCoordinate());
         short endTileYCoordinate = (short) endTile.getTileYCoordinate();
-        short length = getLength(baseTile, type, endTileXCoordinate, endTileYCoordinate, routingGraph);
+        short length = getLength(baseTile, endTileXCoordinate, endTileYCoordinate);
+        if (routingGraph != null) {
+            TileTypeEnum tileType = baseTile.getTileTypeEnum();
+            switch (tileType) {
+                case LAG_LAG:
+                case LAGUNA_TILE:
+                    assert(length == routingGraph.SUPER_LONG_LINE_LENGTH_IN_TILES ||
+                           // U-turn
+                           length == 0);
+                    break;
+                case INT:
+                    if (type.leadsToLaguna()) {
+                        assert(length <= 1); // 1 only if INODE_[EW]_\d+_FT[01]
+                    }
+                    break;
+            }
+        }
 
         return new RouteNodeInfo(type, endTileXCoordinate, endTileYCoordinate, length);
     }
 
     private static short getLength(Tile baseTile,
-                                   RouteNodeType type,
                                    short endTileXCoordinate,
-                                   short endTileYCoordinate,
-                                   RouteNodeGraph routingGraph) {
+                                   short endTileYCoordinate) {
         TileTypeEnum tileType = baseTile.getTileTypeEnum();
         short length = (short) Math.abs(endTileYCoordinate - baseTile.getTileYCoordinate());
         if (tileType == TileTypeEnum.LAG_LAG) {
@@ -90,19 +104,6 @@ public class RouteNodeInfo {
             assert(baseTile.getTileXCoordinate() == endTileXCoordinate - 1);
         } else {
             length += Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate());
-        }
-        switch (tileType) {
-            case LAG_LAG:
-            case LAGUNA_TILE:
-                assert(length == routingGraph.SUPER_LONG_LINE_LENGTH_IN_TILES ||
-                       // U-turn
-                       length == 0);
-                break;
-            case INT:
-                if (type.leadsToLaguna()) {
-                    assert(length <= 1); // 1 only if INODE_[EW]_\d+_FT[01]
-                }
-                break;
         }
         return length;
     }
@@ -136,6 +137,10 @@ public class RouteNodeInfo {
     }
 
     public static RouteNodeType getType(Node node, RouteNodeGraph routingGraph) {
+        if (routingGraph == null) {
+            return null;
+        }
+
         // NOTE: IntentCode is device-dependent
         IntentCode ic = node.getIntentCode();
         TileTypeEnum tileTypeEnum = node.getTile().getTileTypeEnum();

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeInfo.java
@@ -47,6 +47,14 @@ public class RouteNodeInfo {
         this.length = length;
     }
 
+    /**
+     * Gets the information that a {@link RouteNode} is built out of, for a given node.
+     * @param node Node to describe.
+     * @param routingGraph Graph the node is to be a part of, or null to describe the node on its
+     *                     own; the returned {@link #type} is then null, since a type only has
+     *                     meaning within a graph.
+     * @return That information.
+     */
     public static RouteNodeInfo get(Node node, RouteNodeGraph routingGraph) {
         Wire[] wires = node.getAllWiresInNode();
         assert(wires[0].getTile() == node.getTile() && wires[0].getWireIndex() == node.getWireIndex());
@@ -70,13 +78,20 @@ public class RouteNodeInfo {
             break;
         }
 
-        RouteNodeType type = getType(node, routingGraph);
+        // Without a routing graph there is no type to be determined, nor anything to check the
+        // length against; only the length itself is recoverable
+        RouteNodeType type = (routingGraph != null) ? getType(node, routingGraph) : null;
         short endTileXCoordinate = getEndTileXCoordinate(node, (short) endTile.getTileXCoordinate());
         short endTileYCoordinate = (short) endTile.getTileYCoordinate();
-        short length = getLength(baseTile, endTileXCoordinate, endTileYCoordinate);
+        short length = (short) Math.abs(endTileYCoordinate - baseTile.getTileYCoordinate());
+        if (baseTileType == TileTypeEnum.LAG_LAG) {
+            // Nodes in LAGUNA tiles must have no X distance
+            assert(baseTile.getTileXCoordinate() == endTileXCoordinate - 1);
+        } else {
+            length += Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate());
+        }
         if (routingGraph != null) {
-            TileTypeEnum tileType = baseTile.getTileTypeEnum();
-            switch (tileType) {
+            switch (baseTileType) {
                 case LAG_LAG:
                 case LAGUNA_TILE:
                     assert(length == routingGraph.SUPER_LONG_LINE_LENGTH_IN_TILES ||
@@ -92,20 +107,6 @@ public class RouteNodeInfo {
         }
 
         return new RouteNodeInfo(type, endTileXCoordinate, endTileYCoordinate, length);
-    }
-
-    private static short getLength(Tile baseTile,
-                                   short endTileXCoordinate,
-                                   short endTileYCoordinate) {
-        TileTypeEnum tileType = baseTile.getTileTypeEnum();
-        short length = (short) Math.abs(endTileYCoordinate - baseTile.getTileYCoordinate());
-        if (tileType == TileTypeEnum.LAG_LAG) {
-            // Nodes in LAGUNA tiles must have no X distance
-            assert(baseTile.getTileXCoordinate() == endTileXCoordinate - 1);
-        } else {
-            length += Math.abs(endTileXCoordinate - baseTile.getTileXCoordinate());
-        }
-        return length;
     }
 
     private static short getEndTileXCoordinate(Node node, short endTileXCoordinate) {
@@ -137,10 +138,6 @@ public class RouteNodeInfo {
     }
 
     public static RouteNodeType getType(Node node, RouteNodeGraph routingGraph) {
-        if (routingGraph == null) {
-            return null;
-        }
-
         // NOTE: IntentCode is device-dependent
         IntentCode ic = node.getIntentCode();
         TileTypeEnum tileTypeEnum = node.getTile().getTileTypeEnum();

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -559,6 +559,20 @@ public class RouterHelper {
      * @return The map containing net delay for each sink pin paired with an INT tile node of a routed net.
      */
     public static Map<SitePinInst, Pair<Node,Short>> getSourceToSinkINTNodeDelays(Net net, DelayEstimatorBase estimator) {
+        return getSourceToSinkINTNodeDelays(net, estimator, null);
+    }
+
+    /**
+     * Gets a map containing net delay for each sink pin paired with an INT tile node of a routed net.
+     * @param net The target routed net.
+     * @param estimator An instantiation of DelayEstimatorBase.
+     * @param nodeToDriver If non-null, populated during the same traversal of the net's PIPs with a
+     *                     mapping from each node onto the node driving it, so that the routing of any
+     *                     one sink can be recovered by walking backwards from it.
+     * @return The map containing net delay for each sink pin paired with an INT tile node of a routed net.
+     */
+    public static Map<SitePinInst, Pair<Node,Short>> getSourceToSinkINTNodeDelays(Net net, DelayEstimatorBase estimator,
+                                                                                  Map<Node, Node> nodeToDriver) {
         List<PIP> pips = net.getPIPs();
         Map<Node, Integer> delayMap = new HashMap<>();
         for (PIP pip : pips) {
@@ -572,6 +586,9 @@ public class RouterHelper {
                         + DelayEstimatorBase.getExtraDelay(endNode, DelayEstimatorBase.isLong(startNode));
             }
             delayMap.put(endNode, upstreamDelay + delay);
+            if (nodeToDriver != null) {
+                nodeToDriver.put(endNode, startNode);
+            }
         }
 
         Map<SitePinInst, Pair<Node,Short>> sinkNodeDelays = new HashMap<>();

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -586,7 +586,7 @@ public class RouterHelper {
                 }
             }
 
-            short routeDelay = (short) delayMap.get(sinkNode).intValue();
+            short routeDelay = (short) delayMap.getOrDefault(sinkNode, 0).intValue();
             sinkNodeDelays.put(sink, new Pair<>(sinkNode,routeDelay));
         }
 

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -664,34 +664,6 @@ public class RouterHelper {
     }
 
     /**
-     *  Gets the delay of a given path, using output pin only.
-     *  The path format:
-     *  {@code superSource -> Q -> O -> --- -> D.}
-     */
-    public static void getSamplePathDelay(String filePath, TimingManager timingManager,
-            Map<TimingEdge, Connection> timingEdgeConnectionMap, RouteNodeGraph routingGraph) {
-        List<String> verticesOfVivadoPath = new ArrayList<>();
-        // Include CLK if the first in the path is BRAM or DSP to check the logic delay
-        // NOTE: remember to change the pin names of DSPs from subblock to top-level block that we use
-        verticesOfVivadoPath.add("superSource");
-        File vivadoReport = new File(filePath);
-        if (!vivadoReport.exists()) {
-            System.err.println("ERROR: Target file does not exist for getting the sample path delay");
-            return;
-        }
-        try {
-            List<String> path = parseVivadoPathToStringList(vivadoReport);
-            System.out.println("INFO: Given path: " + path);
-            verticesOfVivadoPath.addAll(path);
-        } catch (IOException e) {
-
-            e.printStackTrace();
-        }
-        System.out.println(verticesOfVivadoPath);
-        timingManager.getSamplePathDelayInfo(verticesOfVivadoPath, timingEdgeConnectionMap, true, routingGraph);
-    }
-
-    /**
      * Parses the data path from an input file indicating data path of a Vivado timing report.
      * @param file The file contains a data path of a Vivado timing report.
      * @return The data path.

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -553,20 +553,6 @@ public class RouterHelper {
      * @return The map containing net delay for each sink pin paired with an INT tile node of a routed net.
      */
     public static Map<SitePinInst, Pair<Node,Short>> getSourceToSinkINTNodeDelays(Net net, DelayEstimatorBase estimator) {
-        return getSourceToSinkINTNodeDelays(net, estimator, null);
-    }
-
-    /**
-     * Gets a map containing net delay for each sink pin paired with an INT tile node of a routed net.
-     * @param net The target routed net.
-     * @param estimator An instantiation of DelayEstimatorBase.
-     * @param nodeToDriver If non-null, populated during the same traversal of the net's PIPs with a
-     *                     mapping from each node onto the node driving it, so that the routing of any
-     *                     one sink can be recovered by walking backwards from it.
-     * @return The map containing net delay for each sink pin paired with an INT tile node of a routed net.
-     */
-    public static Map<SitePinInst, Pair<Node,Short>> getSourceToSinkINTNodeDelays(Net net, DelayEstimatorBase estimator,
-                                                                                  Map<Node, Node> nodeToDriver) {
         List<PIP> pips = net.getPIPs();
         Map<Node, Integer> delayMap = new HashMap<>();
         for (PIP pip : pips) {
@@ -580,9 +566,6 @@ public class RouterHelper {
                         + DelayEstimatorBase.getExtraDelay(endNode, DelayEstimatorBase.isLong(startNode));
             }
             delayMap.put(endNode, upstreamDelay + delay);
-            if (nodeToDriver != null) {
-                nodeToDriver.put(endNode, startNode);
-            }
         }
 
         Map<SitePinInst, Pair<Node,Short>> sinkNodeDelays = new HashMap<>();

--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -24,10 +24,6 @@
 
 package com.xilinx.rapidwright.rwroute;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,8 +62,6 @@ import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFNetlist;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
-import com.xilinx.rapidwright.timing.TimingEdge;
-import com.xilinx.rapidwright.timing.TimingManager;
 import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
 import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.Utils;
@@ -603,7 +597,10 @@ public class RouterHelper {
                 }
             }
 
-            short routeDelay = (short) delayMap.getOrDefault(sinkNode, 0).intValue();
+            // A sink that no PIP arrives at has not been routed to yet (e.g. on a placed-only
+            // design), so it has accumulated no route delay
+            Integer delay = delayMap.get(sinkNode);
+            short routeDelay = (delay == null) ? 0 : delay.shortValue();
             sinkNodeDelays.put(sink, new Pair<>(sinkNode,routeDelay));
         }
 
@@ -678,29 +675,5 @@ public class RouterHelper {
 
         System.err.println("ERROR: Failed to find a path between two nodes: " + source + ", " + sink);
         return Collections.emptyList();
-    }
-
-    /**
-     * Parses the data path from an input file indicating data path of a Vivado timing report.
-     * @param file The file contains a data path of a Vivado timing report.
-     * @return The data path.
-     * @throws IOException
-     */
-    public static List<String> parseVivadoPathToStringList(File file) throws IOException{
-        List<String> path = new ArrayList<>();
-        BufferedReader reader = new BufferedReader(new FileReader(file));
-        String line;
-        while ((line = reader.readLine()) != null) {
-            if (line.length() == 0) {
-                break;
-            }
-
-            if (!line.contains(" r  ") && !line.contains(" f  ")) continue;
-
-            String[] dataStrings = line.split("\\s+");
-            path.add(dataStrings[dataStrings.length - 1]);
-        }
-        reader.close();
-        return path;
     }
 }

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -24,8 +24,10 @@
 
 package com.xilinx.rapidwright.rwroute;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.xilinx.rapidwright.design.Design;
@@ -55,9 +57,13 @@ public class TimingAndWirelengthReport{
     private DelayEstimatorBase<InterconnectInfo> estimator;
     private Map<IntentCode, Long> nodeTypeUsage ;
     private Map<IntentCode, Long> nodeTypeLength;
+    /** Only when verbose does {@link TimingManager} print the per-node delay breakdown of the
+     *  critical path, so only then is it worth collecting the nodes of each connection. */
+    private boolean verbose;
 
     public TimingAndWirelengthReport(Design design, RWRouteConfig config, boolean isPartialRouting) {
         this.design = design;
+        verbose = config.isVerbose();
         estimator = new DelayEstimatorBase<>(design.getDevice(),
                 new InterconnectInfo(), config.isUseUTurnNodes(), 0);
         timingManager = new TimingManager(design, null, config, RWRoute.createClkTimingData(config), design.getNets(), isPartialRouting, estimator);
@@ -135,8 +141,13 @@ public class TimingAndWirelengthReport{
      * @param netWrapper
      */
     private void setAccumulativeDelayOfEachNetNode(NetWrapper netWrapper) {
+        Net net = netWrapper.getNet();
+        // Collect each node of this net's routing mapped onto the node driving it, so that the nodes
+        // of each connection below can be recovered by walking backwards from that connection's sink.
+        // Only the verbose critical path breakdown consumes them, so do not pay for them otherwise.
+        Map<Node, Node> nodeToDriver = verbose ? new HashMap<>() : null;
         Map<SitePinInst, Pair<Node,Short>> sourceToSinkINTNodeDelays =
-                RouterHelper.getSourceToSinkINTNodeDelays(netWrapper.getNet(), estimator);
+                RouterHelper.getSourceToSinkINTNodeDelays(net, estimator, nodeToDriver);
 
         for (Connection connection : netWrapper.getConnections()) {
             if (connection.isDirect()) {
@@ -148,6 +159,15 @@ public class TimingAndWirelengthReport{
                 continue;
             }
             connection.setTimingEdgesDelay(connectionDelay);
+
+            if (nodeToDriver != null) {
+                // Connection.getNodes() is expected to be ordered sink-first, source-last
+                List<Node> nodes = new ArrayList<>();
+                for (Node node = sinkINTNodeDelay.getFirst(); node != null; node = nodeToDriver.get(node)) {
+                    nodes.add(node);
+                }
+                connection.setNodes(nodes);
+            }
         }
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -161,9 +161,12 @@ public class TimingAndWirelengthReport{
             connection.setTimingEdgesDelay(connectionDelay);
 
             if (nodeToDriver != null) {
-                // Connection.getNodes() is expected to be ordered sink-first, source-last
+                // Connection.getNodes() is expected to be ordered sink-first, source-last.
+                // Stop at the first node without a driver: either the source node of the net, or
+                // the sink itself if this connection is not routed.
                 List<Node> nodes = new ArrayList<>();
-                for (Node node = sinkINTNodeDelay.getFirst(); node != null; node = nodeToDriver.get(node)) {
+                Node node = sinkINTNodeDelay.getFirst();
+                for (Node driver; (driver = nodeToDriver.get(node)) != null; node = driver) {
                     nodes.add(node);
                 }
                 connection.setNodes(nodes);

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -24,6 +24,7 @@
 
 package com.xilinx.rapidwright.rwroute;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,14 +55,12 @@ public class TimingAndWirelengthReport{
     private DelayEstimatorBase<InterconnectInfo> estimator;
     private Map<IntentCode, Long> nodeTypeUsage ;
     private Map<IntentCode, Long> nodeTypeLength;
-    private RouteNodeGraph routingGraph;
 
     public TimingAndWirelengthReport(Design design, RWRouteConfig config, boolean isPartialRouting) {
         this.design = design;
-        timingManager = new TimingManager(design, null, config, RWRoute.createClkTimingData(config), design.getNets(), isPartialRouting);
-        estimator = new DelayEstimatorBase<InterconnectInfo>(design.getDevice(),
+        estimator = new DelayEstimatorBase<>(design.getDevice(),
                 new InterconnectInfo(), config.isUseUTurnNodes(), 0);
-        routingGraph = new RouteNodeGraphTimingDriven(design, config, estimator);
+        timingManager = new TimingManager(design, null, config, RWRoute.createClkTimingData(config), design.getNets(), isPartialRouting, estimator);
         wirelength = 0;
         usedNodes = 0;
         nodeTypeUsage = new HashMap<>();
@@ -76,9 +75,9 @@ public class TimingAndWirelengthReport{
 
         Pair<Float, TimingVertex> maxDelayAndTimingVertex = timingManager.calculateArrivalRequiredTimes();
         System.out.println();
-        timingManager.getCriticalPathInfo(maxDelayAndTimingVertex, false, routingGraph);
+        timingManager.getCriticalPathInfo(maxDelayAndTimingVertex);
 
-        System.out.println("\n");
+        System.out.println();
         System.out.println("Total nodes: " + usedNodes);
         System.out.println("Total wirelength: " + wirelength);
         RWRoute.printNodeTypeUsageAndWirelength(true, nodeTypeUsage, nodeTypeLength, design.getSeries());
@@ -98,7 +97,7 @@ public class TimingAndWirelengthReport{
                     continue;
                 }
                 usedNodes++;
-                int wl = RouteNode.getLength(node, routingGraph);
+                int wl = RouteNode.getLength(node);
                 wirelength += wl;
                 RouterHelper.addNodeTypeLengthToMap(node, wl, nodeTypeUsage, nodeTypeLength);
             }
@@ -115,7 +114,6 @@ public class TimingAndWirelengthReport{
     private NetWrapper createNetWrapper(Net net) {
         NetWrapper netWrapper = new NetWrapper(numWireNetsToRoute++, net);
         SitePinInst source = net.getSource();
-        Node sourceINTNode = null;
         for (SitePinInst sink:net.getSinkPins()) {
             if (RouterHelper.isExternalConnectionToCout(source, sink)) {
                 source = net.getAlternateSource();
@@ -126,16 +124,7 @@ public class TimingAndWirelengthReport{
             }
             Connection connection = new Connection(numConnectionsToRoute++, source, sink, netWrapper);
             Node sinkINTNode = RouterHelper.projectInputPinToINTNode(sink);
-            if (sinkINTNode == null) {
-                connection.setDirect(true);
-            } else {
-                if (sourceINTNode == null) {
-                    sourceINTNode = RouterHelper.projectOutputPinToINTNode(source);
-                }
-                connection.setSourceRnode(routingGraph.getOrCreate(sourceINTNode, RouteNodeType.EXCLUSIVE_SOURCE));
-                connection.setSinkRnode(routingGraph.getOrCreate(sinkINTNode));
-                connection.setDirect(false);
-            }
+            connection.setDirect(sinkINTNode == null);
         }
         return netWrapper;
     }
@@ -164,7 +153,8 @@ public class TimingAndWirelengthReport{
 
     public static void main(String[] args) {
         if (args.length < 1) {
-            System.out.println("USAGE:\n <input.dcp>");
+            System.out.println("USAGE: <input.dcp>");
+            System.exit(1);
         }
         Design design = Design.readCheckpoint(args[0]);
         if (design.getNets().isEmpty()) {
@@ -175,7 +165,7 @@ public class TimingAndWirelengthReport{
         //design manipulations are necessary, otherwise there will be problems in associating timing edges with connections.
         DesignTools.makePhysNetNamesConsistent(design);
         DesignTools.createMissingSitePinInsts(design);
-        RWRouteConfig config = new RWRouteConfig(new String[0]);
+        RWRouteConfig config = new RWRouteConfig(Arrays.copyOfRange(args, 1, args.length));
         config.setTimingDriven(true);
         final boolean isPartialRouting = false;
         TimingAndWirelengthReport reporter = new TimingAndWirelengthReport(design, config, isPartialRouting);

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -24,10 +24,8 @@
 
 package com.xilinx.rapidwright.rwroute;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.xilinx.rapidwright.design.Design;
@@ -57,13 +55,9 @@ public class TimingAndWirelengthReport{
     private DelayEstimatorBase<InterconnectInfo> estimator;
     private Map<IntentCode, Long> nodeTypeUsage ;
     private Map<IntentCode, Long> nodeTypeLength;
-    /** Only when verbose does {@link TimingManager} print the per-node delay breakdown of the
-     *  critical path, so only then is it worth collecting the nodes of each connection. */
-    private boolean verbose;
 
     public TimingAndWirelengthReport(Design design, RWRouteConfig config, boolean isPartialRouting) {
         this.design = design;
-        verbose = config.isVerbose();
         estimator = new DelayEstimatorBase<>(design.getDevice(),
                 new InterconnectInfo(), config.isUseUTurnNodes(), 0);
         timingManager = new TimingManager(design, null, config, RWRoute.createClkTimingData(config), design.getNets(), isPartialRouting, estimator);
@@ -142,35 +136,18 @@ public class TimingAndWirelengthReport{
      */
     private void setAccumulativeDelayOfEachNetNode(NetWrapper netWrapper) {
         Net net = netWrapper.getNet();
-        // Collect each node of this net's routing mapped onto the node driving it, so that the nodes
-        // of each connection below can be recovered by walking backwards from that connection's sink.
-        // Only the verbose critical path breakdown consumes them, so do not pay for them otherwise.
-        Map<Node, Node> nodeToDriver = verbose ? new HashMap<>() : null;
         Map<SitePinInst, Pair<Node,Short>> sourceToSinkINTNodeDelays =
-                RouterHelper.getSourceToSinkINTNodeDelays(net, estimator, nodeToDriver);
+                RouterHelper.getSourceToSinkINTNodeDelays(net, estimator);
 
         for (Connection connection : netWrapper.getConnections()) {
             if (connection.isDirect()) {
                 continue;
             }
-            Pair<Node,Short> sinkINTNodeDelay = sourceToSinkINTNodeDelays.get(connection.getSink());
-            short connectionDelay = sinkINTNodeDelay.getSecond();
+            short connectionDelay = sourceToSinkINTNodeDelays.get(connection.getSink()).getSecond();
             if (connection.getTimingEdges() == null) {
                 continue;
             }
             connection.setTimingEdgesDelay(connectionDelay);
-
-            if (nodeToDriver != null) {
-                // Connection.getNodes() is expected to be ordered sink-first, source-last.
-                // Stop at the first node without a driver: either the source node of the net, or
-                // the sink itself if this connection is not routed.
-                List<Node> nodes = new ArrayList<>();
-                Node node = sinkINTNodeDelay.getFirst();
-                for (Node driver; (driver = nodeToDriver.get(node)) != null; node = driver) {
-                    nodes.add(node);
-                }
-                connection.setNodes(nodes);
-            }
         }
     }
 

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -142,7 +142,8 @@ public class TimingAndWirelengthReport{
             if (connection.isDirect()) {
                 continue;
             }
-            short connectionDelay = sourceToSinkINTNodeDelays.get(connection.getSink()).getSecond();
+            Pair<Node,Short> sinkINTNodeDelay = sourceToSinkINTNodeDelays.get(connection.getSink());
+            short connectionDelay = sinkINTNodeDelay.getSecond();
             if (connection.getTimingEdges() == null) {
                 continue;
             }

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -135,9 +135,8 @@ public class TimingAndWirelengthReport{
      * @param netWrapper
      */
     private void setAccumulativeDelayOfEachNetNode(NetWrapper netWrapper) {
-        Net net = netWrapper.getNet();
         Map<SitePinInst, Pair<Node,Short>> sourceToSinkINTNodeDelays =
-                RouterHelper.getSourceToSinkINTNodeDelays(net, estimator);
+                RouterHelper.getSourceToSinkINTNodeDelays(netWrapper.getNet(), estimator);
 
         for (Connection connection : netWrapper.getConnections()) {
             if (connection.isDirect()) {

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -167,6 +167,11 @@ public class TimingAndWirelengthReport{
             System.out.println("USAGE:\n <input.dcp>");
         }
         Design design = Design.readCheckpoint(args[0]);
+        if (design.getNets().isEmpty()) {
+            // A placed-only checkpoint can contain no physical nets at all; recover them (along with
+            // their intra-site routing) from the logical netlist so that a timing graph can be built.
+            design.routeSites();
+        }
         //design manipulations are necessary, otherwise there will be problems in associating timing edges with connections.
         DesignTools.makePhysNetNamesConsistent(design);
         DesignTools.createMissingSitePinInsts(design);

--- a/src/com/xilinx/rapidwright/timing/TimingEdge.java
+++ b/src/com/xilinx/rapidwright/timing/TimingEdge.java
@@ -349,7 +349,9 @@ public class TimingEdge extends DefaultEdge {
 
     /**
      * Gets the physical "Net" object associated with this edge.
-     * @return Physical "Net" for this edge.
+     * @return Physical "Net" for this edge, or null when there is no net to associate: edges
+     *         representing a delay internal to a cell, and the edges to and from the super
+     *         source/sink that bound the graph.
      */
     public Net getNet() {
         return this.net;

--- a/src/com/xilinx/rapidwright/timing/TimingGraph.java
+++ b/src/com/xilinx/rapidwright/timing/TimingGraph.java
@@ -415,67 +415,6 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
     }
     
     /**
-     * Finds the given critical path in the timing graph and reports the delay detail
-     * @param verticesNames, the given TimingVertices
-     * @return A list of TimingEdges associated with the given TimingVertices
-     */
-    // output vertices only
-    // return null if path not found in the graph
-    public List<TimingEdge> getTimingEdgeOfPath(List<String> verticesNames) {
-        boolean verbose = true;
-        
-        if (verbose) System.out.println("\nGET DELAY OF GIVEN PATH:\n");
-        List<TimingVertex> vertices = new ArrayList<>();
-        for (String str : verticesNames) {
-            TimingVertex v = safeVertexCheck.get(str);
-            if (v != null) {
-                vertices.add(v);
-            } else {
-                System.err.println("graph does not contain: " + str);
-            }
-        }
-        if (verbose) System.out.println(vertices.size() + " / " + verticesNames.size() + " vertices from the path found in TimingGraph");
-        List<TimingEdge> edges = new ArrayList<>();
-        // Q -> O -> O -> --- -> D
-        for (int i = 0; i < vertices.size() - 1; i++) {
-            if (verbose) {
-                if (i > 0) {//skip superSource outgoing timing edges printout as there are too many
-                    System.out.println(vertices.get(i) + " outgoing timing eges:\n " + outgoingEdgesOf(vertices.get(i)));
-                }
-            }
-            boolean found = false;
-            for (TimingEdge e : outgoingEdgesOf(vertices.get(i))) {
-                if (found) {
-                    break;
-                }
-                if (outgoingEdgesOf(e.getDst()).size() == 0)
-                    System.out.println(e.getDst() + " no outgoing edges, delay =  " + e.getDelay());
-                for (TimingEdge nexte : outgoingEdgesOf(e.getDst())) {
-                    // this means the hops between adjacent pins could be more than two
-                    // otherwise, it will report as NULL TimingEdge found
-                    if (nexte.getDst().equals(vertices.get(i+1))) {
-                        if (verbose) System.out.println("TimingEdge found between: \n  " + vertices.get(i) + ", " + vertices.get(i+1));
-                        edges.add(e);
-                        edges.add(nexte);
-                        found = true;
-                        break;
-                    }
-                }
-                if (e.getDst().equals(vertices.get(i+1))) {
-                    edges.add(e);
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                System.out.println("NULL TimingEdge found between: \n  " + vertices.get(i) + ", " + vertices.get(i+1));
-            }
-            if (verbose) System.out.println();
-        }
-        return edges;
-    }
-        
-    /**
      * Sets the same specified timing requirement on a specified GraphPath.
      * @param requirement The required time in picoseconds at the sink of the path.
      * @param graphPath The GraphPath receiving this required time in picoseconds at the sink of the

--- a/src/com/xilinx/rapidwright/timing/TimingGraph.java
+++ b/src/com/xilinx/rapidwright/timing/TimingGraph.java
@@ -974,8 +974,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
             return false;
         }
         TimingEdge prev = getEdge(vs, vd);
-        boolean tmp = (prev != null && prev.getNet() != null);
-        if (tmp) {
+        if (prev != null) {
             if (verbose)
                 System.out.println("replacing edge:"+e);
             else {
@@ -1123,7 +1122,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                         
                         TimingVertex v1 = newTimingVertex(cellName+"/"+s1);
                         TimingVertex v2 = newTimingVertex(cellName+"/"+s2);
-                        TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                        TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                         
                         safeAddEdge(e.getSrc(), e.getDst(), e);
                         e.setLogicDelay(delay);
@@ -1345,7 +1344,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
 
                             TimingVertex v1 = newTimingVertex(s1);
                             TimingVertex v2 = newTimingVertex(s2);
-                            TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                            TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                             safeAddEdge(e.getSrc(), e.getDst(), e);
                             e.setLogicDelay(logicDelay);
                             setEdgeWeight(e, e.getDelay());
@@ -1414,7 +1413,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                                         for (int i = 0; i < 8; i++) {
                                             TimingVertex v1 = newTimingVertex(cellName + "/" + ep1FirstLetter + j);
                                             TimingVertex v2 = newTimingVertex(cellName + "/" + s2 + i);
-                                            TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                                            TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                                             safeAddEdge(e.getSrc(), e.getDst(), e);
                                             e.setLogicDelay(logicDelay);
                                             setEdgeWeight(e, e.getDelay());
@@ -1424,7 +1423,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                                         }
                                         TimingVertex v1 = newTimingVertex(cellName + "/" + ep1FirstLetter + j);
                                         TimingVertex v2 = newTimingVertex(cellName + "/" + "OUT1");
-                                        TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                                        TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                                         safeAddEdge(e.getSrc(), e.getDst(), e);
                                         e.setLogicDelay(logicDelay);
                                         setEdgeWeight(e, e.getDelay());
@@ -1436,7 +1435,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                                     for (int i = 0; i < 8; i++) {
                                         TimingVertex v1 = newTimingVertex(s1);
                                         TimingVertex v2 = newTimingVertex(s2 + i);
-                                        TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                                        TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                                         safeAddEdge(e.getSrc(), e.getDst(), e);
                                         e.setLogicDelay(logicDelay);
                                         setEdgeWeight(e, e.getDelay());
@@ -1446,7 +1445,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                                     }
                                     TimingVertex v1 = newTimingVertex(s1);
                                     TimingVertex v2 = newTimingVertex(cellName + "/" + "OUT1");
-                                    TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                                    TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                                     safeAddEdge(e.getSrc(), e.getDst(), e);
                                     e.setLogicDelay(logicDelay);
                                     setEdgeWeight(e, e.getDelay());
@@ -1457,7 +1456,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                             } else {
                                 TimingVertex v1 = newTimingVertex(s1);
                                 TimingVertex v2 = newTimingVertex(s2);
-                                TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                                TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                                 safeAddEdge(e.getSrc(), e.getDst(), e);
                                 e.setLogicDelay(logicDelay);
                                 setEdgeWeight(e, e.getDelay());
@@ -1504,7 +1503,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
                 String s2 = cellName + "/" + "O";
                 TimingVertex v1 = newTimingVertex(s1);
                 TimingVertex v2 = newTimingVertex(s2);
-                TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                 safeAddEdge(e.getSrc(), e.getDst(), e);
                 e.setLogicDelay(0);
                 setEdgeWeight(e, e.getDelay());
@@ -1518,7 +1517,7 @@ public class TimingGraph extends DefaultDirectedWeightedGraph<TimingVertex, Timi
             for (Pair<String, String> inOut : dspTimingData.getInputOutputDelays().keySet()) {
                 TimingVertex v1 = newTimingVertex(dspTimingData.getBlockName() + "/" + inOut.getFirst());
                 TimingVertex v2 = newTimingVertex(dspTimingData.getBlockName() + "/" + inOut.getSecond());
-                TimingEdge e = new TimingEdge(this, v1, v2, null, new Net());
+                TimingEdge e = new TimingEdge(this, v1, v2, null, null);
                
                 safeAddEdge(e.getSrc(), e.getDst(), e);
                 e.setLogicDelay(dspTimingData.getInputOutputDelays().get(inOut));

--- a/src/com/xilinx/rapidwright/timing/TimingManager.java
+++ b/src/com/xilinx/rapidwright/timing/TimingManager.java
@@ -199,20 +199,7 @@ public class TimingManager {
         
         printPathDelayBreakDown(arr, criticalEdges, timingGraph.getTimingEdgeConnectionMap(), useRoutable, routingGraph);
     }
-    
-    /**
-     * Gets and prints the given path from the TimingGraph
-     */
-    public void getSamplePathDelayInfo(List<String> verticesOfVivadoPath, Map<TimingEdge, Connection> timingEdgeConnctionMap, boolean routableBased, RouteNodeGraph routingGraph) {
-        List<TimingEdge> edges = timingGraph.getTimingEdgeOfPath(verticesOfVivadoPath);
-        short totalDelay = 0;
-        for (TimingEdge edge : edges) {
-            totalDelay += edge.getDelay();
-        }
-        System.out.println("Total delay: " + totalDelay);
-        printPathDelayBreakDown(totalDelay, edges, timingEdgeConnctionMap, routableBased, routingGraph);
-    }
-    
+
     private void printPathDelayBreakDown(short arr, List<TimingEdge> criticalEdges, Map<TimingEdge, Connection> timingEdgeConnctionMap, boolean useRoutable, RouteNodeGraph routingGraph) {
         if (verbose) {
             System.out.println("\nTimingEdges:");

--- a/src/com/xilinx/rapidwright/timing/TimingManager.java
+++ b/src/com/xilinx/rapidwright/timing/TimingManager.java
@@ -28,8 +28,12 @@ import java.util.Map;
 import com.xilinx.rapidwright.design.ConstraintGroup;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.SiteInst;
+import com.xilinx.rapidwright.design.SitePinInst;
+import com.xilinx.rapidwright.device.BELPin;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Node;
+import com.xilinx.rapidwright.edif.EDIFHierPortInst;
 import com.xilinx.rapidwright.rwroute.Connection;
 import com.xilinx.rapidwright.rwroute.NetWrapper;
 import com.xilinx.rapidwright.rwroute.RWRouteConfig;
@@ -206,13 +210,25 @@ public class TimingManager {
             }
         }
         printTimingPathInTable(criticalEdges, arr);
-        if (!verbose) return;
+        if (!verbose) {
+            return;
+        }
+
+        System.out.println();
         for (TimingEdge edge : criticalEdges) {
             Connection connection = timingEdgeConnctionMap.get(edge);
             if (connection != null) {
                 System.out.println(connection);
+                // Walk the path in source-to-sink order: the hop taken inside the source site,
+                // then the inter-site routing, then the hop taken inside the sink site.
+                // The intra-site hops are not held onto by the timing graph, so recover them here
+                // rather than describe every edge of it just to print this one path.
+                printIntraSiteDelayTerm(timingModel.getSourceIntraSiteDelayTerm(connection.getSource()));
                 // Nodes are ordered sink-first, so the driver of nodes[i] is nodes[i + 1]
                 List<Node> nodes = connection.getNodes();
+                if (nodes.isEmpty()) {
+                    System.out.println("\t(no intersite routing)");
+                }
                 for (int iGroup = nodes.size() -1; iGroup >= 0; iGroup--) {
                     Node node = nodes.get(iGroup);
                     short delay = RouterHelper.computeNodeDelay(estimator, node);
@@ -221,13 +237,99 @@ public class TimingManager {
                         // accumulated route delay of the connection does
                         delay += DelayEstimatorBase.getExtraDelay(node, DelayEstimatorBase.isLong(nodes.get(iGroup + 1)));
                     }
-                    System.out.println("\t " + node + ", " + node.getIntentCode() + ", delay = " + delay);
+                    System.out.printf("\tdelay = %4d, %-18s, %s\n", delay, node.getIntentCode(), node);
+                }
+                printIntraSiteDelayTerm(timingModel.getSinkIntraSiteDelayTerm(connection.getSink()));
+                System.out.println();
+            } else if (edge.getNet() != null) {
+                // No Connection means RWRoute never routed this edge: it is either a direct
+                // connection (e.g. COUT -> CIN) or a net that never leaves its site. Either way
+                // only intra-site hops contribute, so there is nothing to show unless one does.
+                short intraSiteDelay = (short) edge.getIntraSiteDelay();
+                // A direct connection crosses a site pin at each end, so describe those hops
+                Pair<String,Short> sourceTerm = (edge.getFirstPin() != null) ?
+                        timingModel.getSourceIntraSiteDelayTerm(edge.getFirstPin()) : null;
+                Pair<String,Short> sinkTerm = (edge.getSecondPin() != null) ?
+                        timingModel.getSinkIntraSiteDelayTerm(edge.getSecondPin()) : null;
+                System.out.printf("net = %s, %s\n", edge.getNet(), edge);
+                int recovered = (sourceTerm != null ? sourceTerm.getSecond() : 0)
+                              + (sinkTerm != null ? sinkTerm.getSecond() : 0);
+                if (recovered == intraSiteDelay) {
+                    printIntraSiteDelayTerm(sourceTerm);
+                    printIntraSiteDelayTerm(sinkTerm);
+                } else {
+                    // Otherwise the site pins do not describe the delay, which is then the single
+                    // hop between the two cells the edge joins inside their site
+                    printIntraSiteDelayTerm(getIntraSiteDelayTerm(edge, intraSiteDelay));
                 }
                 System.out.println();
             }
         }
     }
     
+    /**
+     * Prints one intra-site hop of the critical path, in the same format used for its nodes.
+     * @param term The hop and its delay, as returned by
+     *             {@link TimingModel#getSourceIntraSiteDelayTerm(SitePinInst)};
+     *             nothing is printed when null.
+     */
+    private static void printIntraSiteDelayTerm(Pair<String,Short> term) {
+        if (term == null) {
+            return;
+        }
+        System.out.printf("\tdelay = %4d, %-18s, %s\n", term.getSecond(), "(intrasite)", term.getFirst());
+    }
+
+    /**
+     * Recovers the hop that the intra-site delay of an edge accounts for from the two cells the
+     * edge joins, for the edges whose site pins do not describe it: those of a net that never
+     * leaves its site, or that has no sink site pin to be described by.
+     * @param edge Edge to describe.
+     * @param intraSiteDelay Intra-site delay of that edge, in picoseconds.
+     * @return The BEL pins the hop is between paired with that delay, falling back to a
+     *         placeholder description when they cannot be recovered.
+     */
+    private Pair<String,Short> getIntraSiteDelayTerm(TimingEdge edge, short intraSiteDelay) {
+        Pair<SiteInst,BELPin> source = getBELPinOfVertex(edge.getSrc());
+        Pair<SiteInst,BELPin> sink = getBELPinOfVertex(edge.getDst());
+        if (source != null && sink != null && source.getFirst() == sink.getFirst()) {
+            String fromBelPin = describeBELPin(source.getSecond());
+            String toBelPin = describeBELPin(sink.getSecond());
+            // Only describe the hop once it is confirmed to be the one charged for
+            Short delay = timingModel.lookupIntraSiteDelay(
+                    source.getFirst().getSiteTypeEnum(), fromBelPin, toBelPin);
+            if (delay != null && delay == intraSiteDelay) {
+                return new Pair<>(fromBelPin + " -> " + toBelPin, intraSiteDelay);
+            }
+        }
+        return new Pair<>("(BEL pins not recoverable)", intraSiteDelay);
+    }
+
+    /**
+     * Finds where the cell pin that a vertex of the timing graph stands for has been placed.
+     * @param vertex Vertex to look up.
+     * @return The site instance and BEL pin it is placed onto, or null if the netlist does not
+     *         name such a cell pin, or it is not placed onto a BEL pin.
+     */
+    private Pair<SiteInst,BELPin> getBELPinOfVertex(TimingVertex vertex) {
+        // Vertices are named after the cell pin they stand for, so let the netlist resolve it
+        EDIFHierPortInst portInst = design.getNetlist().getHierPortInstFromName(vertex.getName());
+        if (portInst == null) {
+            return null;
+        }
+        Pair<SiteInst,BELPin> belPin = portInst.getRoutedBELPin(design);
+        return (belPin == null || belPin.getSecond() == null) ? null : belPin;
+    }
+
+    /**
+     * Names a BEL pin the way the intra-site delay model does.
+     * @param belPin BEL pin to name.
+     * @return That BEL pin named "&lt;BEL&gt;/&lt;pin&gt;".
+     */
+    private static String describeBELPin(BELPin belPin) {
+        return belPin.getBELName() + "/" + belPin.getName();
+    }
+
     private void printTimingPathInTable(List<TimingEdge> path, short arr) {
         System.out.println("\nDetail delays:");
         System.out.println("------------------------------------------------------------------------------");

--- a/src/com/xilinx/rapidwright/timing/TimingManager.java
+++ b/src/com/xilinx/rapidwright/timing/TimingManager.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import com.xilinx.rapidwright.design.ConstraintGroup;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.NetTools;
 import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
 import com.xilinx.rapidwright.device.BELPin;
@@ -234,7 +235,14 @@ public class TimingManager {
                 // Nodes are ordered sink-first, so the driver of nodes[i] is nodes[i + 1]
                 List<Node> nodes = connection.getNodes();
                 if (nodes.isEmpty()) {
-                    System.out.println("\t(no intersite routing)");
+                    if (connection.getNet().hasPIPs()) {
+                        // A connection only carries its nodes when a router assigned them to it; walk
+                        // the PIPs of its net to recover them otherwise. Only the connections of this
+                        // one path are worth paying that for, hence not doing so for every connection.
+                        nodes = NetTools.getNodesToSink(connection.getSink());
+                    } else {
+                        System.out.println("\t(no intersite routing)");
+                    }
                 }
                 for (int iGroup = nodes.size() -1; iGroup >= 0; iGroup--) {
                     Node node = nodes.get(iGroup);
@@ -249,10 +257,10 @@ public class TimingManager {
                 printIntraSiteDelayTerm(timingModel.getSinkIntraSiteDelayTerm(connection.getSink()));
                 System.out.println();
             } else if (edge.getNet() != null) {
-                // No Connection means RWRoute never routed this edge: it is either a direct
-                // connection (e.g. COUT -> CIN) or a net that never leaves its site. Either way
-                // only intra-site hops contribute, so there is nothing to show unless one does.
+                // No Connection means RWRoute never routed this edge: it must be an intra-site
+                // connection (e.g. ALUT6/O -> CARRY8/S[0]).
                 short intraSiteDelay = (short) edge.getIntraSiteDelay();
+                assert(edge.getNetDelay() == intraSiteDelay);
                 // A direct connection crosses a site pin at each end, so describe those hops
                 Pair<String,Short> sourceTerm = (edge.getFirstPin() != null) ?
                         timingModel.getSourceIntraSiteDelayTerm(edge.getFirstPin()) : null;

--- a/src/com/xilinx/rapidwright/timing/TimingManager.java
+++ b/src/com/xilinx/rapidwright/timing/TimingManager.java
@@ -24,7 +24,6 @@ package com.xilinx.rapidwright.timing;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import com.xilinx.rapidwright.design.ConstraintGroup;
 import com.xilinx.rapidwright.design.Design;
@@ -35,8 +34,9 @@ import com.xilinx.rapidwright.rwroute.Connection;
 import com.xilinx.rapidwright.rwroute.NetWrapper;
 import com.xilinx.rapidwright.rwroute.RWRouteConfig;
 import com.xilinx.rapidwright.rwroute.RouteNode;
-import com.xilinx.rapidwright.rwroute.RouteNodeGraph;
+import com.xilinx.rapidwright.rwroute.RouterHelper;
 import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
+import com.xilinx.rapidwright.timing.delayestimator.InterconnectInfo;
 import com.xilinx.rapidwright.util.MessageGenerator;
 import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.RuntimeTrackerTree;
@@ -60,6 +60,8 @@ public class TimingManager {
     private float timingRequirement;
     private float pessimismA = (float) 1.03;
     private float pessimismB = 100;
+
+    private DelayEstimatorBase<InterconnectInfo> estimator;
     
     /**
      * Default constructor: creates the TimingManager object, which the user needs to create for 
@@ -67,17 +69,6 @@ public class TimingManager {
      * @param design RapidWright Design object.
      */
     public TimingManager(Design design) {
-        this(design, true);
-    }
-
-    /**
-     * Alternate constructor for creating the objects for the TimingModel, but with the choice to 
-     * not build the model yet.
-     * @param design RapidWright Design object.
-     * @param doBuild Whether to go ahead and build the model now.  For example, a user might not 
-     * want to build the TimingGraph yet.
-     */
-    public TimingManager(Design design, boolean doBuild) {
         this.design = design;
         timingModel = new TimingModel(design.getDevice());
         timingGraph = new TimingGraph(design);
@@ -85,11 +76,16 @@ public class TimingManager {
         timingGraph.setTimingManager(this);
         timingGraph.setTimingModel(timingModel);
         device = design.getDevice();
-        if (doBuild)
-            build(false, design.getNets());
+        build(false, design.getNets());
     }
     
-    public TimingManager(Design design, RuntimeTrackerTree timer, RWRouteConfig config, ClkRouteTiming clkTiming, Collection<Net> targetNets, boolean isPartialRouting) {
+    public TimingManager(Design design,
+                         RuntimeTrackerTree timer,
+                         RWRouteConfig config,
+                         ClkRouteTiming clkTiming,
+                         Collection<Net> targetNets,
+                         boolean isPartialRouting,
+                         DelayEstimatorBase<InterconnectInfo> estimator) {
         this.design = design;
         setTimingRequirement();
         verbose = config.isVerbose();
@@ -101,6 +97,7 @@ public class TimingManager {
         timingGraph.setTimingManager(this);
         timingGraph.setTimingModel(timingModel);
         device = design.getDevice();
+        this.estimator = estimator;
         build(isPartialRouting, targetNets);
     }
     
@@ -180,7 +177,7 @@ public class TimingManager {
         }
     }
     
-    public void getCriticalPathInfo(Pair<Float, TimingVertex> maxDelayTimingVertex, boolean useRoutable, RouteNodeGraph routingGraph) {
+    public void getCriticalPathInfo(Pair<Float, TimingVertex> maxDelayTimingVertex) {
         TimingVertex maxV = maxDelayTimingVertex.getSecond();
         float maxDelay = maxDelayTimingVertex.getFirst();
         System.out.printf(MessageGenerator.formatString("Timing requirement (ps):", timingRequirement));
@@ -197,10 +194,10 @@ public class TimingManager {
         System.out.printf(MessageGenerator.formatString("Critical path delay (ps):", adjusted));
         System.out.printf(MessageGenerator.formatString("Slack (ps):", (int)(timingRequirement - adjusted)));
         
-        printPathDelayBreakDown(arr, criticalEdges, timingGraph.getTimingEdgeConnectionMap(), useRoutable, routingGraph);
+        printPathDelayBreakDown(arr, criticalEdges, timingGraph.getTimingEdgeConnectionMap());
     }
 
-    private void printPathDelayBreakDown(short arr, List<TimingEdge> criticalEdges, Map<TimingEdge, Connection> timingEdgeConnctionMap, boolean useRoutable, RouteNodeGraph routingGraph) {
+    private void printPathDelayBreakDown(short arr, List<TimingEdge> criticalEdges, Map<TimingEdge, Connection> timingEdgeConnctionMap) {
         if (verbose) {
             System.out.println("\nTimingEdges:");
             int id = 0;
@@ -209,29 +206,19 @@ public class TimingManager {
             }
         }
         printTimingPathInTable(criticalEdges, arr);
-        if (routingGraph == null) return;
         if (!verbose) return;
         for (TimingEdge edge : criticalEdges) {
-            if (timingEdgeConnctionMap.containsKey(edge)) {
-                System.out.println(timingEdgeConnctionMap.get(edge));
-                if (useRoutable) {
-                    List<RouteNode> groups = timingEdgeConnctionMap.get(edge).getRnodes();
-                    for (int iGroup = groups.size() -1; iGroup >= 0; iGroup--) {
-                        System.out.println("\t " + groups.get(iGroup));
-                    }
-                } else {
-                    List<Node> nodes = timingEdgeConnctionMap.get(edge).getNodes();
-                    for (int iGroup = nodes.size() -1; iGroup >= 0; iGroup--) {
-                        RouteNode rnode = routingGraph.getNode(nodes.get(iGroup));
-                        if (rnode != null) {
-                            System.out.println("\t " + rnode.getNode() + ", " + rnode.getIntentCode() + ", delay = " + (short) rnode.getDelay());
-                        } else {
-                            System.out.println("\t " + nodes.get(iGroup) + ", " + nodes.get(iGroup).getIntentCode() + ", delay = " + 0);
-                        }
-                    }
+            Connection connection = timingEdgeConnctionMap.get(edge);
+            if (connection != null) {
+                System.out.println(connection);
+                List<Node> nodes = connection.getNodes();
+                for (int iGroup = nodes.size() -1; iGroup >= 0; iGroup--) {
+                    Node node = nodes.get(iGroup);
+                    short delay = RouterHelper.computeNodeDelay(estimator, node);
+                    System.out.println("\t " + node + ", " + node.getIntentCode() + ", delay = " + delay);
                 }
+                System.out.println();
             }
-            System.out.println();
         }
     }
     

--- a/src/com/xilinx/rapidwright/timing/TimingManager.java
+++ b/src/com/xilinx/rapidwright/timing/TimingManager.java
@@ -211,10 +211,16 @@ public class TimingManager {
             Connection connection = timingEdgeConnctionMap.get(edge);
             if (connection != null) {
                 System.out.println(connection);
+                // Nodes are ordered sink-first, so the driver of nodes[i] is nodes[i + 1]
                 List<Node> nodes = connection.getNodes();
                 for (int iGroup = nodes.size() -1; iGroup >= 0; iGroup--) {
                     Node node = nodes.get(iGroup);
                     short delay = RouterHelper.computeNodeDelay(estimator, node);
+                    if (iGroup + 1 < nodes.size()) {
+                        // Account for the extra delay this node incurs from its driver, as the
+                        // accumulated route delay of the connection does
+                        delay += DelayEstimatorBase.getExtraDelay(node, DelayEstimatorBase.isLong(nodes.get(iGroup + 1)));
+                    }
                     System.out.println("\t " + node + ", " + node.getIntentCode() + ", delay = " + delay);
                 }
                 System.out.println();

--- a/src/com/xilinx/rapidwright/timing/TimingManager.java
+++ b/src/com/xilinx/rapidwright/timing/TimingManager.java
@@ -65,8 +65,12 @@ public class TimingManager {
     private float pessimismA = (float) 1.03;
     private float pessimismB = 100;
 
-    private DelayEstimatorBase<InterconnectInfo> estimator;
-    
+    /** Used to break the delay of the critical path down per node; null when no breakdown is wanted */
+    private final DelayEstimatorBase<InterconnectInfo> estimator;
+
+    /** Format of one line of that breakdown: its delay, what kind of hop it is, and the hop itself */
+    private static final String DELAY_LINE_FORMAT = "\tdelay = %4d, %-18s, %s\n";
+
     /**
      * Default constructor: creates the TimingManager object, which the user needs to create for 
      * using our TimingModel, and then it builds the model.
@@ -80,6 +84,8 @@ public class TimingManager {
         timingGraph.setTimingManager(this);
         timingGraph.setTimingModel(timingModel);
         device = design.getDevice();
+        // No critical path breakdown is printed through this constructor, since it leaves verbose off
+        estimator = null;
         build(false, design.getNets());
     }
     
@@ -198,10 +204,10 @@ public class TimingManager {
         System.out.printf(MessageGenerator.formatString("Critical path delay (ps):", adjusted));
         System.out.printf(MessageGenerator.formatString("Slack (ps):", (int)(timingRequirement - adjusted)));
         
-        printPathDelayBreakDown(arr, criticalEdges, timingGraph.getTimingEdgeConnectionMap());
+        printPathDelayBreakDown(arr, criticalEdges);
     }
 
-    private void printPathDelayBreakDown(short arr, List<TimingEdge> criticalEdges, Map<TimingEdge, Connection> timingEdgeConnctionMap) {
+    private void printPathDelayBreakDown(short arr, List<TimingEdge> criticalEdges) {
         if (verbose) {
             System.out.println("\nTimingEdges:");
             int id = 0;
@@ -215,8 +221,9 @@ public class TimingManager {
         }
 
         System.out.println();
+        Map<TimingEdge, Connection> timingEdgeConnectionMap = timingGraph.getTimingEdgeConnectionMap();
         for (TimingEdge edge : criticalEdges) {
-            Connection connection = timingEdgeConnctionMap.get(edge);
+            Connection connection = timingEdgeConnectionMap.get(edge);
             if (connection != null) {
                 System.out.println(connection);
                 // Walk the path in source-to-sink order: the hop taken inside the source site,
@@ -237,7 +244,7 @@ public class TimingManager {
                         // accumulated route delay of the connection does
                         delay += DelayEstimatorBase.getExtraDelay(node, DelayEstimatorBase.isLong(nodes.get(iGroup + 1)));
                     }
-                    System.out.printf("\tdelay = %4d, %-18s, %s\n", delay, node.getIntentCode(), node);
+                    System.out.printf(DELAY_LINE_FORMAT, delay, node.getIntentCode(), node);
                 }
                 printIntraSiteDelayTerm(timingModel.getSinkIntraSiteDelayTerm(connection.getSink()));
                 System.out.println();
@@ -277,7 +284,7 @@ public class TimingManager {
         if (term == null) {
             return;
         }
-        System.out.printf("\tdelay = %4d, %-18s, %s\n", term.getSecond(), "(intrasite)", term.getFirst());
+        System.out.printf(DELAY_LINE_FORMAT, term.getSecond(), "(intrasite)", term.getFirst());
     }
 
     /**

--- a/src/com/xilinx/rapidwright/timing/TimingModel.java
+++ b/src/com/xilinx/rapidwright/timing/TimingModel.java
@@ -349,11 +349,20 @@ public class TimingModel {
         if (nodeList.size() > 0)
             groups = determineGroups(nodeList, nodeIntents, relevantPIPs);
 
+        // Set the member variables used by "calcIntrasiteDelays()" here too, since the
+        // groups-less path below calls it without going through the List<TimingGroup> overload
+        // (which would otherwise be responsible for setting them)
+        intrasiteDelay = 0;
+        this.startPinInst = startPinInst;
+        this.endPinInst = endPinInst;
+        this.sourceBELPin = sourceBELPin;
+        this.sinkBELPin = sinkBELPin;
+
         float result = 0f;
         if (groups != null) {
             result = calcDelay(startPinInst, endPinInst, sourceBELPin, sinkBELPin, groups);
         } else {
-            accumulateIntrasiteDelays();
+            calcIntrasiteDelays();
         }
 
         return result;
@@ -1135,7 +1144,7 @@ public class TimingModel {
             }
         }
 
-        // set these member variables for use in method: "accumulateIntrasiteDelays()" down below
+        // set these member variables for use in method: "calcIntrasiteDelays()" down below
         intrasiteDelay = 0;
         this.startPinInst = startPinInst;
         this.endPinInst = endPinInst;
@@ -1258,7 +1267,7 @@ public class TimingModel {
 
         netDelayCalc += checkForSitePinDelay(groups);
         
-        accumulateIntrasiteDelays();
+        calcIntrasiteDelays();
 
         for (int i =1 ; i < groups.size(); i++) {
             TimingGroup gprev = groups.get(i-1);
@@ -1539,18 +1548,20 @@ public class TimingModel {
     }
     
     /**
-     * Accumulates onto {@link #intrasiteDelay} the delay of the two intra-site hops that bookend
+     * Computes into {@link #intrasiteDelay} the delay of the two intra-site hops that bookend
      * the inter-site routing of a connection: from the driving BEL pin out to the source site pin,
      * and from the sink site pin in to the driven BEL pin. Either hop contributes zero when it does
      * not exist (for example, a source pin that is neither a MUX nor an "_O" output).
      * Operates on the {@link #startPinInst}, {@link #endPinInst}, {@link #sourceBELPin} and
-     * {@link #sinkBELPin} member variables, which
-     * {@link #calcDelay(SitePinInst, SitePinInst, BELPin, BELPin, List)} sets (along with resetting
+     * {@link #sinkBELPin} member variables, which both
+     * {@link #calcDelay(SitePinInst, SitePinInst, BELPin, BELPin, List)} and
+     * {@link #calcDelay(SitePinInst, SitePinInst, BELPin, BELPin, Net)} set (along with resetting
      * {@link #intrasiteDelay}) before calling this.
      */
-    private void accumulateIntrasiteDelays() {
-        intrasiteDelay += getSinkIntrasiteDelay(endPinInst, null);
-        intrasiteDelay += getSourceIntrasiteDelay(startPinInst, sourceBELPin, sinkBELPin, null);
+    private void calcIntrasiteDelays() {
+        assert(intrasiteDelay == 0);
+        intrasiteDelay = getSinkIntrasiteDelay(endPinInst, null) +
+                getSourceIntrasiteDelay(startPinInst, sourceBELPin, sinkBELPin, null);
     }
 
     /**

--- a/src/com/xilinx/rapidwright/timing/TimingModel.java
+++ b/src/com/xilinx/rapidwright/timing/TimingModel.java
@@ -353,7 +353,7 @@ public class TimingModel {
         if (groups != null) {
             result = calcDelay(startPinInst, endPinInst, sourceBELPin, sinkBELPin, groups);
         } else {
-            checkForIntrasiteDelay();
+            accumulateIntrasiteDelays();
         }
 
         return result;
@@ -1135,7 +1135,7 @@ public class TimingModel {
             }
         }
 
-        // set these member variables for use in method: "checkForSomeIntrasiteDelays()" down below
+        // set these member variables for use in method: "accumulateIntrasiteDelays()" down below
         intrasiteDelay = 0;
         this.startPinInst = startPinInst;
         this.endPinInst = endPinInst;
@@ -1258,7 +1258,7 @@ public class TimingModel {
 
         netDelayCalc += checkForSitePinDelay(groups);
         
-        checkForIntrasiteDelay();  // implementation refactored into a helper method below
+        accumulateIntrasiteDelays();
 
         for (int i =1 ; i < groups.size(); i++) {
             TimingGroup gprev = groups.get(i-1);
@@ -1538,7 +1538,17 @@ public class TimingModel {
         }
     }
     
-    private void checkForIntrasiteDelay() {
+    /**
+     * Accumulates onto {@link #intrasiteDelay} the delay of the two intra-site hops that bookend
+     * the inter-site routing of a connection: from the driving BEL pin out to the source site pin,
+     * and from the sink site pin in to the driven BEL pin. Either hop contributes zero when it does
+     * not exist (for example, a source pin that is neither a MUX nor an "_O" output).
+     * Operates on the {@link #startPinInst}, {@link #endPinInst}, {@link #sourceBELPin} and
+     * {@link #sinkBELPin} member variables, which
+     * {@link #calcDelay(SitePinInst, SitePinInst, BELPin, BELPin, List)} sets (along with resetting
+     * {@link #intrasiteDelay}) before calling this.
+     */
+    private void accumulateIntrasiteDelays() {
         intrasiteDelay += getSinkIntrasiteDelay(endPinInst, null);
         intrasiteDelay += getSourceIntrasiteDelay(startPinInst, sourceBELPin, sinkBELPin, null);
     }
@@ -1568,19 +1578,17 @@ public class TimingModel {
             if (endPinInst != null) {
                 String sourcepin = endPinInst.getName();
 
-                if (!sourcepin.startsWith("CKEN") &&
-                        !sourcepin.startsWith("CLK1") &&
-                        !sourcepin.startsWith("CLK2") &&
-                        !sourcepin.startsWith("SRST")) {
-
+                if (sourcepin.startsWith("CKEN")) {
+                    describeIntrasiteDelay(description, sourcepin, sinkType + "/" + "CKEN");
+                    return (short) INTRASITE_DELAY_SITEPIN_TO_FF_INPUT;
+                } else if (!sourcepin.startsWith("CLK") &&
+                           !sourcepin.startsWith("SRST")) {
                     short tmpIntrasiteDelay = intrasiteAndLogicDelayModel.getIntraSiteDelay(SiteTypeEnum.SLICEL,
                                             sourcepin, sinkType + "/" + "D");
                     describeIntrasiteDelay(description, sourcepin, sinkType + "/" + "D");
                     return tmpIntrasiteDelay;
-                } else if (sourcepin.startsWith("CKEN")) {
-                    describeIntrasiteDelay(description, sourcepin, sinkType + "/" + "CKEN");
-                    return (short) INTRASITE_DELAY_SITEPIN_TO_FF_INPUT;
                 }
+                // Clock and reset site pins carry no site-pin-to-FF-input term
             }
         } else if (endPinInst != null && endPinInst.getName().startsWith("CIN")) {
             describeIntrasiteDelay(description, endPinInst.getName(), sinkType + "/" + "CIN");

--- a/src/com/xilinx/rapidwright/timing/TimingModel.java
+++ b/src/com/xilinx/rapidwright/timing/TimingModel.java
@@ -38,6 +38,7 @@ import com.xilinx.rapidwright.device.TileTypeEnum;
 import com.xilinx.rapidwright.device.Wire;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.util.FileTools;
+import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.Utils;
 import org.python.google.common.collect.SetMultimap;
 import org.python.google.common.collect.TreeMultimap;
@@ -1538,7 +1539,20 @@ public class TimingModel {
     }
     
     private void checkForIntrasiteDelay() {
-        String sourceType = "";
+        intrasiteDelay += getSinkIntrasiteDelay(endPinInst, null);
+        intrasiteDelay += getSourceIntrasiteDelay(startPinInst, sourceBELPin, sinkBELPin, null);
+    }
+
+    /**
+     * Gets the delay of the hop taken inside the sink site, from the sink site pin onto the BEL pin
+     * of the cell it drives.
+     * @param endPinInst Sink pin as a SitePinInst for the physical Net.
+     * @param description If non-null, appended with the BEL pins the delay was looked up for.
+     *                    Left untouched when there is no such hop. Only pass one when the
+     *                    description is actually going to be used, as building it is not free.
+     * @return The delay in picoseconds, zero if there is no such hop.
+     */
+    private short getSinkIntrasiteDelay(SitePinInst endPinInst, StringBuilder description) {
         String sinkType = "";
         if (endPinInst != null) {
             Set<Cell> cells = DesignTools.getConnectedCells(endPinInst);
@@ -1549,12 +1563,54 @@ public class TimingModel {
                 }
             }
         }
+
+        if (ultraScaleFlopNames.contains(sinkType)) {
+            if (endPinInst != null) {
+                String sourcepin = endPinInst.getName();
+
+                if (!sourcepin.startsWith("CKEN") &&
+                        !sourcepin.startsWith("CLK1") &&
+                        !sourcepin.startsWith("CLK2") &&
+                        !sourcepin.startsWith("SRST")) {
+
+                    short tmpIntrasiteDelay = intrasiteAndLogicDelayModel.getIntraSiteDelay(SiteTypeEnum.SLICEL,
+                                            sourcepin, sinkType + "/" + "D");
+                    describeIntrasiteDelay(description, sourcepin, sinkType + "/" + "D");
+                    return tmpIntrasiteDelay;
+                } else if (sourcepin.startsWith("CKEN")) {
+                    describeIntrasiteDelay(description, sourcepin, sinkType + "/" + "CKEN");
+                    return (short) INTRASITE_DELAY_SITEPIN_TO_FF_INPUT;
+                }
+            }
+        } else if (endPinInst != null && endPinInst.getName().startsWith("CIN")) {
+            describeIntrasiteDelay(description, endPinInst.getName(), sinkType + "/" + "CIN");
+            return intrasiteAndLogicDelayModel.getIntraSiteDelay(SiteTypeEnum.SLICEL,
+                    endPinInst.getName(), sinkType + "/" + "CIN");
+        }
+        return 0;
+    }
+
+    /**
+     * Gets the delay of the hop taken inside the source site, from the BEL pin driving the source
+     * site pin onto that site pin.
+     * @param startPinInst Source pin as a SitePinInst for the physical Net.
+     * @param sourceBELPin BEL pin driving startPinInst, or null to recover it from the cell
+     *                     connected to startPinInst.
+     * @param sinkBELPin BEL pin driven by the sink pin of the physical Net, or null.
+     * @param description If non-null, appended with the BEL pins the delay was looked up for.
+     *                    Left untouched when there is no such hop. Only pass one when the
+     *                    description is actually going to be used, as building it is not free.
+     * @return The delay in picoseconds, zero if there is no such hop.
+     */
+    private short getSourceIntrasiteDelay(SitePinInst startPinInst,
+                                          BELPin sourceBELPin, BELPin sinkBELPin,
+                                          StringBuilder description) {
+        String sourceType = "";
         BELPin tmpPin = null;
-        SitePinInst pin = endPinInst;
         Integer startPinSiteWireIdx = null;
 
         if (startPinInst != null) {
-            Site site = pin.getSiteInst().getSite();
+            Site site = startPinInst.getSiteInst().getSite();
             startPinSiteWireIdx = site.getSiteWireIndex(startPinInst.getName());
         }
         
@@ -1593,34 +1649,13 @@ public class TimingModel {
             }
         }
 
-        if (ultraScaleFlopNames.contains(sinkType)) {
-            if (endPinInst != null) {
-                String sourcepin = endPinInst.getName();
-
-                if (!sourcepin.startsWith("CKEN") &&
-                        !sourcepin.startsWith("CLK1") &&
-                        !sourcepin.startsWith("CLK2") &&
-                        !sourcepin.startsWith("SRST")) {
-
-                    short tmpIntrasiteDelay = intrasiteAndLogicDelayModel.getIntraSiteDelay(SiteTypeEnum.SLICEL,
-                                            sourcepin, sinkType + "/" + "D");
-                    intrasiteDelay += tmpIntrasiteDelay;
-                } else if (sourcepin.startsWith("CKEN")) {
-                    intrasiteDelay += INTRASITE_DELAY_SITEPIN_TO_FF_INPUT;
-                }
-            }
-        } else if (endPinInst != null && endPinInst.getName().startsWith("CIN")) {
-            intrasiteDelay += intrasiteAndLogicDelayModel.getIntraSiteDelay(SiteTypeEnum.SLICEL, 
-                    endPinInst.getName(), sinkType + "/" + "CIN");
-        }
-
         /**
          * Checking for additional intrasite delays
          */
         
         if ((startPinInst == null || sourceType == null) || 
                 (tmpPin == null && sourceBELPin == null)) {
-                return;
+                return 0;
         }
         
         //TODO cleaning up: remove if-else, call the intrasiteAndLogicDelayModel.getIntraSiteDelay() instead
@@ -1631,13 +1666,67 @@ public class TimingModel {
             else {
                 fromPinName += sourceBELPin.getName();
             }
-            short tmpIntrasiteDelay = intrasiteAndLogicDelayModel.getIntraSiteDelay(
+            describeIntrasiteDelay(description, fromPinName, startPinInst.getName());
+            return intrasiteAndLogicDelayModel.getIntraSiteDelay(
                     SiteTypeEnum.SLICEL, fromPinName, startPinInst.getName());
-            intrasiteDelay += tmpIntrasiteDelay;
-           
         } else if (startPinInst.getName().endsWith("_O")) {
-            intrasiteDelay += INTRASITE_DELAY_LUT_OUTPUT_TO_O_SITEPIN;   
+            describeIntrasiteDelay(description, sourceType + "/O", startPinInst.getName());
+            return (short) INTRASITE_DELAY_LUT_OUTPUT_TO_O_SITEPIN;
         }
+        return 0;
+    }
+
+    /**
+     * Describes one intra-site hop, for the verbose critical path breakdown.
+     * @param description Appended with the description; does nothing when null.
+     * @param fromPinName Name of the BEL pin or site pin the hop starts at.
+     * @param toPinName Name of the BEL pin or site pin the hop ends at.
+     */
+    private static void describeIntrasiteDelay(StringBuilder description,
+                                               String fromPinName, String toPinName) {
+        if (description == null) {
+            return;
+        }
+        description.append(fromPinName).append(" -> ").append(toPinName);
+    }
+
+    /**
+     * Recovers the hop inside the source site that the intra-site delay of a connection accounts
+     * for. Not cached, so only call this for the few connections whose breakdown is wanted.
+     * @param startPinInst Source pin as a SitePinInst for the physical Net.
+     * @return The BEL pins the delay was looked up for paired with that delay, or null if there is
+     *         no such hop.
+     */
+    public Pair<String,Short> getSourceIntraSiteDelayTerm(SitePinInst startPinInst) {
+        StringBuilder description = new StringBuilder();
+        short delay = getSourceIntrasiteDelay(startPinInst, null, null, description);
+        return description.length() == 0 ? null : new Pair<>(description.toString(), delay);
+    }
+
+    /**
+     * Recovers the hop inside the sink site that the intra-site delay of a connection accounts for.
+     * Not cached, so only call this for the few connections whose breakdown is wanted.
+     * @param endPinInst Sink pin as a SitePinInst for the physical Net.
+     * @return The BEL pins the delay was looked up for paired with that delay, or null if there is
+     *         no such hop.
+     */
+    public Pair<String,Short> getSinkIntraSiteDelayTerm(SitePinInst endPinInst) {
+        StringBuilder description = new StringBuilder();
+        short delay = getSinkIntrasiteDelay(endPinInst, description);
+        return description.length() == 0 ? null : new Pair<>(description.toString(), delay);
+    }
+
+    /**
+     * Looks up the delay of a hop between two BEL pins of the same site.
+     * @param siteType Type of the site both BEL pins belong to.
+     * @param fromBelPin BEL pin the hop starts at, named "&lt;BEL&gt;/&lt;pin&gt;".
+     * @param toBelPin BEL pin the hop ends at, named "&lt;BEL&gt;/&lt;pin&gt;".
+     * @return The delay in picoseconds, or null if the model holds no term for this hop.
+     */
+    public Short lookupIntraSiteDelay(SiteTypeEnum siteType, String fromBelPin, String toBelPin) {
+        Short delay = intrasiteAndLogicDelayModel.getIntraSiteDelay(siteType, fromBelPin, toBelPin);
+        // An unknown hop is reported as a negative delay rather than as absent
+        return (delay == null || delay < 0) ? null : delay;
     }
 
     /**

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -23,6 +23,8 @@
 
 package com.xilinx.rapidwright.rwroute;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -540,10 +542,25 @@ public class TestRWRoute {
     })
     public void testTimingAndWirelengthReport(String dcpShortPath, boolean verbose) {
         String dcp = RapidWrightDCP.getString(dcpShortPath);
+        String[] args = verbose ? new String[]{dcp, "--verbose"} : new String[]{dcp};
+
+        ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        try {
+            System.setOut(new PrintStream(capture, true));
+            TimingAndWirelengthReport.main(args);
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        String output = capture.toString();
+        System.out.print(output);
+        Assertions.assertTrue(output.contains("Critical path delay (ps):"));
         if (verbose) {
-            TimingAndWirelengthReport.main(new String[]{dcp, "--verbose"});
-        } else {
-            TimingAndWirelengthReport.main(new String[]{dcp});
+            // Every critical path ends on a flop input, so it must cross into that flop's site
+            Assertions.assertTrue(output.contains("(intrasite)"));
+            // Each intra-site hop must be attributable to a specific pair of BEL pins
+            Assertions.assertFalse(output.contains("(BEL pins not recoverable)"));
         }
     }
 

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -531,9 +531,13 @@ public class TestRWRoute {
         Assertions.assertTrue(Files.exists(outputFile));
     }
 
-    @Test
-    public void testTimingAndWirelengthReport() {
-        String dcp = RapidWrightDCP.getString("picoblaze_ooc_X10Y235.dcp");
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "picoblaze_ooc_X10Y235.dcp",
+            "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp",
+    })
+    public void testTimingAndWirelengthReport(String dcpShortPath) {
+        String dcp = RapidWrightDCP.getString(dcpShortPath);
         TimingAndWirelengthReport.main(new String[]{dcp});
     }
 

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -532,13 +532,19 @@ public class TestRWRoute {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "picoblaze_ooc_X10Y235.dcp",
-            "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp",
+    @CsvSource({
+            "picoblaze_ooc_X10Y235.dcp,false",
+            "picoblaze_ooc_X10Y235.dcp,true",
+            "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,false",
+            "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,true",
     })
-    public void testTimingAndWirelengthReport(String dcpShortPath) {
+    public void testTimingAndWirelengthReport(String dcpShortPath, boolean verbose) {
         String dcp = RapidWrightDCP.getString(dcpShortPath);
-        TimingAndWirelengthReport.main(new String[]{dcp});
+        if (verbose) {
+            TimingAndWirelengthReport.main(new String[]{dcp, "--verbose"});
+        } else {
+            TimingAndWirelengthReport.main(new String[]{dcp});
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Fixes so that `TimingAndWirelengthReport`:
- Prints out intra-site timing edges
- Fix `--verbose` for routed DCPs (as opposed to those just routed by RWRoute) by recovering the routing from the net's PIPs
- Fix so that placed-but-unrouted DCPs do not error out
- Plus other cleanups

Added:
- `NetTools.getNodeToDriver()`
- `NetTools.getNodesToSink()`