### PR TITLE
[EDIFNetlist] Guard expandMacroUnisims() against a missing part name

### DIFF
--- a/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFNetlist.java
@@ -1805,8 +1805,16 @@ public class EDIFNetlist extends EDIFName {
      *         otherwise.
      */
     public boolean expandMacroUnisims() {
-        Part part = PartNameTools.getPart(EDIFTools.getPartName(this));
-        if (part == null) {
+        String partName = EDIFTools.getPartName(this);
+        if (partName == null) {
+            return false;
+        }
+        Part part;
+        try {
+            part = PartNameTools.getPart(partName);
+        } catch (RuntimeException e) {
+            // getPart() throws rather than returning null for a part it cannot
+            // identify, which this method reports as a failure to expand
             return false;
         }
         expandMacroUnisims(part.getSeries());

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFNetlist.java
@@ -660,4 +660,24 @@ class TestEDIFNetlist {
             Assertions.assertEquals("[ob/P/O]", netlist.getPhysicalPins("ob/O").toString());
         }
     }
+
+    @Test
+    public void testExpandMacroUnisimsWithoutPartName() {
+        EDIFNetlist netlist = new EDIFNetlist("test");
+        netlist.setDesign(new EDIFDesign("top"));
+        // A netlist whose design carries no PART property has nothing to expand
+        // against, and must report that rather than dereferencing a null part name
+        Assertions.assertFalse(netlist.expandMacroUnisims());
+    }
+
+    @Test
+    public void testExpandMacroUnisimsWithUnknownPartName() {
+        EDIFNetlist netlist = new EDIFNetlist("test");
+        EDIFDesign design = new EDIFDesign("top");
+        netlist.setDesign(design);
+        design.addProperty(EDIFTools.EDIF_PART_PROP, "xcNotARealPart");
+        // PartNameTools.getPart() throws for an unidentifiable part; the documented
+        // contract here is to return false instead
+        Assertions.assertFalse(netlist.expandMacroUnisims());
+    }
 }


### PR DESCRIPTION
### Problem

`EDIFTools.getPartName()` returns `null` when the design carries no `PART` property. `PartNameTools.getPart()` dereferences its argument immediately (`partName.toLowerCase()`), so `expandMacroUnisims()` threw a `NullPointerException` instead of reporting that there was nothing to expand against.

The `if (part == null) return false;` already present below the call cannot be reached for this case, since `getPart()` throws rather than returning null.

### Change

Return `false` when the part name is absent, matching how `EDIFNetlist.getDevice()` already handles the same condition a few hundred lines above.

### Testing

Adds a case to `TestEDIFNetlist` that builds a netlist whose design has no `PART` property and asserts `expandMacroUnisims()` returns `false`. It throws on `master`.