### PR TITLE
[EDIFParser] Key cell reference map by legal library name

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFParser.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFParser.java
@@ -152,8 +152,11 @@ public class EDIFParser extends AbstractEDIFParserWorker implements AutoCloseabl
         EDIFLibrary library = parseEdifLibraryHead();
 
         String currToken;
+        // Cell references name their library by its legal EDIF name, which differs
+        // from getName() whenever the library carries a (rename ...)
+        String libraryLegalName = cache.getLegalEDIFName(library);
         while (LEFT_PAREN.equals(currToken = getNextToken(true))) {
-            final EDIFCell cell = parseEDIFCell(library.getName(), getNextToken(true));
+            final EDIFCell cell = parseEDIFCell(libraryLegalName, getNextToken(true));
             library.addCellRenameDuplicates(cell, cache.getEDIFRename(cell));
         }
         expect(RIGHT_PAREN, currToken);

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFCellRefLinking.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFCellRefLinking.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Checks that a (cellRef ... (libraryRef ...)) resolves to the cell it names,
+ * including when the library it names carries a (rename ...).
+ */
+public class TestEDIFCellRefLinking {
+
+    private static String netlist(String libraryNameDef, String libraryRef) {
+        return "(edif test\n"
+                + "  (edifVersion 2 0 0)\n"
+                + "  (edifLevel 0)\n"
+                + "  (keywordMap (keywordLevel 0))\n"
+                + "  (status (written (timeStamp 2024 1 1 0 0 0)"
+                + " (program \"Vivado\" (version \"2024.1\"))))\n"
+                + "  (library " + libraryNameDef + "\n"
+                + "    (edifLevel 0)\n"
+                + "    (technology (numberDefinition))\n"
+                + "    (cell sub (cellType GENERIC)\n"
+                + "      (view netlist (viewType NETLIST)\n"
+                + "        (interface (port i (direction INPUT)) (port o (direction OUTPUT)))\n"
+                + "      )\n"
+                + "    )\n"
+                + "    (cell top (cellType GENERIC)\n"
+                + "      (view netlist (viewType NETLIST)\n"
+                + "        (interface (port a (direction INPUT)))\n"
+                + "        (contents\n"
+                + "          (instance inst1 (viewRef netlist"
+                + " (cellRef sub (libraryRef " + libraryRef + "))))\n"
+                + "        )\n"
+                + "      )\n"
+                + "    )\n"
+                + "  )\n"
+                + "  (design top (cellRef top (libraryRef " + libraryRef + ")))\n"
+                + ")\n";
+    }
+
+    private static EDIFNetlist parse(Path dir, String name, String content) throws IOException {
+        Path p = dir.resolve(name);
+        Files.write(p, content.getBytes(StandardCharsets.UTF_8));
+        try (EDIFParser parser = new EDIFParser(p)) {
+            return parser.parseEDIFNetlist();
+        }
+    }
+
+    private static void assertCellRefResolved(EDIFNetlist netlist) {
+        EDIFCell sub = netlist.getDesign().getTopCell().getCellInst("inst1").getCellType();
+        Assertions.assertEquals("sub", sub.getName());
+        // An unresolved reference leaves behind a placeholder cell with no ports
+        Assertions.assertEquals(2, sub.getPorts().size());
+    }
+
+    @Test
+    public void testPlainLibrary(@TempDir Path dir) throws IOException {
+        assertCellRefResolved(parse(dir, "plain.edf", netlist("work", "work")));
+    }
+
+    @Test
+    public void testRenamedLibrary(@TempDir Path dir) throws IOException {
+        assertCellRefResolved(parse(dir, "renamed.edf",
+                netlist("(rename work_lib \"Work Library\")", "work_lib")));
+    }
+}


### PR DESCRIPTION
### Problem

`EDIFParser` keys `edifInstCellMap` two different ways for the same library:

- `parseEDIFLibrary()` inserts using `library.getName()`
- `getRefEDIFCell()` looks up using the `libraryref` token read from the file, which is the library's **legal EDIF name**

For a library declared as `(library (rename work_lib "Work Library") ...)` those disagree: `getName()` returns `Work Library`, while `(libraryRef work_lib)` uses `work_lib`. The placeholder `EDIFCell` created for a forward reference is therefore never reconciled with the cell parsed later, and instances are left pointing at an empty `EDIFCell`.

This does not fail at parse time. It surfaces later as a `NullPointerException`, or as a silently incomplete netlist, which makes it awkward to trace back to the parser.

### Change

Use `cache.getLegalEDIFName(library)`, which is already what `parseEDIFCell()` uses for the cell half of the same key.

`ParallelEDIFParser` is unaffected — it keys by `EDIFLibrary` identity rather than by name.

### Testing

New `TestEDIFCellRefLinking` parses a netlist whose cross-library `(cellRef sub (libraryRef ...))` resolves to a cell with known ports, and asserts the ports are present rather than the reference having been left as an empty placeholder. It covers a plain library and a renamed one; the renamed case fails on `master` with a `NullPointerException`.