### PR TITLE
[MetadataParser] Resolves new Net(null) with getParentNetName()

### DIFF
--- a/src/com/xilinx/rapidwright/design/MetadataParser.java
+++ b/src/com/xilinx/rapidwright/design/MetadataParser.java
@@ -313,10 +313,16 @@ public class MetadataParser {
                     expect(NETNAME, tokens[1]);
                     currPortNet = m.getNet(tokens[2]);
                     if (currPortNet==null) {
+                        // The physical net is named after the parent (canonical) net of this
+                        // alias.  Nets without a driver (such as an unused output port) have no
+                        // parent, fall back onto the name provided by the metadata in that case.
                         String parentNetName = m.getNetlist().getParentNetName(tokens[2]);
-                        currPortNet = m.getNet(parentNetName);
-                        if (currPortNet==null) {
-                            currPortNet = new Net(parentNetName);
+                        String netName = parentNetName != null ? parentNetName : tokens[2];
+                        currPortNet = m.getNet(netName);
+                        if (currPortNet==null && implicitConnections) {
+                            // Only implicit connections need a Net to group the ports by, don't
+                            // burden modules with explicit connections with empty nets.
+                            currPortNet = new Net(netName);
                             m.addNet(currPortNet);
                         }
                     }
@@ -488,7 +494,9 @@ public class MetadataParser {
         if (!port.isOutPort()) {
             return;
         }
-        if (!port.getSitePinInsts().isEmpty() || port.getType() == PortType.GROUND || port.getType() == PortType.POWER) {
+        if (!port.getSitePinInsts().isEmpty() || port.getType() == PortType.GROUND || port.getType() == PortType.POWER
+                || port.getType() == PortType.UNCONNECTED) {
+            // An unconnected port is not expected to have a source
             return;
         }
         //Any input among passthru ports?


### PR DESCRIPTION
Issues:
  - `new Net(null)` — the new `PORT_NET` code resolves a port's net via `getParentNetName()`. An undriven net (e.g. an unused output port) has no parent, so `getParentNetName()` returns `null` and constructing `Net(null)` throws. 
  - Spurious empty nets — even when the parent name resolved, an empty `Net` was added to the module. On instantiation those became design nets that alias the real top-level nets, tripping the parent-net assertion in
    `DesignTools.createMissingSitePinInsts()`. That's the `testNoUnrouteStaticNets` failure (`java.lang.AssertionError at DesignTools.java:2563`), and it explains why only that variant failed while `test(boolean)` passed.
  - `checkForOutputPortSource()` also threw `NoSuchElementException` on output ports the parser had marked `UNCONNECTED` (empty begin connections block), which have no source by definition.

  Fix (`src/com/xilinx/rapidwright/design/MetadataParser.java`): fall back to the metadata's own net name when there is no parent net; only create/register the Net when `implicitConnections` is set (it is read nowhere else); and skip `UNCONNECTED` ports in
  `checkForOutputPortSource()`, matching `createImplicitConnections()`.
