### PR TITLE
[PartialRouter] Preserve LUT routethru arcs when unpreserving nets

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -391,8 +391,9 @@ public class PartialRouter extends RWRoute {
 
                     // Do not include arcs that the router wouldn't explore
                     // e.g. those that leave the INT tile, since we project pins to their INT tile
-                    // Except for routethru PIPs.
-                    if (RouteNodeGraph.isExcludedTile(end) && !pip.isRouteThru()) {
+                    // Except for routethru PIPs where the start node is not in an excluded tile.
+                    if (RouteNodeGraph.isExcludedTile(end) &&
+                            (!pip.isRouteThru() || RouteNodeGraph.isExcludedTile(start))) {
                         continue;
                     }
 
@@ -630,9 +631,10 @@ public class PartialRouter extends RWRoute {
                 Node end = (pip.isReversed()) ? pip.getStartNode() : pip.getEndNode();
 
                 // Do not include arcs that the router wouldn't explore
-                // e.g. those that leave the INT tile, since we project pins to their INT tile.
-                // Except for routethru PIPs.
-                if (RouteNodeGraph.isExcludedTile(end) && !pip.isRouteThru()) {
+                // e.g. those that leave the INT tile, since we project pins to their INT tile
+                // Except for routethru PIPs where the start node is not in an excluded tile.
+                if (RouteNodeGraph.isExcludedTile(end) &&
+                        (!pip.isRouteThru() || RouteNodeGraph.isExcludedTile(start))) {
                     continue;
                 }
 

--- a/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
+++ b/src/com/xilinx/rapidwright/rwroute/PartialRouter.java
@@ -391,7 +391,8 @@ public class PartialRouter extends RWRoute {
 
                     // Do not include arcs that the router wouldn't explore
                     // e.g. those that leave the INT tile, since we project pins to their INT tile
-                    if (RouteNodeGraph.isExcludedTile(end)) {
+                    // Except for routethru PIPs.
+                    if (RouteNodeGraph.isExcludedTile(end) && !pip.isRouteThru()) {
                         continue;
                     }
 
@@ -407,6 +408,15 @@ public class PartialRouter extends RWRoute {
                     }
                     assert(rend.getPrev() == null);
                     rend.setPrev(rstart);
+
+                    // When lutRoutethru is disabled, RWRoute does not normally explore non-sink PINFEED nodes.
+                    // Here, these nodes exist because they were on a previously-preserved net: mark these as
+                    // INACCESSIBLE such that once this connection gets rerouted, this node can't be used again.
+                    if (!routingGraph.lutRoutethru && pip.isRouteThru()) {
+                        assert(rstart.getIntentCode() == IntentCode.NODE_PINFEED);
+                        assert(rstart.getType() == RouteNodeType.LOCAL_EAST || rstart.getType() == RouteNodeType.LOCAL_WEST);
+                        rstart.setType(RouteNodeType.INACCESSIBLE);
+                    }
                 }
 
                 // Use the prev pointers to attempt to recover routing for all indirect connections
@@ -576,9 +586,11 @@ public class PartialRouter extends RWRoute {
                 Node end = (pip.isReversed()) ? pip.getStartNode() : pip.getEndNode();
 
                 // Do not include arcs that the router wouldn't explore
-                // e.g. those that leave the INT tile, since we project pins to their INT tile
-                if (RouteNodeGraph.isExcludedTile(end))
+                // e.g. those that leave the INT tile, since we project pins to their INT tile.
+                // Except for routethru PIPs.
+                if (RouteNodeGraph.isExcludedTile(end) && !pip.isRouteThru()) {
                     continue;
+                }
 
                 // Skip PIPs that would otherwise get projected away
                 if (isExcludedPip(start, end)) {
@@ -618,9 +630,11 @@ public class PartialRouter extends RWRoute {
                 Node end = (pip.isReversed()) ? pip.getStartNode() : pip.getEndNode();
 
                 // Do not include arcs that the router wouldn't explore
-                // e.g. those that leave the INT tile, since we project pins to their INT tile
-                if (RouteNodeGraph.isExcludedTile(end))
+                // e.g. those that leave the INT tile, since we project pins to their INT tile.
+                // Except for routethru PIPs.
+                if (RouteNodeGraph.isExcludedTile(end) && !pip.isRouteThru()) {
                     continue;
+                }
 
                 if (pip.isPIPFixed()) {
                     // Do not unpreserve locked nodes
@@ -647,6 +661,15 @@ public class PartialRouter extends RWRoute {
                 // Also set the prev pointer according to the PIP
                 assert (rend.getPrev() == null);
                 rend.setPrev(rstart);
+
+                // When lutRoutethru is disabled, RWRoute does not normally explore non-sink PINFEED nodes.
+                // Here, these nodes exist because they were on a previously-preserved net: mark these as
+                // INACCESSIBLE such that once this connection gets rerouted, this node can't be used again.
+                if (!routingGraph.lutRoutethru && pip.isRouteThru()) {
+                    assert(rstart.getIntentCode() == IntentCode.NODE_PINFEED);
+                    assert(rstart.getType() == RouteNodeType.LOCAL_EAST || rstart.getType() == RouteNodeType.LOCAL_WEST);
+                    rstart.setType(RouteNodeType.INACCESSIBLE);
+                }
             }
 
             // Try and use prev pointers to recover the routing for each connection
@@ -675,6 +698,10 @@ public class PartialRouter extends RWRoute {
         for (RouteNode rnode : rnodes) {
             // Check already unpreserved above
             assert(!routingGraph.isPreserved(rnode));
+
+            if (rnode.getType() == RouteNodeType.INACCESSIBLE) {
+                continue;
+            }
 
             // Each rnode should be added as a child to all of its parents
             // that already exist

--- a/src/com/xilinx/rapidwright/rwroute/RouteNode.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNode.java
@@ -432,7 +432,9 @@ public class RouteNode extends Node implements Comparable<RouteNode> {
                 (RouteNodeType.isAnyLocal(this.type) && type == RouteNodeType.LOCAL_RESERVED && visited == 0) ||
                 // Or promotions to EXCLUSIVE_SINK_NON_LOCAL from NON_LOCAL (by PartialRouter.determineRoutingTargets()
                 // for the begin node of a locked path to sinks, before any routing)
-                (this.type == RouteNodeType.NON_LOCAL.ordinal() && type == RouteNodeType.EXCLUSIVE_SINK_NON_LOCAL && visited == 0)
+                (this.type == RouteNodeType.NON_LOCAL.ordinal() && type == RouteNodeType.EXCLUSIVE_SINK_NON_LOCAL && visited == 0) ||
+                // Or demotion from LOCAL_{EAST,WEST} for a now-unpreserved PINFEED routethru to being INACCESSIBLE
+                ((this.type == RouteNodeType.LOCAL_EAST.ordinal() || this.type == RouteNodeType.LOCAL_WEST.ordinal()) && type == RouteNodeType.INACCESSIBLE && visited == 0)
         );
         this.type = (byte) type.ordinal();
     }

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeGraph.java
@@ -793,7 +793,9 @@ public class RouteNodeGraph {
                 if (childRnode != null) {
                     assert(childRnode.getType().isAnyExclusiveSink() ||
                            childRnode.getType().isLocalLeadingToLaguna() ||
-                           ((lutRoutethru || lutPinSwapping) && childRnode.getType().isAnyLocal()));
+                           ((lutRoutethru || lutPinSwapping) && childRnode.getType().isAnyLocal()) ||
+                           // This is a routethru node used on a now-unpreserved net
+                           (!lutRoutethru && childRnode.getType() == RouteNodeType.INACCESSIBLE));
                 } else if (!lutRoutethru) {
                     // child does not already exist in our routing graph, meaning it's not a used site pin
                     // in our design, but it could be a IMUX that leads to a Laguna

--- a/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouteNodeType.java
@@ -62,7 +62,8 @@ public enum RouteNodeType {
     /**
      * Denotes {@link RouteNode} objects that should be treated as being inaccessible and
      * never queued for exploration during routing. Typically, these are routing nodes that
-     * have already been created but later discovered to not be needed (e.g. is a dead-end node).
+     * have already been created but later discovered to not be needed (e.g. is a dead-end node),
+     * or from a routethru on an unpreserved net.
      */
     INACCESSIBLE;
 


### PR DESCRIPTION
Previously, arcs leaving the INT tile were dropped when collecting the PIPs of a preserved net, since the router projects pins to their INT tile and would never explore them. For a net containing a LUT routethru this broke the prev pointer chain at the CLE, so `finishRouteConnection()` could not recover the existing routing once the net was unpreserved under `softPreserve`.

Keep routethru PIPs in all three PIP loops so the chain stays intact. With `lutRoutethru` disabled, mark the `IMUX` feeding such a routethru as `INACCESSIBLE`: RWRoute does not normally explore non-sink `PINFEED` nodes, and this one is only present because it was on a previously-preserved net, so no other connection may claim a pin the routethru physically occupies. Such nodes are skipped when resetting children lists, and `RouteNode.setType()` gains a `LOCAL_{EAST,WEST}` -> `INACCESSIBLE` demotion.