### PR TITLE
[EDIFParser] Accept author and optional program in (written ...)

### DIFF
--- a/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
+++ b/src/com/xilinx/rapidwright/edif/AbstractEDIFParserWorker.java
@@ -48,6 +48,7 @@ public abstract class AbstractEDIFParserWorker {
     public static final String STATUS = "status";
     public static final String WRITTEN = "written";
     public static final String TIMESTAMP = "timestamp";
+    public static final String AUTHOR = "author";
     public static final String PROGRAM = "program";
     public static final String VERSION = "version";
     public static final String COMMENT = "comment";
@@ -96,6 +97,28 @@ public abstract class AbstractEDIFParserWorker {
                 fileName.toString().endsWith(".gz") && Params.RW_DECOMPRESS_GZIPPED_EDIF_TO_DISK);
         tokenizer = new EDIFTokenizer(fileName, in, uniquifier);
         this.cache = cache;
+    }
+
+    /**
+     * Consumes the remainder of the construct currently being parsed, through its
+     * matching closing parenthesis. The construct's opening parenthesis and keyword
+     * are assumed to have already been consumed.
+     */
+    protected void skipConstruct() {
+        int depth = 1;
+        while (depth > 0) {
+            String token = requireToken(tokenizer.getOptionalNextTokenString(true));
+            // A quoted string is returned without its quotes, so its text can equal
+            // "(" or ")" without being a parenthesis
+            if (tokenizer.wasLastTokenQuoted()) {
+                continue;
+            }
+            if (LEFT_PAREN.equals(token)) {
+                depth++;
+            } else if (RIGHT_PAREN.equals(token)) {
+                depth--;
+            }
+        }
     }
 
     private static <T> T requireToken(T t) {
@@ -234,30 +257,41 @@ public abstract class AbstractEDIFParserWorker {
         int min = Integer.parseInt(getNextToken(true));
         int sec = Integer.parseInt(getNextToken(true));
         expect(RIGHT_PAREN, getNextToken(true));
-        expect(LEFT_PAREN, getNextToken(true));
-        expect(PROGRAM, getNextToken(true));
-        String progName = getNextToken(true);
-        expect(LEFT_PAREN, getNextToken(true));
-        expect(VERSION, getNextToken(true));
-        String ver = getNextToken(true);
-        expect(RIGHT_PAREN, getNextToken(true));
-        expect(RIGHT_PAREN, getNextToken(true));
 
         String currToken;
         while (LEFT_PAREN.equals(currToken = getNextToken(true))) {
-            String commentOrMetax = getNextToken(true);
-            if (commentOrMetax.equals(COMMENT)) {
+            String writtenEntry = getNextToken(true);
+            if (writtenEntry.equals(PROGRAM)) {
+                getNextToken(true); // Program name, unused
+                // program ::= (program programName {version | comment | userData}),
+                // so any number of sub-entries may follow, in any order
+                String programEntry;
+                while (LEFT_PAREN.equals(programEntry = getNextToken(true))) {
+                    if (VERSION.equals(getNextToken(true))) {
+                        getNextToken(true); // Version string, unused
+                        expect(RIGHT_PAREN, getNextToken(true));
+                    } else {
+                        // A comment or userData entry, neither of which is modelled
+                        skipConstruct();
+                    }
+                }
+                expect(RIGHT_PAREN, programEntry); // Program end
+                continue;
+            } else if (writtenEntry.equals(AUTHOR)) {
+                getNextToken(true); // Author name, unused
+            } else if (writtenEntry.equals(COMMENT)) {
                 currNetlist.addComment(getNextToken(false));
-            } else if (commentOrMetax.equals(METAX)) {
+            } else if (writtenEntry.equals(METAX)) {
                 String key = getNextToken(false);
                 EDIFPropertyValue value = parsePropertyValue();
                 currNetlist.addMetax(key,value);
-            } else if (commentOrMetax.equals(PROPERTY)) {
+            } else if (writtenEntry.equals(PROPERTY)) {
                 // Discard this property for now
-                parseProperty(new EDIFPropertyObject(), commentOrMetax);
+                parseProperty(new EDIFPropertyObject(), writtenEntry);
                 continue;
             } else {
-                expect(COMMENT + "|" + METAX + "|" + PROPERTY, commentOrMetax);
+                expect(PROGRAM + "|" + AUTHOR + "|" + COMMENT + "|" + METAX + "|" + PROPERTY,
+                        writtenEntry);
             }
             expect(RIGHT_PAREN, getNextToken(true));
         }

--- a/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
+++ b/src/com/xilinx/rapidwright/edif/EDIFTokenizer.java
@@ -57,6 +57,7 @@ public class EDIFTokenizer implements AutoCloseable {
     protected int offset = 0;
     private int available = 0;
     private boolean sawEOF = false;
+    private boolean lastTokenWasQuoted = false;
 
     private boolean ensureRead(int startOffset, int endOffset) throws IOException {
         while (startOffset < endOffset) {
@@ -313,12 +314,15 @@ public class EDIFTokenizer implements AutoCloseable {
             while ((ch = readByte()) != 0) {
                 switch (ch) {
                     case '"':
+                        lastTokenWasQuoted = true;
                         return getQuotedToken(isShortLived);
                     case '(':
+                        lastTokenWasQuoted = false;
                         byteOffset++;
                         available--;
                         return "(";
                     case ')':
+                        lastTokenWasQuoted = false;
                         byteOffset++;
                         available--;
                         return ")";
@@ -331,6 +335,7 @@ public class EDIFTokenizer implements AutoCloseable {
                         available--;
                         break;
                     default:
+                        lastTokenWasQuoted = false;
                         return getUnquotedToken(isShortLived);
                 }
             }
@@ -340,6 +345,18 @@ public class EDIFTokenizer implements AutoCloseable {
             throw new UncheckedIOException("ERROR: IOException while reading EDIF file: "
                     + fileName, e);
         }
+    }
+
+    /**
+     * Reports whether the token most recently returned came from a quoted string.
+     * A quoted string is returned with its quotes stripped, so its text can be
+     * indistinguishable from a parenthesis token; callers that scan for balanced
+     * parentheses must consult this to avoid desynchronizing.
+     *
+     * @return True if the last token was quoted in the source, false otherwise.
+     */
+    public boolean wasLastTokenQuoted() {
+        return lastTokenWasQuoted;
     }
 
     public Path getFileName() {

--- a/test/src/com/xilinx/rapidwright/edif/TestEDIFParserGrammar.java
+++ b/test/src/com/xilinx/rapidwright/edif/TestEDIFParserGrammar.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * This file is part of RapidWright.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.xilinx.rapidwright.edif;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Checks that the EDIF parser accepts the constructs the EDIF 2.0.0 grammar
+ * permits, rather than only the subset Vivado happens to emit.
+ */
+public class TestEDIFParserGrammar {
+
+    /**
+     * Builds a minimal but complete netlist, varying only the status block so each
+     * test can exercise one shape of (written ...).
+     */
+    protected static String netlist(String status) {
+        return "(edif test\n"
+                + "  (edifVersion 2 0 0)\n"
+                + "  (edifLevel 0)\n"
+                + "  (keywordMap (keywordLevel 0))\n"
+                + status
+                + "  (library work\n"
+                + "    (edifLevel 0)\n"
+                + "    (technology (numberDefinition))\n"
+                + "    (cell sub (cellType GENERIC)\n"
+                + "      (view netlist (viewType NETLIST)\n"
+                + "        (interface (port i (direction INPUT)))\n"
+                + "      )\n"
+                + "    )\n"
+                + "    (cell top (cellType GENERIC)\n"
+                + "      (view netlist (viewType NETLIST)\n"
+                + "        (interface\n"
+                + "          (port a (direction INPUT))\n"
+                + "          (port b (direction OUTPUT))\n"
+                + "        )\n"
+                + "        (contents\n"
+                + "          (instance inst1 (viewRef netlist (cellRef sub (libraryRef work))))\n"
+                + "          (net n1 (joined (portRef a) (portRef i (instanceRef inst1))))\n"
+                + "        )\n"
+                + "      )\n"
+                + "    )\n"
+                + "  )\n"
+                + "  (design top (cellRef top (libraryRef work)))\n"
+                + ")\n";
+    }
+
+    protected static String defaultStatus() {
+        return "  (status (written (timeStamp 2024 1 1 0 0 0)"
+                + " (program \"Vivado\" (version \"2024.1\"))))\n";
+    }
+
+    protected static String simple() {
+        return netlist(defaultStatus());
+    }
+
+    protected static EDIFNetlist parse(Path dir, String name, String content) throws IOException {
+        Path p = dir.resolve(name);
+        Files.write(p, content.getBytes(StandardCharsets.UTF_8));
+        try (EDIFParser parser = new EDIFParser(p)) {
+            return parser.parseEDIFNetlist();
+        }
+    }
+
+    protected static void assertWellFormed(EDIFNetlist netlist) {
+        Assertions.assertNotNull(netlist.getDesign());
+        EDIFCell top = netlist.getDesign().getTopCell();
+        Assertions.assertEquals("top", top.getName());
+        Assertions.assertEquals(2, top.getPorts().size());
+        Assertions.assertEquals(1, top.getCellInsts().size());
+        Assertions.assertEquals(1, top.getNets().size());
+        EDIFCell sub = top.getCellInst("inst1").getCellType();
+        Assertions.assertEquals("sub", sub.getName());
+        Assertions.assertEquals(1, sub.getPorts().size());
+    }
+
+    /** The baseline fixture must parse, so later assertions mean something. */
+    @Test
+    public void testBaseline(@TempDir Path dir) throws IOException {
+        assertWellFormed(parse(dir, "baseline.edf", simple()));
+    }
+
+    /** (author ...) may precede (program ...), and the version is optional. */
+    @Test
+    public void testWrittenAuthorAndOptionalProgram(@TempDir Path dir) throws IOException {
+        String status = "  (status (written (timeStamp 2024 1 1 0 0 0)\n"
+                + "    (author \"Some Tool\")\n"
+                + "    (program \"NoVersionTool\")))\n";
+        assertWellFormed(parse(dir, "author.edf", netlist(status)));
+    }
+
+    /** (program ...) may still carry a version, in any position. */
+    @Test
+    public void testWrittenProgramWithVersionAfterAuthor(@TempDir Path dir) throws IOException {
+        String status = "  (status (written (timeStamp 2024 1 1 0 0 0)\n"
+                + "    (author \"Some Tool\")\n"
+                + "    (program \"Tool\" (version \"1.2\"))))\n";
+        assertWellFormed(parse(dir, "authorver.edf", netlist(status)));
+    }
+
+    /**
+     * Bodies the EDIF grammar permits inside (written ...). Every entry is optional
+     * and repeatable, and the order between them is not fixed.
+     */
+    static Stream<Arguments> writtenBodies() {
+        return Stream.of(
+                Arguments.of("author only, no program",
+                        "    (author \"Some Tool\")\n"),
+                Arguments.of("neither author nor program",
+                        ""),
+                Arguments.of("program ahead of author",
+                        "    (program \"Tool\" (version \"1.2\")) (author \"Some Tool\")\n"),
+                Arguments.of("author repeated",
+                        "    (author \"First\") (author \"Second\")\n"),
+                Arguments.of("author text containing spaces and parentheses",
+                        "    (author \"A B (x)\")\n"),
+                Arguments.of("program carrying a comment instead of a version",
+                        "    (program \"Tool\" (comment \"built somewhere\"))\n"),
+                Arguments.of("program carrying both a version and a comment",
+                        "    (program \"Tool\" (version \"1.2\") (comment \"note\"))\n"),
+                Arguments.of("program carrying nested userData",
+                        "    (program \"Tool\" (userData ud (inner (deeper 1))))\n"),
+                Arguments.of("program comment holding several strings",
+                        "    (program \"Tool\" (comment \"one\" \"two\"))\n"),
+                Arguments.of("program comment whose text is a parenthesis",
+                        "    (program \"Tool\" (comment \")\"))\n"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("writtenBodies")
+    public void testWrittenBodyVariants(String description, String writtenBody, @TempDir Path dir)
+            throws IOException {
+        String status = "  (status (written (timeStamp 2024 1 1 0 0 0)\n" + writtenBody + "  ))\n";
+        assertWellFormed(parse(dir, "written.edf", netlist(status)));
+    }
+
+    /**
+     * A comment inside (written ...) is retained on the netlist. An author has
+     * nowhere to be stored and is dropped, so it must not be mistaken for one.
+     */
+    @Test
+    public void testWrittenCommentRetainedAlongsideAuthor(@TempDir Path dir) throws IOException {
+        String status = "  (status (written (timeStamp 2024 1 1 0 0 0)\n"
+                + "    (author \"Some Tool\")\n"
+                + "    (comment \"a retained comment\")))\n";
+        EDIFNetlist netlist = parse(dir, "comment.edf", netlist(status));
+        assertWellFormed(netlist);
+        Assertions.assertEquals(1, netlist.getComments().size());
+        Assertions.assertEquals("a retained comment", netlist.getComments().get(0));
+    }
+}


### PR DESCRIPTION
### Problem

`parseStatus()` required `(program name (version v))` immediately after the timestamp, but the grammar is:

```
written ::= (written timeStamp { author | program | dataOrigin | property | comment | userData })
program ::= (program programName { version | comment | userData })
```

Every entry is optional, repeatable and unordered, and `program`'s version is itself optional. So EDIF carrying `(author ...)`, or a program with no version, or a program carrying a comment, is rejected.

Vivado always writes `(program "Vivado" (version "..."))` in exactly that position, which is why this went unnoticed. EDIF from other writers does not.

### Change

Fold `program` into the loop that already handled comment/metax/property, add an `author` branch, and iterate over `program`'s sub-entries rather than assuming a single `(version ...)`.

Skipping an unmodelled sub-entry means scanning for a balanced closing parenthesis, which requires telling a real parenthesis from a quoted string whose text is one — `getQuotedToken()` strips the quotes, so `(comment ")")` yields a token whose text is `)` and a naive depth count desynchronizes. `EDIFTokenizer` now records whether the token it returned was quoted, and `skipConstruct()` consults it. The byte offset bookkeeping `ParallelEDIFParser` resynchronizes on is unchanged.

`(author ...)` is read and discarded: `EDIFNetlist` has no field for it and `EXPORT_CONST_EDIF_VERSION` writes a fixed status header, so storing it would be write-only. This matches how `program` was already treated. `(comment ...)` continues to be retained.

### Testing

`TestEDIFParserGrammar` covers fourteen shapes of `(written ...)`, including the five `(program ...)` sub-entry cases raised in review. Verified non-vacuous: with `AbstractEDIFParserWorker` reverted to master, all but the baseline fail.

`(program "Tool" (comment ")"))` is a test case specifically because it is what breaks a naive balanced-paren scan.

A `(comment ...)` alongside an `(author ...)` is asserted to still be retained on the netlist, so a future refactor merging those branches could not silently drop comments.

### Scope note

This PR previously also relaxed `parseEDIFCell()` to accept cell-level properties before the view. That is an unrelated fix in a different method sharing no code with this one, so it has been split out and will follow separately, leaving this PR to one subject.

### Known limitation

The keyword comparisons in this loop use `String.equals()` and are therefore case-sensitive, as they were before this change. EDIF keywords are case-insensitive per the LRM, so a writer emitting `(Author ...)` would still be rejected, and `expect()` being case-insensitive means the match and error paths differ here. Fixing that means touching the existing comment/metax/property comparisons too — happy to do it here or separately if you would prefer.