### PR TITLE
TimingAndWirelengthReport and RouterHelper fixes

### DIFF
--- a/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
+++ b/src/com/xilinx/rapidwright/rwroute/RouterHelper.java
@@ -42,6 +42,7 @@ import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.DesignTools;
 import com.xilinx.rapidwright.design.Net;
+import com.xilinx.rapidwright.design.NetTools;
 import com.xilinx.rapidwright.design.NetType;
 import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
@@ -548,25 +549,18 @@ public class RouterHelper {
 
     /**
      * Gets a map containing net delay for each sink pin paired with an INT tile node of a routed net.
+     * The delay to each sink is accumulated by walking upstream from it to the start of the net's
+     * routing; the net is assumed to be loop-free, and this walk does not terminate on one that is not.
      * @param net The target routed net.
      * @param estimator An instantiation of DelayEstimatorBase.
      * @return The map containing net delay for each sink pin paired with an INT tile node of a routed net.
      */
     public static Map<SitePinInst, Pair<Node,Short>> getSourceToSinkINTNodeDelays(Net net, DelayEstimatorBase estimator) {
-        List<PIP> pips = net.getPIPs();
+        // Net.getPIPs() is in no particular order, so accumulating delay by walking it would use
+        // an upstream delay that is not yet final. Walk upstream from each sink instead, using a
+        // map that also gives bidirectional PIPs the direction PIP.isReversed() indicates.
+        Map<Node, Node> nodeToDriver = NetTools.getNodeToDriver(net);
         Map<Node, Integer> delayMap = new HashMap<>();
-        for (PIP pip : pips) {
-            Node startNode = pip.getStartNode();
-            int upstreamDelay = delayMap.getOrDefault(startNode, 0);
-
-            Node endNode = pip.getEndNode();
-            int delay = 0;
-            if (endNode.getTile().getTileTypeEnum() == TileTypeEnum.INT) {//device independent?
-                delay = computeNodeDelay(estimator, endNode)
-                        + DelayEstimatorBase.getExtraDelay(endNode, DelayEstimatorBase.isLong(startNode));
-            }
-            delayMap.put(endNode, upstreamDelay + delay);
-        }
 
         Map<SitePinInst, Pair<Node,Short>> sinkNodeDelays = new HashMap<>();
         for (SitePinInst sink : net.getSinkPins()) {
@@ -580,11 +574,37 @@ public class RouterHelper {
                 }
             }
 
-            // A sink that no PIP arrives at has not been routed to yet (e.g. on a placed-only
-            // design), so it has accumulated no route delay
-            Integer delay = delayMap.get(sinkNode);
-            short routeDelay = (delay == null) ? 0 : delay.shortValue();
-            sinkNodeDelays.put(sink, new Pair<>(sinkNode,routeDelay));
+            // Walk upstream until a node of already known delay, or the start of this net's
+            // routing, is reached
+            List<Node> upstreamNodes = new ArrayList<>();
+            Node curr = sinkNode;
+            Integer knownDelay;
+            while ((knownDelay = delayMap.get(curr)) == null) {
+                Node driver = nodeToDriver.get(curr);
+                if (driver == null) {
+                    // No PIP arrives at this node: either it is the node of the net's source pin,
+                    // or it is where the routing to a sink not routed to yet gives out (e.g. on a
+                    // placed-only design), in which case no route delay has been accumulated
+                    break;
+                }
+                upstreamNodes.add(curr);
+                curr = driver;
+            }
+
+            // Then accumulate back downstream from there, memoizing every node walked through so
+            // that nodes shared by more than one sink of this net are only visited once
+            int delay = (knownDelay == null) ? 0 : knownDelay;
+            for (int i = upstreamNodes.size() - 1; i >= 0; i--) {
+                Node downhill = upstreamNodes.get(i);
+                if (downhill.getTile().getTileTypeEnum() == TileTypeEnum.INT) {//device independent?
+                    delay += computeNodeDelay(estimator, downhill)
+                            + DelayEstimatorBase.getExtraDelay(downhill, DelayEstimatorBase.isLong(curr));
+                }
+                delayMap.put(downhill, delay);
+                curr = downhill;
+            }
+
+            sinkNodeDelays.put(sink, new Pair<>(sinkNode,(short) delay));
         }
 
         return sinkNodeDelays;

--- a/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
+++ b/src/com/xilinx/rapidwright/rwroute/TimingAndWirelengthReport.java
@@ -113,14 +113,20 @@ public class TimingAndWirelengthReport{
      */
     private NetWrapper createNetWrapper(Net net) {
         NetWrapper netWrapper = new NetWrapper(numWireNetsToRoute++, net);
-        SitePinInst source = net.getSource();
         for (SitePinInst sink:net.getSinkPins()) {
+            SitePinInst source = net.getSource();
             if (RouterHelper.isExternalConnectionToCout(source, sink)) {
-                source = net.getAlternateSource();
-                if (source == null) {
-                    String errMsg = "Null alternate source is for COUT-CIN connection: " + net.toStringFull();
-                     throw new IllegalArgumentException(errMsg);
+                SitePinInst altSource = net.getAlternateSource();
+                if (altSource == null) {
+                    altSource = DesignTools.getLegalAlternativeOutputPin(net);
+                    if (altSource == null) {
+                        String errMsg = "Null alternate source is for COUT-CIN connection: " + net.toStringFull();
+                        throw new IllegalArgumentException(errMsg);
+                    }
+                    net.addPin(altSource);
+                    DesignTools.routeAlternativeOutputSitePin(net, altSource);
                 }
+                source = altSource;
             }
             Connection connection = new Connection(numConnectionsToRoute++, source, sink, netWrapper);
             Node sinkINTNode = RouterHelper.projectInputPinToINTNode(sink);

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -535,12 +535,12 @@ public class TestRWRoute {
 
     @ParameterizedTest
     @CsvSource({
-            // "picoblaze_ooc_X10Y235.dcp,false",
-            // "picoblaze_ooc_X10Y235.dcp,true",
-            // "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,false",
-            // "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,true",
+            "picoblaze_ooc_X10Y235.dcp,false",
+            "picoblaze_ooc_X10Y235.dcp,true",
+            "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,false",
+            "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,true",
             "optical-flow.dcp,false",
-            "optical-flow_routed.dcp,true",
+            "optical-flow.dcp,true",
     })
     public void testTimingAndWirelengthReport(String dcpShortPath, boolean verbose) {
         String dcp = RapidWrightDCP.getString(dcpShortPath);

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRWRoute.java
@@ -535,10 +535,12 @@ public class TestRWRoute {
 
     @ParameterizedTest
     @CsvSource({
-            "picoblaze_ooc_X10Y235.dcp,false",
-            "picoblaze_ooc_X10Y235.dcp,true",
-            "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,false",
-            "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,true",
+            // "picoblaze_ooc_X10Y235.dcp,false",
+            // "picoblaze_ooc_X10Y235.dcp,true",
+            // "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,false",
+            // "gnl_2_4_3_1.3_gnl_3000_07_3_80_80_placed.dcp,true",
+            "optical-flow.dcp,false",
+            "optical-flow_routed.dcp,true",
     })
     public void testTimingAndWirelengthReport(String dcpShortPath, boolean verbose) {
         String dcp = RapidWrightDCP.getString(dcpShortPath);

--- a/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
+++ b/test/src/com/xilinx/rapidwright/rwroute/TestRouterHelper.java
@@ -27,15 +27,20 @@ import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Net;
 import com.xilinx.rapidwright.design.SiteInst;
 import com.xilinx.rapidwright.design.SitePinInst;
+import com.xilinx.rapidwright.design.TestDesignHelper;
 import com.xilinx.rapidwright.design.Unisim;
 import com.xilinx.rapidwright.design.tools.LUTTools;
 import com.xilinx.rapidwright.device.Device;
 import com.xilinx.rapidwright.device.Node;
+import com.xilinx.rapidwright.device.PIP;
 import com.xilinx.rapidwright.edif.EDIFCellInst;
 import com.xilinx.rapidwright.edif.EDIFPortInst;
 import com.xilinx.rapidwright.edif.EDIFTools;
 import com.xilinx.rapidwright.support.RapidWrightDCP;
 import com.xilinx.rapidwright.support.rwroute.RouterHelperSupport;
+import com.xilinx.rapidwright.timing.delayestimator.DelayEstimatorBase;
+import com.xilinx.rapidwright.timing.delayestimator.InterconnectInfo;
+import com.xilinx.rapidwright.util.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -47,6 +52,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -350,5 +356,90 @@ public class TestRouterHelper {
 
         List<Node> path = RouterHelper.findPathBetweenNodes(sourceNode, sinkNode);
         Assertions.assertTrue(path.size() > 2);
+    }
+
+    /**
+     * Checks that {@link RouterHelper#getSourceToSinkINTNodeDelays} accumulates delay by walking
+     * upstream from each sink, rather than in {@link Net#getPIPs()} order which
+     * {@link Net#setPIPs(Set)} leaves unspecified, and that it follows bidirectional PIPs in the
+     * direction that {@link PIP#isReversed()} gives rather than the direction the device declares.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            // Sink pin, the INT tile node it projects to, its expected delay, and whether to
+            // reverse the order that the net's PIPs are given in
+            "B3,INT_X54Y135/IMUX_W25,178,false",
+            "B3,INT_X54Y135/IMUX_W25,178,true",
+            "D5,INT_X54Y135/IMUX_W31,174,false",
+            "D5,INT_X54Y135/IMUX_W31,174,true",
+            "H3,INT_X54Y135/IMUX_W33,178,false",
+            "H3,INT_X54Y135/IMUX_W33,178,true",
+            // A1 is the only sink reached through the reversed PIP below; walking that PIP in the
+            // direction the device declares for it instead loses the two nodes ahead of it, and
+            // under-reports A1 as 204ps
+            "A1,INT_X54Y136/IMUX_W10,269,false",
+            "A1,INT_X54Y136/IMUX_W10,269,true"
+    })
+    public void testGetSourceToSinkINTNodeDelays(String sinkPinName, String sinkNodeName,
+                                                 short expectedDelay, boolean reversePipOrder) {
+        Design design = new Design("design", "xcvu3p");
+        Device device = design.getDevice();
+
+        // A net taken from a Vivado-routed design, listed here in topological order, that fans out
+        // to four sinks and that uses one bidirectional PIP in the reverse of the direction that
+        // the device declares for it
+        String[] pips = new String[]{
+                "INT_X54Y135/INT.LOGIC_OUTS_W30->>INT_NODE_IMUX_60_INT_OUT1",
+                "INT_X54Y135/INT.INT_NODE_IMUX_60_INT_OUT1->>BYPASS_W14",
+                "INT_X54Y135/INT.BYPASS_W14->>INT_NODE_IMUX_50_INT_OUT1",
+                "INT_X54Y135/INT.INT_NODE_IMUX_50_INT_OUT1->>BYPASS_W10",
+                "INT_X54Y135/INT.BYPASS_W10->>INT_NODE_IMUX_41_INT_OUT1",
+                "INT_X54Y135/INT.INT_NODE_IMUX_41_INT_OUT1->>IMUX_W25",
+                "INT_X54Y135/INT.BYPASS_W10->>INT_NODE_IMUX_41_INT_OUT0",
+                "INT_X54Y135/INT.INT_NODE_IMUX_41_INT_OUT0->>IMUX_W31",
+                "INT_X54Y135/INT.BYPASS_W10->>INT_NODE_IMUX_40_INT_OUT0",
+                "INT_X54Y135/INT.INT_NODE_IMUX_40_INT_OUT0->>IMUX_W33",
+                "INT_X54Y135/INT.INT_NODE_IMUX_50_INT_OUT0<<->>BYPASS_W14",
+                "INT_X54Y135/INT.INT_NODE_IMUX_50_INT_OUT0->>BOUNCE_W_13_FT0",
+                "INT_X54Y136/INT.BOUNCE_W_BLN_13_FT1->>INT_NODE_IMUX_62_INT_OUT0",
+                "INT_X54Y136/INT.INT_NODE_IMUX_62_INT_OUT0->>BYPASS_W5",
+                "INT_X54Y136/INT.BYPASS_W5->>INT_NODE_IMUX_48_INT_OUT0",
+                "INT_X54Y136/INT.INT_NODE_IMUX_48_INT_OUT0->>IMUX_W10"
+        };
+        if (reversePipOrder) {
+            // Any permutation must give the same result; reversing puts every PIP ahead of its driver
+            Collections.reverse(Arrays.asList(pips));
+        }
+        Net net = TestDesignHelper.createTestNet(design, "net", pips);
+
+        // PIP.toString() does not capture that a bidirectional PIP is used in reverse
+        for (PIP pip : net.getPIPs()) {
+            if (pip.toString().equals("INT_X54Y135/INT.INT_NODE_IMUX_50_INT_OUT0<<->>BYPASS_W14")) {
+                pip.setIsReversed(true);
+            }
+        }
+
+        SiteInst si135 = design.createSiteInst("SLICE_X84Y135");
+        SiteInst si136 = design.createSiteInst("SLICE_X84Y136");
+        net.createPin("EQ", si135);
+        for (String pinName : new String[]{"B3", "D5", "H3"}) {
+            net.createPin(pinName, si135);
+        }
+        net.createPin("A1", si136);
+
+        DelayEstimatorBase<InterconnectInfo> estimator = new DelayEstimatorBase<>(device, new InterconnectInfo(), false, 0);
+        Map<SitePinInst, Pair<Node,Short>> sinkNodeDelays = RouterHelper.getSourceToSinkINTNodeDelays(net, estimator);
+        Assertions.assertEquals(net.getSinkPins().size(), sinkNodeDelays.size());
+
+        Pair<Node,Short> nodeDelay = null;
+        for (Map.Entry<SitePinInst, Pair<Node,Short>> e : sinkNodeDelays.entrySet()) {
+            if (e.getKey().getName().equals(sinkPinName)) {
+                nodeDelay = e.getValue();
+                break;
+            }
+        }
+        Assertions.assertNotNull(nodeDelay);
+        Assertions.assertEquals(sinkNodeName, nodeDelay.getFirst().toString());
+        Assertions.assertEquals(expectedDelay, (short) nodeDelay.getSecond());
     }
 }


### PR DESCRIPTION
- `TimingAndWirelengthReport`: Fix `createNetWrapper()` for `COUT` sources (mirroring behaviour in RWRoute)
- `RouterHelper`: Fix `getSourceToSinkINTNodeDelays()` reversed/unsorted PIPs
  - Prior to this PR, this method relied on PIP ordering being topologically sorted, leading to some incorrectly computed values.

Note: this is a stacked PR!