### PR TITLE
[EDIFTools] Detect gzipped EDIF by content, not file name

### DIFF
--- a/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
+++ b/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
@@ -29,9 +29,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.xilinx.rapidwright.util.Params;
 import com.xilinx.rapidwright.util.StringPool;
-import com.xilinx.rapidwright.util.function.InputStreamSupplier;
 
 public abstract class AbstractEDIFParserWorker {
 
@@ -92,8 +90,7 @@ public abstract class AbstractEDIFParserWorker {
     }
 
     public AbstractEDIFParserWorker(Path fileName, StringPool uniquifier, EDIFReadLegalNameCache cache) throws FileNotFoundException {
-        in = InputStreamSupplier.getInputStream(fileName,
-                fileName.toString().endsWith(".gz") && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK);
+        in = EDIFTools.openEDIFInputStream(fileName);
         tokenizer = new EDIFTokenizer(fileName, in, uniquifier);
         this.cache = cache;
     }

--- a/src/com/xilinx/rapidwright/edif/EDIFTools.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTools.java
@@ -25,6 +25,7 @@
  */
 package com.xilinx.rapidwright.edif;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,6 +50,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.zip.GZIPInputStream;
 
 import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
@@ -62,6 +64,7 @@ import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.util.FileTools;
 import com.xilinx.rapidwright.util.Pair;
 import com.xilinx.rapidwright.util.Params;
+import com.xilinx.rapidwright.util.function.InputStreamSupplier;
 
 
 /**
@@ -949,11 +952,88 @@ public class EDIFTools {
         return loadEDIFFile(fileName, Integer.MAX_VALUE);
     }
 
+    /** Magic bytes that begin every gzip stream. */
+    private static final byte[] GZIP_MAGIC = { (byte) 0x1f, (byte) 0x8b };
+
+    /**
+     * Checks whether the provided file is gzip-compressed, either by its '.gz'
+     * extension or by inspecting its magic bytes. Some tools emit gzipped EDIF
+     * without the conventional extension.
+     *
+     * @param fileName Path to the file to check.
+     * @return True if the file is gzip-compressed, false otherwise.
+     */
+    public static boolean isGzipped(Path fileName) {
+        if (fileName.toString().endsWith(".gz")) {
+            return true;
+        }
+        try (InputStream in = Files.newInputStream(fileName)) {
+            return startsWithGzipMagic(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException("ERROR: Couldn't read file: " + fileName, e);
+        }
+    }
+
+    /**
+     * Reads the leading magic bytes of a stream to determine whether it is
+     * gzip-compressed. A stream that supports mark/reset is rewound, leaving those
+     * bytes available to the caller.
+     *
+     * @param in The stream to inspect.
+     * @return True if the stream begins with the gzip magic bytes, false otherwise.
+     */
+    private static boolean startsWithGzipMagic(InputStream in) throws IOException {
+        boolean rewindable = in.markSupported();
+        if (rewindable) {
+            in.mark(GZIP_MAGIC.length);
+        }
+        byte[] magic = new byte[GZIP_MAGIC.length];
+        int read = 0;
+        int count;
+        while (read < magic.length && (count = in.read(magic, read, magic.length - read)) >= 0) {
+            read += count;
+        }
+        if (rewindable) {
+            in.reset();
+        }
+        return read == magic.length && Arrays.equals(magic, GZIP_MAGIC);
+    }
+
+    /**
+     * Opens an InputStream over an EDIF file, transparently decompressing it when
+     * gzipped, whether or not it carries a '.gz' extension.
+     *
+     * @param fileName Path to the EDIF file from which to get an InputStream.
+     * @return An InputStream of the (decompressed) EDIF contents.
+     */
+    public static InputStream openEDIFInputStream(Path fileName) {
+        boolean nameEndsWithGz = fileName.toString().endsWith(".gz");
+        InputStream in = InputStreamSupplier.getInputStream(fileName,
+                nameEndsWithGz && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK);
+        if (nameEndsWithGz) {
+            // getInputStream() has already decompressed this. The decompress-to-disk
+            // option is keyed on the extension, so it never applies below.
+            return in;
+        }
+        // Detect gzip on the stream that is already open, so the file is neither
+        // re-opened nor read twice
+        try {
+            in = new BufferedInputStream(in);
+            return startsWithGzipMagic(in) ? new GZIPInputStream(in) : in;
+        } catch (IOException e) {
+            FileTools.close(in);
+            throw new UncheckedIOException("ERROR: Couldn't read file: " + fileName, e);
+        }
+    }
+
     public static EDIFNetlist loadEDIFFile(Path fileName, int maxThreads) {
         try {
             final long size = Files.size(fileName);
-            if (ParallelEDIFParser.calcThreads(size, maxThreads, fileName.toString().endsWith(".gz")) > 1) {
-                try (ParallelEDIFParser p = new ParallelEDIFParser(fileName)) {
+            // Determined once here and threaded through, so the parser does not
+            // re-open the file to ask the same question
+            final boolean gzipped = isGzipped(fileName);
+            if (ParallelEDIFParser.calcThreads(size, maxThreads, gzipped) > 1) {
+                try (ParallelEDIFParser p = new ParallelEDIFParser(fileName, size, gzipped)) {
                     return p.parseEDIFNetlist();
                 }
             } else {

--- a/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/ParallelEDIFParser.java
@@ -57,6 +57,9 @@ public class ParallelEDIFParser implements AutoCloseable{
     private final int maxThreads;
     protected final InputStreamSupplier inputStreamSupplier;
     protected final int maxTokenLength;
+
+    /** Whether the input is gzip-compressed, determined once by the caller. */
+    private final boolean gzipped;
     protected StringPool uniquifier = StringPool.concurrentPool();
 
     protected final EDIFReadLegalNameCache cache;
@@ -68,13 +71,20 @@ public class ParallelEDIFParser implements AutoCloseable{
     public static final int EDIF_GZIP_COMPRESSION_RATIO = 16;
 
     ParallelEDIFParser(Path fileName, long fileSize, InputStreamSupplier inputStreamSupplier,
-            int maxTokenLength, int maxThreads) {
+            int maxTokenLength, int maxThreads, boolean gzipped) {
         this.fileName = fileName;
         this.fileSize = fileSize;
         this.inputStreamSupplier = inputStreamSupplier;
         this.maxTokenLength = maxTokenLength;
         this.cache = EDIFReadLegalNameCache.createMultiThreaded();
         this.maxThreads = maxThreads;
+        this.gzipped = gzipped;
+    }
+
+    ParallelEDIFParser(Path fileName, long fileSize, InputStreamSupplier inputStreamSupplier,
+            int maxTokenLength, int maxThreads) {
+        this(fileName, fileSize, inputStreamSupplier, maxTokenLength, maxThreads,
+                EDIFTools.isGzipped(fileName));
     }
 
     public ParallelEDIFParser(Path fileName, long fileSize, InputStreamSupplier inputStreamSupplier) {
@@ -82,9 +92,19 @@ public class ParallelEDIFParser implements AutoCloseable{
                 Integer.MAX_VALUE);
     }
 
+    /**
+     * @param p        Path to the EDIF file to parse.
+     * @param fileSize Size of the file on disk, in bytes.
+     * @param gzipped  Whether the file is gzip-compressed. Accepting it here lets a
+     *                 caller that has already determined this avoid a second check.
+     */
+    public ParallelEDIFParser(Path p, long fileSize, boolean gzipped) {
+        this(p, fileSize, () -> EDIFTools.openEDIFInputStream(p),
+                EDIFTokenizer.DEFAULT_MAX_TOKEN_LENGTH, Integer.MAX_VALUE, gzipped);
+    }
+
     public ParallelEDIFParser(Path p, long fileSize) {
-        this(p, fileSize, InputStreamSupplier.fromPath(p,
-                p.toString().endsWith(".gz") && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK));
+        this(p, fileSize, EDIFTools.isGzipped(p));
     }
 
     public ParallelEDIFParser(Path p) throws IOException {
@@ -105,9 +125,8 @@ public class ParallelEDIFParser implements AutoCloseable{
 
     protected void initializeWorkers() throws IOException {
         workers.clear();
-        boolean isGzipped = fileName.toString().endsWith(".gz");
-        int threads = calcThreads(fileSize, maxThreads, isGzipped);
-        long offsetPerThread = (isGzipped ? (fileSize * EDIF_GZIP_COMPRESSION_RATIO) : fileSize)
+        int threads = calcThreads(fileSize, maxThreads, gzipped);
+        long offsetPerThread = (gzipped ? (fileSize * EDIF_GZIP_COMPRESSION_RATIO) : fileSize)
                 / threads;
         for (int i=0;i<threads;i++) {
             ParallelEDIFParserWorker worker = makeWorker(i*offsetPerThread);

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFGzipDetection.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFGzipDetection.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Checks that gzipped EDIF is recognized by its content, so that files which do
+ * not carry the conventional '.gz' extension are still read correctly.
+ */
+public class TestEDIFGzipDetection {
+
+    private static final String NETLIST = "(edif test\n"
+            + "  (edifVersion 2 0 0)\n"
+            + "  (edifLevel 0)\n"
+            + "  (keywordMap (keywordLevel 0))\n"
+            + "  (status (written (timeStamp 2024 1 1 0 0 0)"
+            + " (program \"Vivado\" (version \"2024.1\"))))\n"
+            + "  (library work\n"
+            + "    (edifLevel 0)\n"
+            + "    (technology (numberDefinition))\n"
+            + "    (cell top (cellType GENERIC)\n"
+            + "      (view netlist (viewType NETLIST)\n"
+            + "        (interface (port a (direction INPUT)))\n"
+            + "      )\n"
+            + "    )\n"
+            + "  )\n"
+            + "  (design top (cellRef top (libraryRef work)))\n"
+            + ")\n";
+
+    private static void assertParses(EDIFNetlist netlist) {
+        Assertions.assertNotNull(netlist.getDesign());
+        Assertions.assertEquals("top", netlist.getDesign().getTopCell().getName());
+        Assertions.assertEquals(1, netlist.getDesign().getTopCell().getPorts().size());
+    }
+
+    private static Path writeGzipped(Path dir, String name) throws IOException {
+        Path p = dir.resolve(name);
+        try (OutputStream out = new GZIPOutputStream(Files.newOutputStream(p))) {
+            out.write(NETLIST.getBytes(StandardCharsets.UTF_8));
+        }
+        return p;
+    }
+
+    private static Path writePlain(Path dir, String name) throws IOException {
+        Path p = dir.resolve(name);
+        Files.write(p, NETLIST.getBytes(StandardCharsets.UTF_8));
+        return p;
+    }
+
+    @Test
+    public void testGzippedWithoutGzExtension(@TempDir Path dir) throws IOException {
+        Path p = writeGzipped(dir, "compressed.edf");
+        Assertions.assertTrue(EDIFTools.isGzipped(p));
+        try (EDIFParser parser = new EDIFParser(p)) {
+            assertParses(parser.parseEDIFNetlist());
+        }
+        assertParses(EDIFTools.loadEDIFFile(p));
+    }
+
+    @Test
+    public void testGzippedWithGzExtension(@TempDir Path dir) throws IOException {
+        Path p = writeGzipped(dir, "compressed.edf.gz");
+        Assertions.assertTrue(EDIFTools.isGzipped(p));
+        assertParses(EDIFTools.loadEDIFFile(p));
+    }
+
+    @Test
+    public void testPlainFileNotDetectedAsGzip(@TempDir Path dir) throws IOException {
+        Path p = writePlain(dir, "plain.edf");
+        Assertions.assertFalse(EDIFTools.isGzipped(p));
+        assertParses(EDIFTools.loadEDIFFile(p));
+    }
+
+    @Test
+    public void testEmptyFileNotDetectedAsGzip(@TempDir Path dir) throws IOException {
+        Path p = dir.resolve("empty.edf");
+        Files.write(p, new byte[0]);
+        Assertions.assertFalse(EDIFTools.isGzipped(p));
+    }
+
+    /**
+     * Detection peeks at the stream that is already open, so it must leave the
+     * leading bytes in place for the caller.
+     */
+    @Test
+    public void testOpenEDIFInputStreamPreservesLeadingBytes(@TempDir Path dir) throws IOException {
+        for (Path p : new Path[] { writePlain(dir, "plain.edf"), writeGzipped(dir, "gz.edf"),
+                writeGzipped(dir, "named.edf.gz") }) {
+            try (InputStream in = EDIFTools.openEDIFInputStream(p)) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buffer = new byte[512];
+                int read;
+                while ((read = in.read(buffer)) >= 0) {
+                    out.write(buffer, 0, read);
+                }
+                Assertions.assertEquals(NETLIST, out.toString("UTF-8"),
+                        "content differs for " + p.getFileName());
+            }
+        }
+    }
+
+    /** A file too short to hold the magic bytes must not be misread as gzip. */
+    @Test
+    public void testTruncatedFileNotDetectedAsGzip(@TempDir Path dir) throws IOException {
+        Path p = dir.resolve("onebyte.edf");
+        Files.write(p, new byte[] { (byte) 0x1f });
+        Assertions.assertFalse(EDIFTools.isGzipped(p));
+        try (InputStream in = EDIFTools.openEDIFInputStream(p)) {
+            Assertions.assertEquals(0x1f, in.read());
+            Assertions.assertEquals(-1, in.read());
+        }
+    }
+
+    /**
+     * The parallel parser derives its thread count and worker offsets from the gzip
+     * flag, so it must reach that path correctly both when the caller supplies the
+     * flag and when the parser determines it.
+     */
+    @Test
+    public void testParallelParserOnGzippedWithoutGzExtension(@TempDir Path dir)
+            throws IOException {
+        Path p = writeGzipped(dir, "compressed.edf");
+        try (ParallelEDIFParser parser =
+                new ParallelEDIFParser(p, Files.size(p), EDIFTools.isGzipped(p))) {
+            assertParses(parser.parseEDIFNetlist());
+        }
+        try (ParallelEDIFParser parser = new ParallelEDIFParser(p)) {
+            assertParses(parser.parseEDIFNetlist());
+        }
+    }
+
+    /** The same, for a plain file, so a wrongly-set flag cannot pass unnoticed. */
+    @Test
+    public void testParallelParserOnPlainFile(@TempDir Path dir) throws IOException {
+        Path p = writePlain(dir, "plain.edf");
+        try (ParallelEDIFParser parser =
+                new ParallelEDIFParser(p, Files.size(p), EDIFTools.isGzipped(p))) {
+            assertParses(parser.parseEDIFNetlist());
+        }
+    }
+}


### PR DESCRIPTION
### Problem

Some tools emit gzip-compressed EDIF without the conventional `.gz` extension. RapidWright decided whether to decompress based on the file name alone, in three separate places, so such a file was handed to the tokenizer still compressed and failed to parse.

### Change

- Add `EDIFTools.isGzipped(Path)`, which keeps the `.gz` fast path and otherwise falls back to inspecting the gzip magic bytes (`0x1f 0x8b`).
- Add `EDIFTools.openEDIFInputStream(Path)`, which wraps the stream in a `GZIPInputStream` when the content is gzipped but the name is not.
- Route `EDIFParser` (via `AbstractEDIFParserWorker`) and `ParallelEDIFParser` through it, so the two parsers no longer re-derive the answer independently.
- Use the same answer for the thread-count heuristic in `EDIFTools.loadEDIFFile()` and `ParallelEDIFParser.initializeWorkers()`, which previously disagreed for a gzipped file without the extension.

`openEDIFInputStream()` throws `UncheckedIOException` rather than declaring `IOException`, matching the existing `InputStreamSupplier.getInputStream()`. This keeps `AbstractEDIFParserWorker`'s `throws FileNotFoundException` and the `EDIFParser` public constructors unchanged.

The decompress-to-disk option (`RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK`) stays keyed on the `.gz` extension, matching the cleanup path in `ParallelEDIFParser.parseEDIFNetlist()` that deletes the decompressed file.

### Testing

New `TestEDIFGzipDetection` covers gzipped EDIF with and without the `.gz` extension, a plain file, and an empty file, through both `EDIFParser` and `EDIFTools.loadEDIFFile()`.

Full `./gradlew testJava` run locally: 1526 tests, 28 skipped, no regressions. The one failure, `TestPicoBlazeArray`, reproduces unmodified on `master` and is a macOS artifact — `CodePerfTracker.getTotalOSMemUsage()` reads `/proc/<pid>/status`, which does not exist on that platform.